### PR TITLE
change path to /react-native-implementation.js

### DIFF
--- a/src/StorageController.react-native.js
+++ b/src/StorageController.react-native.js
@@ -11,7 +11,7 @@
 
 import ParsePromise from './ParsePromise';
 // RN packager nonsense
-import { AsyncStorage } from 'react-native/Libraries/react-native/react-native.js';
+import { AsyncStorage } from 'react-native/Libraries/react-native/react-native-implementation.js';
 
 var StorageController = {
   async: 1,


### PR DESCRIPTION
According to [this](https://github.com/facebook/react-native/blob/master/Libraries/react-native/react-native-implementation.js)

The path has changed from `/react-native.js` to `/react-native-implementation.js`