### PR TITLE
Update ParseFile to handle a data URI containing a number

### DIFF
--- a/src/ParseFile.js
+++ b/src/ParseFile.js
@@ -25,7 +25,7 @@ export type FileSource = {
 };
 
 var dataUriRegexp =
-  /^data:([a-zA-Z]*\/[a-zA-Z+.-]*);(charset=[a-zA-Z0-9\-\/\s]*,)?base64,/;
+  /^data:([\w\/\+]+);(charset=[a-zA-Z0-9\-\/\s]*,)?base64,/;
 
 function b64Digit(number: number): string {
   if (number < 26) {

--- a/src/ParseFile.js
+++ b/src/ParseFile.js
@@ -25,7 +25,7 @@ export type FileSource = {
 };
 
 var dataUriRegexp =
-  /^data:([\w\/\+]+);(charset=[a-zA-Z0-9\-\/\s]*,)?base64,/;
+  /^data:([a-zA-Z]+\/[-a-zA-Z0-9+.]+)(;charset=[a-zA-Z0-9\-\/]*)?;base64,/;
 
 function b64Digit(number: number): string {
   if (number < 26) {

--- a/src/__tests__/ParseFile-test.js
+++ b/src/__tests__/ParseFile-test.js
@@ -54,6 +54,22 @@ describe('ParseFile', () => {
     expect(file._source.type).toBe('audio/m4a');
   });
 
+  it('can extract data type from base64 with a complex mime type', () => {
+    var file = new ParseFile('parse.kml', {
+        base64: 'data:application/vnd.google-earth.kml+xml;base64,ParseA=='
+    });
+    expect(file._source.base64).toBe('ParseA==');
+    expect(file._source.type).toBe('application/vnd.google-earth.kml+xml');
+  });
+
+  it('can extract data type from base64 with a charset param', () => {
+    var file = new ParseFile('parse.kml', {
+        base64: 'data:application/vnd.3gpp.pic-bw-var;charset=utf-8;base64,ParseA=='
+    });
+    expect(file._source.base64).toBe('ParseA==');
+    expect(file._source.type).toBe('application/vnd.3gpp.pic-bw-var');
+  });
+
   it('can create files with byte arrays', () => {
     var file = new ParseFile('parse.txt', [61, 170, 236, 120]);
     expect(file._source.base64).toBe('ParseA==');

--- a/src/__tests__/ParseFile-test.js
+++ b/src/__tests__/ParseFile-test.js
@@ -38,12 +38,20 @@ describe('ParseFile', () => {
     expect(file._source.type).toBe('');
   });
 
-  it('can extact data type from base64', () => {
+  it('can extract data type from base64', () => {
     var file = new ParseFile('parse.txt', {
       base64: 'data:image/png;base64,ParseA=='
     });
     expect(file._source.base64).toBe('ParseA==');
     expect(file._source.type).toBe('image/png');
+  });
+
+  it('can extract data type from base64 with data type containing a number', () => {
+    var file = new ParseFile('parse.m4a', {
+      base64: 'data:audio/m4a;base64,ParseA=='
+    });
+    expect(file._source.base64).toBe('ParseA==');
+    expect(file._source.type).toBe('audio/m4a');
   });
 
   it('can create files with byte arrays', () => {


### PR DESCRIPTION
The regex to extract the components from a base64 encoded string doesn't handle mime types which contain a number, e.g. audio/m4a.

It was failing with the error:
TypeError: Cannot read property '1' of null
at ParseFile (/app/node_modules/parse/lib/node/ParseFile.js:121)

The regex has been updated to allow numbers, and a test added which failed before the change.