### PR TITLE
update path of react-native module

### DIFF
--- a/src/StorageController.react-native.js
+++ b/src/StorageController.react-native.js
@@ -11,7 +11,7 @@
 
 import ParsePromise from './ParsePromise';
 // RN packager nonsense
-import { AsyncStorage } from 'react-native/Libraries/react-native/react-native.js';
+import { AsyncStorage } from 'react-native/Libraries/react-native/react-native-implementation.js';
 
 var StorageController = {
   async: 1,


### PR DESCRIPTION
As of react-native 0.43, the main entry point of the package has been renamed (see: https://github.com/facebook/react-native/commit/cf1bc8d6443432ba24efa17cd15ba73072fad193).

This allows the library to work with RN-0.43 but will break on prior versions.