### PR TITLE
ParseFile & useMasterKey: pass options through to RESTController from saveBase64

### DIFF
--- a/src/ParseFile.js
+++ b/src/ParseFile.js
@@ -161,18 +161,18 @@ export default class ParseFile {
    * @param {Object} options A Backbone-style options object.
    * @return {Parse.Promise} Promise that is resolved when the save finishes.
    */
-  save(options?: { success?: any, error?: any }) {
+  save(options?: { useMasterKey?: boolean, success?: any, error?: any }) {
     options = options || {};
     var controller = CoreManager.getFileController();
     if (!this._previousSave) {
       if (this._source.format === 'file') {
-        this._previousSave = controller.saveFile(this._name, this._source).then((res) => {
+        this._previousSave = controller.saveFile(this._name, this._source, options).then((res) => {
           this._name = res.name;
           this._url = res.url;
           return this;
         });
       } else {
-        this._previousSave = controller.saveBase64(this._name, this._source).then((res) => {
+        this._previousSave = controller.saveBase64(this._name, this._source, options).then((res) => {
           this._name = res.name;
           this._url = res.url;
           return this;
@@ -256,7 +256,7 @@ var DefaultController = {
     return CoreManager.getRESTController().ajax('POST', url, source.file, headers);
   },
 
-  saveBase64: function(name: string, source: FileSource) {
+  saveBase64: function(name: string, source: FileSource, options?: { useMasterKey?: boolean, success?: any, error?: any }) {
     if (source.format !== 'base64') {
       throw new Error('saveBase64 can only be used with Base64-type sources.');
     }
@@ -267,7 +267,7 @@ var DefaultController = {
       data._ContentType = source.type;
     }
     var path = 'files/' + name;
-    return CoreManager.getRESTController().request('POST', path, data);
+    return CoreManager.getRESTController().request('POST', path, data, options);
   }
 };
 


### PR DESCRIPTION
Without this, we are getting unauthorized messages when saving base64 files. 