### PR TITLE
Add isFetched method to Parse.Object

### DIFF
--- a/src/ParseObject.js
+++ b/src/ParseObject.js
@@ -168,6 +168,10 @@ export default class ParseObject {
     return this._getServerData().updatedAt;
   }
 
+  get isFetched(): boolean {
+    return !!this.createdAt;
+  }
+
   /** Private methods **/
 
   /**

--- a/src/ParseObject.js
+++ b/src/ParseObject.js
@@ -168,6 +168,11 @@ export default class ParseObject {
     return this._getServerData().updatedAt;
   }
 
+  /**
+   * Returns true if the object was fetched previously.
+   * @property isFetched
+   * @type boolean
+   */
   get isFetched(): boolean {
     return !!this.createdAt;
   }

--- a/src/__tests__/ParseObject-test.js
+++ b/src/__tests__/ParseObject-test.js
@@ -2101,4 +2101,29 @@ describe('ParseObject extensions', () => {
     var i = new InitObject()
     expect(i.get('field')).toBe(12);
   });
+
+  it('returns correct isFetched state', asyncHelper((done) => {
+    CoreManager.getRESTController()._setXHR(
+      mockXHR([{
+        status: 200,
+        response: {
+          objectId: 'P5'
+        }
+      }, {
+        status: 200,
+        response: {
+          createdAt: '2013-12-14T04:51:19Z'
+        }
+      }])
+    );
+
+    return new ParseObject('Test').save().then((obj) => {
+      var p = ParseObject.createWithoutData(obj.id);
+      expect(p.isFetched).toBe(false);
+      return p.fetch();
+    }).then((o) => {
+      expect(o.isFetched).toBe(true);
+      done();
+    });
+  }));
 });


### PR DESCRIPTION
Hi,

often, I want to assert that in a specific method a parse object has been fetched. Also, sometimes I only want to fetch an object if it hasn't been fetched before. Others seem to have [similar requests](https://parse.com/questions/determine-if-parseobject-has-been-fetched).

So far I've been using the proposed work-around: `!!parseObject.createdAt`. This works fine, however, makes the code harder to read and if the behavior of `createdAt` changes at some point code might get broken.

To fix this for all of us, I created this PR. It adds a `isFetched` property to ParseObject which currently is calculated exactly like the work-around (I'm not an expert on parse object internals).

I'm happy for feedback.
