### PR TITLE
Parse.Query.fromJSON method

### DIFF
--- a/src/ParseQuery.js
+++ b/src/ParseQuery.js
@@ -269,7 +269,7 @@ export default class ParseQuery {
    * query.equalTo(key: value);
    * query.limit(100);
    * ... (others queries)
-   * Create JSON representaion of Query Object
+   * Create JSON representation of Query Object
    * var jsonFromServer = query.fromJSON();
    *
    * On client side getting query:
@@ -278,13 +278,11 @@ export default class ParseQuery {
    *
    * and continue to query...
    * query.skip(100).find().then(...);
-   * @method fromJSON
-   * @namespace Parse.Query.fromJSON
+   * @method withJSON
    * @param {QueryJSON} json from Parse.Query.toJSON() method
    * @return {Parse.Query} Returns the query, so you can chain this call.
    */
-  fromJSON(json): ParseQuery {
-    var key;
+  withJSON(json: QueryJSON): ParseQuery {
 
     if (json.where) {
       this._where = json.where;
@@ -310,7 +308,7 @@ export default class ParseQuery {
       this._order = json.order.split(",");
     }
 
-    for (key in json) if (json.hasOwnProperty(key))  {
+    for (let key in json) if (json.hasOwnProperty(key))  {
       if (["where", "include", "keys", "limit", "skip", "order"].indexOf(key) === -1) {
         this._extraOptions[key] = json[key];
       }
@@ -318,6 +316,18 @@ export default class ParseQuery {
 
     return this;
 
+  }
+
+    /**
+     * Static method to restore Parse.Query by json representation
+     * Internally calling Parse.Query.withJSON
+     * @param {String} className
+     * @param {QueryJSON} json from Parse.Query.toJSON() method
+     * @returns {Parse.Query} new created query
+     */
+  static fromJSON(className: string, json: QueryJSON): ParseQuery {
+    const query = new ParseQuery(className);
+    return query.withJSON(json);
   }
 
   /**

--- a/src/ParseQuery.js
+++ b/src/ParseQuery.js
@@ -262,6 +262,65 @@ export default class ParseQuery {
   }
 
   /**
+   * Return a query with conditions from json, can be useful to send query from server side to client
+   * Not static, all query conditions was set before calling this method will be deleted.
+   * For example on the server side we have
+   * var query = new Parse.Query("className");
+   * query.equalTo(key: value);
+   * query.limit(100);
+   * ... (others queries)
+   * Create JSON representaion of Query Object
+   * var jsonFromServer = query.fromJSON();
+   *
+   * On client side getting query:
+   * var query = new Parse.Query("className");
+   * query.fromJSON(jsonFromServer);
+   *
+   * and continue to query...
+   * query.skip(100).find().then(...);
+   * @method fromJSON
+   * @namespace Parse.Query.fromJSON
+   * @param {QueryJSON} json from Parse.Query.toJSON() method
+   * @return {Parse.Query} Returns the query, so you can chain this call.
+   */
+  fromJSON(json): ParseQuery {
+    var key;
+
+    if (json.where) {
+      this._where = json.where;
+    }
+
+    if (json.include) {
+      this._include = json.include.split(",");
+    }
+
+    if (json.keys) {
+      this._select = json.keys.split(",");
+    }
+
+    if (json.limit) {
+      this._limit  = json.limit;
+    }
+
+    if (json.skip) {
+      this._skip = json.skip;
+    }
+
+    if (json.order) {
+      this._order = json.order.split(",");
+    }
+
+    for (key in json) if (json.hasOwnProperty(key))  {
+      if (["where", "include", "keys", "limit", "skip", "order"].indexOf(key) === -1) {
+        this._extraOptions[key] = json[key];
+      }
+    }
+
+    return this;
+
+  }
+
+  /**
    * Constructs a Parse.Object whose id is already known by fetching data from
    * the server.  Either options.success or options.error is called when the
    * find completes.

--- a/src/__tests__/ParseQuery-test.js
+++ b/src/__tests__/ParseQuery-test.js
@@ -1557,7 +1557,7 @@ describe('ParseQuery', () => {
   });
 
   it('restores queries from json representation', () => {
-    var q = new ParseQuery('Item');
+    const q = new ParseQuery('Item');
 
     q.include('manufacturer');
     q.select('inStock', 'lastPurchase');
@@ -1566,11 +1566,11 @@ describe('ParseQuery', () => {
     q.skip(4);
     q.equalTo('size', 'medium');
 
-    var json = q.toJSON();
+    const json = q.toJSON();
 
-    var newQuery = new ParseQuery('Item');
+    const newQuery = ParseQuery.fromJSON('Item', json);
 
-    newQuery.fromJSON(json);
+    expect(newQuery.className).toBe('Item');
 
     expect(newQuery.toJSON()).toEqual({
       include: 'manufacturer',

--- a/src/__tests__/ParseQuery-test.js
+++ b/src/__tests__/ParseQuery-test.js
@@ -1555,4 +1555,33 @@ describe('ParseQuery', () => {
       done.fail(error);
     });
   });
+
+  it('restores queries from json representation', () => {
+    var q = new ParseQuery('Item');
+
+    q.include('manufacturer');
+    q.select('inStock', 'lastPurchase');
+    q.limit(10);
+    q.ascending(['a', 'b', 'c']);
+    q.skip(4);
+    q.equalTo('size', 'medium');
+
+    var json = q.toJSON();
+
+    var newQuery = new ParseQuery('Item');
+
+    newQuery.fromJSON(json);
+
+    expect(newQuery.toJSON()).toEqual({
+      include: 'manufacturer',
+      keys: 'inStock,lastPurchase',
+      limit: 10,
+      order: 'a,b,c',
+      skip: 4,
+      where: {
+        size: 'medium'
+      }
+    });
+
+  });
 });


### PR DESCRIPTION
Made mistake with previous PR. This is new one.
Method restores query from json gained from Parse.Query.toJSON()