### PR TITLE
ParseLiveQuery controller should wrap all subscription events

### DIFF
--- a/src/ParseLiveQuery.js
+++ b/src/ParseLiveQuery.js
@@ -196,6 +196,12 @@ const DefaultLiveQueryController = {
         subscription.on('delete', (object) => {
           subscriptionWrap.emit('delete', object);
         });
+        subscription.on('close', (object) => {
+          subscriptionWrap.emit('close', object);
+        });
+        subscription.on('error', (object) => {
+          subscriptionWrap.emit('error', object);
+        });
 
         this.resolve();
       });

--- a/src/__tests__/ParseLiveQuery-test.js
+++ b/src/__tests__/ParseLiveQuery-test.js
@@ -11,11 +11,16 @@ jest.dontMock('../ParseLiveQuery');
 jest.dontMock('../CoreManager');
 jest.dontMock('../ParsePromise');
 jest.dontMock('../LiveQueryClient');
+jest.dontMock('../LiveQuerySubscription');
 jest.dontMock('../ParseObject');
+jest.dontMock('../ParsePromise');
+jest.dontMock('../ParseQuery');
+jest.dontMock('../EventEmitter');
 
 const ParseLiveQuery = require('../ParseLiveQuery');
 const CoreManager = require('../CoreManager');
 const ParsePromise = require('../ParsePromise').default;
+const ParseQuery = require('../ParseQuery').default;
 
 describe('ParseLiveQuery', () => {
   beforeEach(() => {
@@ -98,5 +103,84 @@ describe('ParseLiveQuery', () => {
       expect(client.sessionToken).toBe('token');
       done();
     });
+  });
+
+  it('subscribes to all subscription events', (done) => {
+
+    CoreManager.set('UserController', {
+      currentUserAsync() {
+        return ParsePromise.as({
+          getSessionToken() {
+            return 'token';
+          }
+        });
+      }
+    });
+    CoreManager.set('APPLICATION_ID', 'appid');
+    CoreManager.set('JAVASCRIPT_KEY', 'jskey');
+    CoreManager.set('LIVEQUERY_SERVER_URL', null);
+
+    const controller = CoreManager.getLiveQueryController();
+
+    controller.getDefaultLiveQueryClient().then((client) => {
+
+      const query = new ParseQuery("ObjectType");
+      query.equalTo("test", "value");
+      const ourSubscription = controller.subscribe(query, "close");
+
+      var isCalled = {};
+      ["open", 
+        "close",
+        "error",
+        "create",
+        "update", 
+        "enter", 
+        "leave", 
+        "delete"].forEach((key) =>{
+        ourSubscription.on(key, () => {
+          isCalled[key] = true;
+        });
+      });
+      
+      // controller.subscribe() completes asynchronously, 
+      // so we need to give it a chance to complete before finishing
+      setTimeout(() => { 
+        try {
+          client.connectPromise.resolve();
+          var actualSubscription = client.subscriptions.get(1);
+
+          expect(actualSubscription).toBeDefined();
+
+          actualSubscription.emit("open");
+          expect(isCalled["open"]).toBe(true);
+
+          actualSubscription.emit("close");
+          expect(isCalled["close"]).toBe(true);
+
+          actualSubscription.emit("error");
+          expect(isCalled["error"]).toBe(true);
+
+          actualSubscription.emit("create");
+          expect(isCalled["create"]).toBe(true);
+
+          actualSubscription.emit("update");
+          expect(isCalled["update"]).toBe(true);
+
+          actualSubscription.emit("enter");
+          expect(isCalled["enter"]).toBe(true);
+
+          actualSubscription.emit("leave");
+          expect(isCalled["leave"]).toBe(true);
+
+          actualSubscription.emit("delete");
+          expect(isCalled["delete"]).toBe(true);
+
+          done();
+        } catch(e){
+          done.fail(e);
+        }
+      }, 1); 
+    });
+
   });
 });


### PR DESCRIPTION
When you call `subscribe()` on a query (which goes through the ParseLiveQuery controller), the resulting subscription does not currently receive `close` or `error` events for the underlying connection. This was occurring because the LiveQueryController is wrapping the underlying subscriptions, and was not forwarding the `close` or `error` events.

This pull request correctly wraps these two event types so that subscriptions receive all the event notifications they are supposed to, and introduces a new test case to check that all subscription events are forwarded correctly.