### PR TITLE
Corrects Guide Link in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 [![CDNJS version](https://img.shields.io/cdnjs/v/parse.svg)](https://cdnjs.com/libraries/parse)
 [![License][license-svg]][license-link]
 
-A library that gives you access to the powerful Parse cloud platform from your JavaScript app. For more information on Parse and its features, see [the website](http://parseplatform.org) or [the JavaScript guide](https://docs.parseplatform.org/js/guide/).
+A library that gives you access to the powerful Parse cloud platform from your JavaScript app. For more information on Parse and its features, see [the website](http://parseplatform.org) or [the JavaScript guide](http://docs.parseplatform.org/js/guide/).
 
 ## Getting Started
 


### PR DESCRIPTION
Just a small fix of `https` to `http` for the JS guide link, which is only available over `http`.