### PR TITLE
Fix typo in error message 'There is no current user user on a node.js…

### DIFF
--- a/src/ParseUser.js
+++ b/src/ParseUser.js
@@ -655,7 +655,7 @@ export default class ParseUser extends ParseObject {
   static logOut() {
     if (!canUseCurrentUser) {
       throw new Error(
-        'There is no current user user on a node.js server environment.'
+        'There is no current user on a node.js server environment.'
       );
     }
 

--- a/src/__tests__/ParseUser-test.js
+++ b/src/__tests__/ParseUser-test.js
@@ -131,7 +131,7 @@ describe('ParseUser', () => {
       'It is not memory-safe to become a user in a server environment'
     );
     expect(ParseUser.logOut).toThrow(
-      'There is no current user user on a node.js server environment.'
+      'There is no current user on a node.js server environment.'
     );
   });
 


### PR DESCRIPTION
… server environment.'