### PR TITLE
Add sensible string representation of ParseError objects

### DIFF
--- a/src/ParseError.js
+++ b/src/ParseError.js
@@ -19,6 +19,10 @@ export default class ParseError {
     this.code = code;
     this.message = message;
   }
+  
+  toString() {
+    return 'ParseError: ' + this.code + ' ' + this.message;
+  }
 }
 
 /**

--- a/src/__tests__/ParseError-test.js
+++ b/src/__tests__/ParseError-test.js
@@ -1,0 +1,22 @@
+/**
+ * Copyright (c) 2015-present, Parse, LLC.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+jest.dontMock('../ParseError');
+
+var ParseError = require('../ParseError').default;
+
+describe('ParseError', () => {
+  it('have sensible string representation', () => {
+    var error = new ParseError(123, 'some error message');
+    
+    expect(error.toString()).toMatch('ParseError');
+    expect(error.toString()).toMatch('123');
+    expect(error.toString()).toMatch('some error message');
+  });
+});


### PR DESCRIPTION
I noticed that our error logs are filled with thousands of "[Object object]" due to the ParseError object not having a sensible string representation. Errors ripple down to the Express.js error log handler, which calls `console.error(err.stack || err.toString())`. In our case, these are typically `209 Invalid session token` errors, as we just migrated to using revocable sessions. The proposed fix in this pull request is to add a `toSting()` method for ParseErrors.