### PR TITLE
Fixes jsdoc generation, adds jsdoc support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,4 +9,5 @@ integration/test_logs
 .DS_Store
 .idea/
 integration/test_logs
+out/
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 ---
 language: node_js
 node_js:
-- '5'
+- '6.11.4'
 
 branches:
   only:

--- a/jsdoc-conf.json
+++ b/jsdoc-conf.json
@@ -5,7 +5,6 @@
   },
   "source": {
     "include": ["./package.json", "./README.md"],
-    "exclude": [ /* array of paths to exclude */ ],
     "excludePattern": "(^|\\/|\\\\)_"
   },
   "templates": {

--- a/jsdoc-conf.json
+++ b/jsdoc-conf.json
@@ -4,9 +4,8 @@
       "plugins": ["transform-flow-strip-types"]
   },
   "source": {
-    "include": ["./package.json", "./README.md", "./src/Analytics.js", "./src/Cloud.js", "./src/Push.js", "./src/FacebookUtils.js", "./src/LiveQueryClient.js", "./src/LiveQuerySubscription.js" ],
+    "include": ["./package.json", "./README.md"],
     "exclude": [ /* array of paths to exclude */ ],
-    "includePattern": "src/Parse.+\\.js(doc|x)?$",
     "excludePattern": "(^|\\/|\\\\)_"
   },
   "templates": {

--- a/jsdoc-conf.json
+++ b/jsdoc-conf.json
@@ -1,0 +1,22 @@
+{
+  "plugins": ["node_modules/jsdoc-babel"],
+  "babel": {
+      "plugins": ["transform-flow-strip-types"]
+  },
+  "source": {
+    "include": ["./package.json", "./README.md", "./src/Analytics.js", "./src/Cloud.js", "./src/Push.js", "./src/FacebookUtils.js", "./src/LiveQueryClient.js", "./src/LiveQuerySubscription.js" ],
+    "exclude": [ /* array of paths to exclude */ ],
+    "includePattern": "src/Parse.+\\.js(doc|x)?$",
+    "excludePattern": "(^|\\/|\\\\)_"
+  },
+  "templates": {
+    "default": {
+      "outputSourceFiles": false
+    },
+    "cleverLinks": false,
+    "monospaceLinks": false
+  },
+  "opts": {
+    "recurse": true
+  }
+}

--- a/package.json
+++ b/package.json
@@ -53,12 +53,15 @@
     "gulp-uglify": "^2.1.2",
     "jasmine-reporters": "~2.2.1",
     "jest-cli": "^19.0.2",
+    "jsdoc": "^3.5.5",
+    "jsdoc-babel": "^0.3.0",
     "vinyl-source-stream": "^1.1.0"
   },
   "scripts": {
     "build": "./build_releases.sh",
     "release": "./build_releases.sh && npm publish",
-    "test": "PARSE_BUILD=node jest"
+    "test": "PARSE_BUILD=node jest",
+    "docs": "jsdoc -c ./jsdoc-conf.json ./src"
   },
   "jest": {
     "automock": true,

--- a/src/Analytics.js
+++ b/src/Analytics.js
@@ -19,6 +19,7 @@ import type ParsePromise from './ParsePromise';
  *
  * @class Parse.Analytics
  * @static
+ * @hideconstructor
  */
 
  /**
@@ -44,6 +45,7 @@ import type ParsePromise from './ParsePromise';
   * There is a default limit of 8 dimensions per event tracked.
   *
   * @method track
+  * @name Parse.Analytics.track
   * @param {String} name The name of the custom event to report to Parse as
   * having happened.
   * @param {Object} dimensions The dictionary of information by which to

--- a/src/Cloud.js
+++ b/src/Cloud.js
@@ -24,11 +24,13 @@ import ParsePromise from './ParsePromise';
  *
  * @class Parse.Cloud
  * @static
+ * @hideconstructor
  */
 
  /**
   * Makes a call to a cloud function.
   * @method run
+  * @name Parse.Cloud.run
   * @param {String} name The function name.
   * @param {Object} data The parameters to send to the cloud function.
   * @param {Object} options A Backbone-style options object

--- a/src/CoreManager.js
+++ b/src/CoreManager.js
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2015-present, Parse, LLC.
  * All rights reserved.
  *

--- a/src/FacebookUtils.js
+++ b/src/FacebookUtils.js
@@ -93,6 +93,7 @@ var provider = {
  * Provides a set of utilities for using Parse with Facebook.
  * @class Parse.FacebookUtils
  * @static
+ * @hideconstructor
  */
 var FacebookUtils = {
   /**
@@ -105,6 +106,7 @@ var FacebookUtils = {
    * with these arguments.
    *
    * @method init
+   * @name Parse.FacebookUtils.init
    * @param {Object} options Facebook options argument as described here:
    *   <a href=
    *   "https://developers.facebook.com/docs/reference/javascript/FB.init/">
@@ -141,6 +143,7 @@ var FacebookUtils = {
    * Gets whether the user has their account linked to Facebook.
    *
    * @method isLinked
+   * @name Parse.FacebookUtils.isLinked
    * @param {Parse.User} user User to check for a facebook link.
    *     The user must be logged in on this device.
    * @return {Boolean} <code>true</code> if the user has their account
@@ -156,7 +159,8 @@ var FacebookUtils = {
    * creates, in the case where it is a new user) a Parse.User.
    *
    * @method logIn
-   * @param {String, Object} permissions The permissions required for Facebook
+   * @name Parse.FacebookUtils.logIn
+   * @param {(String|Object)} permissions The permissions required for Facebook
    *    log in.  This is a comma-separated string of permissions.
    *    Alternatively, supply a Facebook authData object as described in our
    *    REST API docs if you want to handle getting facebook auth tokens
@@ -191,9 +195,10 @@ var FacebookUtils = {
    * the account to the Parse.User.
    *
    * @method link
+   * @name Parse.FacebookUtils.link
    * @param {Parse.User} user User to link to Facebook. This must be the
    *     current user.
-   * @param {String, Object} permissions The permissions required for Facebook
+   * @param {(String|Object)} permissions The permissions required for Facebook
    *    log in.  This is a comma-separated string of permissions.
    *    Alternatively, supply a Facebook authData object as described in our
    *    REST API docs if you want to handle getting facebook auth tokens
@@ -226,6 +231,7 @@ var FacebookUtils = {
    * Unlinks the Parse.User from a Facebook account.
    *
    * @method unlink
+   * @name Parse.FacebookUtils.unlink
    * @param {Parse.User} user User to unlink from Facebook. This must be the
    *     current user.
    * @param {Object} options Standard options object with success and error

--- a/src/FacebookUtils.js
+++ b/src/FacebookUtils.js
@@ -167,6 +167,7 @@ var FacebookUtils = {
    *    yourself.
    * @param {Object} options Standard options object with success and error
    *    callbacks.
+   * @returns {Parse.Promise}
    */
   logIn(permissions, options) {
     if (!permissions || typeof permissions === 'string') {
@@ -205,6 +206,7 @@ var FacebookUtils = {
    *    yourself.
    * @param {Object} options Standard options object with success and error
    *    callbacks.
+   * @returns {Parse.Promise}
    */
   link(user, permissions, options) {
     if (!permissions || typeof permissions === 'string') {
@@ -236,6 +238,7 @@ var FacebookUtils = {
    *     current user.
    * @param {Object} options Standard options object with success and error
    *    callbacks.
+   * @returns {Parse.Promise}
    */
   unlink: function(user, options) {
     if (!initialized) {

--- a/src/LiveQueryClient.js
+++ b/src/LiveQueryClient.js
@@ -78,16 +78,6 @@ let generateInterval = (k) => {
  *
  * javascriptKey and masterKey are used for verifying the LiveQueryClient when it tries
  * to connect to the LiveQuery server
- * 
- * @class Parse.LiveQueryClient
- * @constructor
- * @param {Object} options
- * @param {string} options.applicationId - applicationId of your Parse app
- * @param {string} options.serverURL - <b>the URL of your LiveQuery server</b>
- * @param {string} options.javascriptKey (optional)
- * @param {string} options.masterKey (optional) Your Parse Master Key. (Node.js only!)
- * @param {string} options.sessionToken (optional)
- *
  *
  * We expose three events to help you monitor the status of the LiveQueryClient.
  *
@@ -119,10 +109,9 @@ let generateInterval = (k) => {
  * client.on('error', (error) => {
  * 
  * });</pre>
- * 
- * 
+ * @alias Parse.LiveQueryClient
  */
-export default class LiveQueryClient extends EventEmitter {
+class LiveQueryClient extends EventEmitter {
   attempts: number;
   id: number;
   requestId: number;
@@ -136,6 +125,14 @@ export default class LiveQueryClient extends EventEmitter {
   socket: any;
   state: string;
 
+  /**
+   * @param {Object} options
+   * @param {string} options.applicationId - applicationId of your Parse app
+   * @param {string} options.serverURL - <b>the URL of your LiveQuery server</b>
+   * @param {string} options.javascriptKey (optional)
+   * @param {string} options.masterKey (optional) Your Parse Master Key. (Node.js only!)
+   * @param {string} options.sessionToken (optional)
+   */
   constructor({
     applicationId,
     serverURL,
@@ -177,7 +174,6 @@ export default class LiveQueryClient extends EventEmitter {
    * <a href="https://github.com/ParsePlatform/parse-server/wiki/Parse-LiveQuery-Protocol-Specification">here</a> for more details. The subscription you get is the same subscription you get 
    * from our Standard API.
    * 
-   * @method subscribe
    * @param {Object} query - the ParseQuery you want to subscribe to
    * @param {string} sessionToken (optional) 
    * @return {Object} subscription
@@ -218,7 +214,6 @@ export default class LiveQueryClient extends EventEmitter {
   /**
    * After calling unsubscribe you'll stop receiving events from the subscription object.
    * 
-   * @method unsubscribe
    * @param {Object} subscription - subscription you would like to unsubscribe from.
    */ 
   unsubscribe(subscription: Object) {
@@ -240,7 +235,6 @@ export default class LiveQueryClient extends EventEmitter {
    * After open is called, the LiveQueryClient will try to send a connect request
    * to the LiveQuery server.
    * 
-   * @method open
    */ 
   open() {
     let WebSocketImplementation = this._getWebSocketImplementation();
@@ -303,7 +297,6 @@ export default class LiveQueryClient extends EventEmitter {
    * This method will close the WebSocket connection to this LiveQueryClient, 
    * cancel the auto reconnect and unsubscribe all subscriptions based on it.
    * 
-   * @method close
    */ 
   close() {
     if (this.state === CLIENT_STATE.INITIALIZED || this.state === CLIENT_STATE.DISCONNECTED) {
@@ -448,3 +441,5 @@ export default class LiveQueryClient extends EventEmitter {
     }).bind(this), time);
   }
 }
+
+export default LiveQueryClient;

--- a/src/LiveQuerySubscription.js
+++ b/src/LiveQuerySubscription.js
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2015-present, Parse, LLC.
  * All rights reserved.
  *
@@ -16,10 +16,6 @@ import CoreManager from './CoreManager';
  * Extends events.EventEmitter
  * <a href="https://nodejs.org/api/events.html#events_class_eventemitter">cloud functions</a>.
  * 
- * @constructor
- * @param {string} id - subscription id
- * @param {string} query - query to subscribe to
- * @param {string} sessionToken - optional session token
  *
  * <p>Open Event - When you call query.subscribe(), we send a subscribe request to 
  * the LiveQuery server, when we get the confirmation from the LiveQuery server,
@@ -88,9 +84,14 @@ import CoreManager from './CoreManager';
  * 
  * });</pre></p>
  *
- * 
+ * @alias Parse.LiveQuerySubscription
  */
-export default class Subscription extends EventEmitter {
+class Subscription extends EventEmitter {
+  /*
+   * @param {string} id - subscription id
+   * @param {string} query - query to subscribe to
+   * @param {string} sessionToken - optional session token
+   */
   constructor(id, query, sessionToken) {
     super();
     this.id = id;
@@ -99,7 +100,7 @@ export default class Subscription extends EventEmitter {
   }
 
   /**
-   * @method unsubscribe
+   * closes the subscription
    */
   unsubscribe() {
     let _this = this;
@@ -110,3 +111,5 @@ export default class Subscription extends EventEmitter {
     });
   }
 }
+
+export default Subscription;

--- a/src/Parse.js
+++ b/src/Parse.js
@@ -16,14 +16,15 @@ import RESTController from './RESTController';
 
 /**
  * Contains all Parse API classes and functions.
- * @class Parse
  * @static
+ * @global
+ * @class
+ * @hideconstructor
  */
 var Parse = {
   /**
    * Call this method first to set up your authentication tokens for Parse.
    * You can get your keys from the Data Browser on parse.com.
-   * @method initialize
    * @param {String} applicationId Your Parse Application ID.
    * @param {String} javaScriptKey (optional) Your Parse JavaScript Key (Not needed for parse-server)
    * @param {String} masterKey (optional) Your Parse Master Key. (Node.js only!)
@@ -48,6 +49,11 @@ var Parse = {
 };
 
 /** These legacy setters may eventually be deprecated **/
+/** 
+ * @member Parse.applicationId
+ * @type string
+ * @static
+ */
 Object.defineProperty(Parse, 'applicationId', {
   get() {
     return CoreManager.get('APPLICATION_ID');
@@ -56,6 +62,12 @@ Object.defineProperty(Parse, 'applicationId', {
     CoreManager.set('APPLICATION_ID', value);
   }
 });
+
+/** 
+ * @member Parse.javaScriptKey
+ * @type string
+ * @static
+ */
 Object.defineProperty(Parse, 'javaScriptKey', {
   get() {
     return CoreManager.get('JAVASCRIPT_KEY');
@@ -64,6 +76,12 @@ Object.defineProperty(Parse, 'javaScriptKey', {
     CoreManager.set('JAVASCRIPT_KEY', value);
   }
 });
+
+/** 
+ * @member Parse.masterKey
+ * @type string
+ * @static
+ */
 Object.defineProperty(Parse, 'masterKey', {
   get() {
     return CoreManager.get('MASTER_KEY');
@@ -72,6 +90,12 @@ Object.defineProperty(Parse, 'masterKey', {
     CoreManager.set('MASTER_KEY', value);
   }
 });
+
+/** 
+ * @member Parse.serverURL
+ * @type string
+ * @static
+ */
 Object.defineProperty(Parse, 'serverURL', {
   get() {
     return CoreManager.get('SERVER_URL');
@@ -80,6 +104,11 @@ Object.defineProperty(Parse, 'serverURL', {
     CoreManager.set('SERVER_URL', value);
   }
 });
+/** 
+ * @member Parse.liveQueryServerURL
+ * @type string
+ * @static
+ */
 Object.defineProperty(Parse, 'liveQueryServerURL', {
   get() {
     return CoreManager.get('LIVEQUERY_SERVER_URL');
@@ -88,7 +117,7 @@ Object.defineProperty(Parse, 'liveQueryServerURL', {
     CoreManager.set('LIVEQUERY_SERVER_URL', value);
   }
 });
-/** End setters **/
+/* End setters */
 
 Parse.ACL = require('./ParseACL').default;
 Parse.Analytics = require('./Analytics');

--- a/src/ParseACL.js
+++ b/src/ParseACL.js
@@ -24,16 +24,18 @@ var PUBLIC_KEY = '*';
  *   permission for only that user.
  * If the argument is any other JSON object, that object will be interpretted
  *   as a serialized ACL created with toJSON().
- * @class Parse.ACL
- * @constructor
- *
+ * 
  * <p>An ACL, or Access Control List can be added to any
  * <code>Parse.Object</code> to restrict access to only a subset of users
  * of your application.</p>
+ * @alias Parse.ACL
  */
-export default class ParseACL {
+class ParseACL {
   permissionsById: ByIdMap;
 
+  /**
+   * @param {(Parse.User|Object)} user The user to initialize the ACL for
+   */
   constructor(arg1: ParseUser | ByIdMap) {
     this.permissionsById = {};
     if (arg1 && typeof arg1 === 'object') {
@@ -74,7 +76,6 @@ export default class ParseACL {
 
   /**
    * Returns a JSON-encoded version of the ACL.
-   * @method toJSON
    * @return {Object}
    */
   toJSON(): ByIdMap {
@@ -87,7 +88,6 @@ export default class ParseACL {
 
   /**
    * Returns whether this ACL is equal to another object
-   * @method equals
    * @param other The other object to compare to
    * @return {Boolean}
    */
@@ -176,7 +176,6 @@ export default class ParseACL {
 
   /**
    * Sets whether the given user is allowed to read this object.
-   * @method setReadAccess
    * @param userId An instance of Parse.User or its objectId.
    * @param {Boolean} allowed Whether that user should have read access.
    */
@@ -189,7 +188,6 @@ export default class ParseACL {
    * Even if this returns false, the user may still be able to access it if
    * getPublicReadAccess returns true or a role that the user belongs to has
    * write access.
-   * @method getReadAccess
    * @param userId An instance of Parse.User or its objectId, or a Parse.Role.
    * @return {Boolean}
    */
@@ -199,7 +197,6 @@ export default class ParseACL {
 
   /**
    * Sets whether the given user id is allowed to write this object.
-   * @method setWriteAccess
    * @param userId An instance of Parse.User or its objectId, or a Parse.Role..
    * @param {Boolean} allowed Whether that user should have write access.
    */
@@ -212,7 +209,6 @@ export default class ParseACL {
    * Even if this returns false, the user may still be able to write it if
    * getPublicWriteAccess returns true or a role that the user belongs to has
    * write access.
-   * @method getWriteAccess
    * @param userId An instance of Parse.User or its objectId, or a Parse.Role.
    * @return {Boolean}
    */
@@ -222,7 +218,6 @@ export default class ParseACL {
 
   /**
    * Sets whether the public is allowed to read this object.
-   * @method setPublicReadAccess
    * @param {Boolean} allowed
    */
   setPublicReadAccess(allowed: boolean) {
@@ -231,7 +226,6 @@ export default class ParseACL {
 
   /**
    * Gets whether the public is allowed to read this object.
-   * @method getPublicReadAccess
    * @return {Boolean}
    */
   getPublicReadAccess(): boolean {
@@ -240,7 +234,6 @@ export default class ParseACL {
 
   /**
    * Sets whether the public is allowed to write this object.
-   * @method setPublicWriteAccess
    * @param {Boolean} allowed
    */
   setPublicWriteAccess(allowed: boolean) {
@@ -249,7 +242,6 @@ export default class ParseACL {
 
   /**
    * Gets whether the public is allowed to write this object.
-   * @method getPublicWriteAccess
    * @return {Boolean}
    */
   getPublicWriteAccess(): boolean {
@@ -261,7 +253,6 @@ export default class ParseACL {
    * to read this object. Even if this returns false, the role may
    * still be able to write it if a parent role has read access.
    *
-   * @method getRoleReadAccess
    * @param role The name of the role, or a Parse.Role object.
    * @return {Boolean} true if the role has read access. false otherwise.
    * @throws {TypeError} If role is neither a Parse.Role nor a String.
@@ -284,7 +275,6 @@ export default class ParseACL {
    * to write this object. Even if this returns false, the role may
    * still be able to write it if a parent role has write access.
    *
-   * @method getRoleWriteAccess
    * @param role The name of the role, or a Parse.Role object.
    * @return {Boolean} true if the role has write access. false otherwise.
    * @throws {TypeError} If role is neither a Parse.Role nor a String.
@@ -306,7 +296,6 @@ export default class ParseACL {
    * Sets whether users belonging to the given role are allowed
    * to read this object.
    *
-   * @method setRoleReadAccess
    * @param role The name of the role, or a Parse.Role object.
    * @param {Boolean} allowed Whether the given role can read this object.
    * @throws {TypeError} If role is neither a Parse.Role nor a String.
@@ -328,7 +317,6 @@ export default class ParseACL {
    * Sets whether users belonging to the given role are allowed
    * to write this object.
    *
-   * @method setRoleWriteAccess
    * @param role The name of the role, or a Parse.Role object.
    * @param {Boolean} allowed Whether the given role can write this object.
    * @throws {TypeError} If role is neither a Parse.Role nor a String.
@@ -346,3 +334,5 @@ export default class ParseACL {
     this.setWriteAccess('role:' + role, allowed);
   }
 }
+
+export default ParseACL;

--- a/src/ParseConfig.js
+++ b/src/ParseConfig.js
@@ -21,11 +21,10 @@ import Storage from './Storage';
  * Parse.Config is a local representation of configuration data that
  * can be set from the Parse dashboard.
  *
- * @class Parse.Config
- * @constructor
+ * @alias Parse.Config
  */
 
-export default class ParseConfig {
+class ParseConfig {
   attributes: { [key: string]: any };
   _escapedAttributes: { [key: string]: any };
 
@@ -36,7 +35,6 @@ export default class ParseConfig {
 
   /**
    * Gets the value of an attribute.
-   * @method get
    * @param {String} attr The name of an attribute.
    */
   get(attr: string): any {
@@ -45,7 +43,6 @@ export default class ParseConfig {
 
   /**
    * Gets the HTML-escaped value of an attribute.
-   * @method escape
    * @param {String} attr The name of an attribute.
    */
   escape(attr: string): string {
@@ -66,7 +63,6 @@ export default class ParseConfig {
    * Retrieves the most recently-fetched configuration object, either from
    * memory or from local storage if necessary.
    *
-   * @method current
    * @static
    * @return {Config} The most recently-fetched Parse.Config if it
    *     exists, else an empty Parse.Config.
@@ -78,7 +74,6 @@ export default class ParseConfig {
 
   /**
    * Gets a new configuration object from the server.
-   * @method get
    * @static
    * @param {Object} options A Backbone-style options object.
    * Valid options are:<ul>
@@ -176,3 +171,5 @@ var DefaultController = {
 };
 
 CoreManager.setConfigController(DefaultController);
+
+export default ParseConfig;

--- a/src/ParseError.js
+++ b/src/ParseError.js
@@ -9,12 +9,13 @@
 
  /**
   * Constructs a new Parse.Error object with the given code and message.
-  * @class Parse.Error
-  * @constructor
-  * @param {Number} code An error code constant from <code>Parse.Error</code>.
-  * @param {String} message A detailed description of the error.
+  * @alias Parse.Error
   */
-export default class ParseError {
+class ParseError {
+  /**
+   * @param {Number} code An error code constant from <code>Parse.Error</code>.
+   * @param {String} message A detailed description of the error.
+   */
   constructor(code, message) {
     this.code = code;
     this.message = message;
@@ -493,3 +494,5 @@ ParseError.FILE_READ_ERROR = 601;
  * @final
  */
 ParseError.X_DOMAIN_REQUEST = 602;
+
+export default ParseError;

--- a/src/ParseFile.js
+++ b/src/ParseFile.js
@@ -49,39 +49,40 @@ function b64Digit(number: number): string {
 /**
  * A Parse.File is a local representation of a file that is saved to the Parse
  * cloud.
- * @class Parse.File
- * @constructor
- * @param name {String} The file's name. This will be prefixed by a unique
- *     value once the file has finished saving. The file name must begin with
- *     an alphanumeric character, and consist of alphanumeric characters,
- *     periods, spaces, underscores, or dashes.
- * @param data {Array} The data for the file, as either:
- *     1. an Array of byte value Numbers, or
- *     2. an Object like { base64: "..." } with a base64-encoded String.
- *     3. a File object selected with a file upload control. (3) only works
- *        in Firefox 3.6+, Safari 6.0.2+, Chrome 7+, and IE 10+.
- *        For example:<pre>
- * var fileUploadControl = $("#profilePhotoFileUpload")[0];
- * if (fileUploadControl.files.length > 0) {
- *   var file = fileUploadControl.files[0];
- *   var name = "photo.jpg";
- *   var parseFile = new Parse.File(name, file);
- *   parseFile.save().then(function() {
- *     // The file has been saved to Parse.
- *   }, function(error) {
- *     // The file either could not be read, or could not be saved to Parse.
- *   });
- * }</pre>
- * @param type {String} Optional Content-Type header to use for the file. If
- *     this is omitted, the content type will be inferred from the name's
- *     extension.
+ * @alias Parse.File
  */
-export default class ParseFile {
+class ParseFile {
   _name: string;
   _url: ?string;
   _source: FileSource;
   _previousSave: ?ParsePromise;
 
+  /**
+   * @param name {String} The file's name. This will be prefixed by a unique
+   *     value once the file has finished saving. The file name must begin with
+   *     an alphanumeric character, and consist of alphanumeric characters,
+   *     periods, spaces, underscores, or dashes.
+   * @param data {Array} The data for the file, as either:
+   *     1. an Array of byte value Numbers, or
+   *     2. an Object like { base64: "..." } with a base64-encoded String.
+   *     3. a File object selected with a file upload control. (3) only works
+   *        in Firefox 3.6+, Safari 6.0.2+, Chrome 7+, and IE 10+.
+   *        For example:<pre>
+   * var fileUploadControl = $("#profilePhotoFileUpload")[0];
+   * if (fileUploadControl.files.length > 0) {
+   *   var file = fileUploadControl.files[0];
+   *   var name = "photo.jpg";
+   *   var parseFile = new Parse.File(name, file);
+   *   parseFile.save().then(function() {
+   *     // The file has been saved to Parse.
+   *   }, function(error) {
+   *     // The file either could not be read, or could not be saved to Parse.
+   *   });
+   * }</pre>
+   * @param type {String} Optional Content-Type header to use for the file. If
+   *     this is omitted, the content type will be inferred from the name's
+   *     extension.
+   */
   constructor(name: string, data?: FileData, type?: string) {
     var specifiedType = type || '';
 
@@ -129,7 +130,6 @@ export default class ParseFile {
    * Gets the name of the file. Before save is called, this is the filename
    * given by the user. After save is called, that name gets prefixed with a
    * unique identifier.
-   * @method name
    * @return {String}
    */
   name(): string {
@@ -139,7 +139,6 @@ export default class ParseFile {
   /**
    * Gets the url of the file. It is only available after you save the file or
    * after you get the file from a Parse.Object.
-   * @method url
    * @param {Object} options An object to specify url options
    * @return {String}
    */
@@ -157,7 +156,6 @@ export default class ParseFile {
 
   /**
    * Saves the file to the Parse cloud.
-   * @method save
    * @param {Object} options A Backbone-style options object.
    * @return {Parse.Promise} Promise that is resolved when the save finishes.
    */
@@ -272,3 +270,5 @@ var DefaultController = {
 };
 
 CoreManager.setFileController(DefaultController);
+
+export default ParseFile;

--- a/src/ParseGeoPoint.js
+++ b/src/ParseGeoPoint.js
@@ -20,9 +20,6 @@ import ParsePromise from './ParsePromise';
  *   new GeoPoint({latitude: 30, longitude: 30})
  *   new GeoPoint()  // defaults to (0, 0)
  *   </pre>
- * @class Parse.GeoPoint
- * @constructor
- *
  * <p>Represents a latitude / longitude point that may be associated
  * with a key in a ParseObject or used as a reference point for geo queries.
  * This allows proximity-based queries on the key.</p>
@@ -34,11 +31,16 @@ import ParsePromise from './ParsePromise';
  *   var object = new Parse.Object("PlaceObject");
  *   object.set("location", point);
  *   object.save();</pre></p>
+ * @alias Parse.GeoPoint
  */
-export default class ParseGeoPoint {
+class ParseGeoPoint {
   _latitude: number;
   _longitude: number;
 
+  /**
+   * @param {(Number[]|Object|Number)} options Either a list of coordinate pairs, an object with `latitude`, `longitude`, or the latitude or the point. 
+   * @param {Number} longitude The longitude of the GeoPoint
+   */
   constructor(
     arg1: Array<number> |
     { latitude: number; longitude: number } |
@@ -94,7 +96,7 @@ export default class ParseGeoPoint {
 
   /**
    * Returns a JSON representation of the GeoPoint, suitable for Parse.
-   * @method toJSON
+
    * @return {Object}
    */
   toJSON(): { __type: string; latitude: number; longitude: number } {
@@ -116,7 +118,7 @@ export default class ParseGeoPoint {
 
   /**
    * Returns the distance from this GeoPoint to another in radians.
-   * @method radiansTo
+
    * @param {Parse.GeoPoint} point the other Parse.GeoPoint.
    * @return {Number}
    */
@@ -140,7 +142,7 @@ export default class ParseGeoPoint {
 
   /**
    * Returns the distance from this GeoPoint to another in kilometers.
-   * @method kilometersTo
+
    * @param {Parse.GeoPoint} point the other Parse.GeoPoint.
    * @return {Number}
    */
@@ -150,7 +152,7 @@ export default class ParseGeoPoint {
 
   /**
    * Returns the distance from this GeoPoint to another in miles.
-   * @method milesTo
+
    * @param {Parse.GeoPoint} point the other Parse.GeoPoint.
    * @return {Number}
    */
@@ -158,7 +160,7 @@ export default class ParseGeoPoint {
     return this.radiansTo(point) * 3958.8;
   }
 
-  /**
+  /*
    * Throws an exception if the given lat-long is out of bounds.
    */
   static _validate(latitude: number, longitude: number) {
@@ -192,7 +194,7 @@ export default class ParseGeoPoint {
   /**
    * Creates a GeoPoint with the user's current location, if available.
    * Calls options.success with a new GeoPoint instance or calls options.error.
-   * @method current
+
    * @param {Object} options An object with success and error callbacks.
    * @static
    */
@@ -209,3 +211,5 @@ export default class ParseGeoPoint {
     return promise._thenRunCallbacks(options);
   }
 }
+
+export default ParseGeoPoint;

--- a/src/ParseLiveQuery.js
+++ b/src/ParseLiveQuery.js
@@ -59,7 +59,7 @@ let LiveQuery = new EventEmitter();
  * After open is called, the LiveQuery will try to send a connect request
  * to the LiveQuery server.
  * 
- * @method open
+
  */ 
 LiveQuery.open = open;
 
@@ -70,7 +70,7 @@ LiveQuery.open = open;
  * If you call query.subscribe() after this, we'll create a new WebSocket
  * connection to the LiveQuery server.
  * 
- * @method close
+
  */
 
 LiveQuery.close = close;

--- a/src/ParseObject.js
+++ b/src/ParseObject.js
@@ -528,7 +528,7 @@ class ParseObject {
   /**
    * Gets a relation on the given class for the attribute.
    * @param String attr The attribute to get the relation for.
-   * @return {ParseRelation}
+   * @return {Parse.Relation}
    */
   relation(attr: string): ParseRelation {
     var value = this.get(attr);

--- a/src/ParseObject.js
+++ b/src/ParseObject.js
@@ -82,37 +82,28 @@ function getServerUrlPath() {
 
 /**
  * Creates a new model with defined attributes.
- *
- * <p>You won't normally call this method directly.  It is recommended that
- * you use a subclass of <code>Parse.Object</code> instead, created by calling
- * <code>extend</code>.</p>
- *
- * <p>However, if you don't want to use a subclass, or aren't sure which
- * subclass is appropriate, you can use this form:<pre>
- *     var object = new Parse.Object("ClassName");
- * </pre>
- * That is basically equivalent to:<pre>
- *     var MyClass = Parse.Object.extend("ClassName");
- *     var object = new MyClass();
- * </pre></p>
- *
- * @class Parse.Object
- * @constructor
- * @param {String} className The class name for the object
- * @param {Object} attributes The initial set of data to store in the object.
- * @param {Object} options The options for this object instance.
+  *
+  * <p>You won't normally call this method directly.  It is recommended that
+  * you use a subclass of <code>Parse.Object</code> instead, created by calling
+  * <code>extend</code>.</p>
+  *
+  * <p>However, if you don't want to use a subclass, or aren't sure which
+  * subclass is appropriate, you can use this form:<pre>
+  *     var object = new Parse.Object("ClassName");
+  * </pre>
+  * That is basically equivalent to:<pre>
+  *     var MyClass = Parse.Object.extend("ClassName");
+  *     var object = new MyClass();
+  * </pre></p>
+  *
+ * @alias Parse.Object
  */
-export default class ParseObject {
+class ParseObject {
   /**
-   * The ID of this object, unique within its class.
-   * @property id
-   * @type String
+   * @param {String} className The class name for the object
+   * @param {Object} attributes The initial set of data to store in the object.
+   * @param {Object} options The options for this object instance.
    */
-  id: ?string;
-  _localId: ?string;
-  _objCount: number;
-  className: string;
-
   constructor(className: ?string | { className: string, [attr: string]: mixed }, attributes?: { [attr: string]: mixed }, options?: { ignoreValidation: boolean }) {
     // Enable legacy initializers
     if (typeof this.initialize === 'function') {
@@ -142,6 +133,16 @@ export default class ParseObject {
       throw new Error('Can\'t create an invalid Parse Object');
     }
   }
+
+  /**
+   * The ID of this object, unique within its class.
+   * @property id
+   * @type String
+   */
+  id: ?string;
+  _localId: ?string;
+  _objCount: number;
+  className: string;
 
   /** Prototype getters / setters **/
 
@@ -407,7 +408,6 @@ export default class ParseObject {
 
   /**
    * Returns a JSON version of the object suitable for saving to Parse.
-   * @method toJSON
    * @return {Object}
    */
   toJSON(seen: Array<any> | void): AttributeMap {
@@ -435,7 +435,7 @@ export default class ParseObject {
 
   /**
    * Determines whether this ParseObject is equal to another ParseObject
-   * @method equals
+   * @param {Object} other - An other object ot compare
    * @return {Boolean}
    */
   equals(other: mixed): boolean {
@@ -454,7 +454,6 @@ export default class ParseObject {
    * Returns true if this object has been modified since its last
    * save/refresh.  If an attribute is specified, it returns true only if that
    * particular attribute has been modified since the last save/refresh.
-   * @method dirty
    * @param {String} attr An attribute name (optional).
    * @return {Boolean}
    */
@@ -486,8 +485,7 @@ export default class ParseObject {
 
   /**
    * Returns an array of keys that have been modified since last save/refresh
-   * @method dirtyKeys
-   * @return {Array of string}
+   * @return {String[]}
    */
   dirtyKeys(): Array<string> {
     var pendingOps = this._getPendingOps();
@@ -506,8 +504,7 @@ export default class ParseObject {
 
   /**
    * Gets a Pointer referencing this Object.
-   * @method toPointer
-   * @return {Object}
+   * @return {Pointer}
    */
   toPointer(): Pointer {
     if (!this.id) {
@@ -522,7 +519,6 @@ export default class ParseObject {
 
   /**
    * Gets the value of an attribute.
-   * @method get
    * @param {String} attr The string name of an attribute.
    */
   get(attr: string): mixed {
@@ -531,8 +527,8 @@ export default class ParseObject {
 
   /**
    * Gets a relation on the given class for the attribute.
-   * @method relation
    * @param String attr The attribute to get the relation for.
+   * @return {ParseRelation}
    */
   relation(attr: string): ParseRelation {
     var value = this.get(attr);
@@ -548,7 +544,6 @@ export default class ParseObject {
 
   /**
    * Gets the HTML-escaped value of an attribute.
-   * @method escape
    * @param {String} attr The string name of an attribute.
    */
   escape(attr: string): string {
@@ -569,7 +564,6 @@ export default class ParseObject {
   /**
    * Returns <code>true</code> if the attribute contains a value that is not
    * null or undefined.
-   * @method has
    * @param {String} attr The string name of the attribute.
    * @return {Boolean}
    */
@@ -603,7 +597,6 @@ export default class ParseObject {
    *
    *   game.set("finished", true);</pre></p>
    *
-   * @method set
    * @param {String} key The key to set.
    * @param {} value The value to give it.
    * @param {Object} options A set of options for the set.
@@ -697,7 +690,6 @@ export default class ParseObject {
   /**
    * Remove an attribute from the model. This is a noop if the attribute doesn't
    * exist.
-   * @method unset
    * @param {String} attr The string name of an attribute.
    */
   unset(attr: string, options?: { [opt: string]: mixed }): ParseObject | boolean {
@@ -710,7 +702,6 @@ export default class ParseObject {
    * Atomically increments the value of the given attribute the next time the
    * object is saved. If no amount is specified, 1 is used by default.
    *
-   * @method increment
    * @param attr {String} The key.
    * @param amount {Number} The amount to increment by (optional).
    */
@@ -727,9 +718,9 @@ export default class ParseObject {
   /**
    * Atomically add an object to the end of the array associated with a given
    * key.
-   * @method add
    * @param attr {String} The key.
    * @param item {} The item to add.
+   * @return {(ParseObject|Boolean)}
    */
   add(attr: string, item: mixed): ParseObject | boolean {
     return this.set(attr, new AddOp([item]));
@@ -738,9 +729,8 @@ export default class ParseObject {
   /**
    * Atomically add the objects to the end of the array associated with a given
    * key.
-   * @method addAll
    * @param attr {String} The key.
-   * @param items {[]} The items to add.
+   * @param items {Object[]} The items to add.
    */
   addAll(attr: string, items: Array<mixed>): ParseObject | boolean {
     return this.set(attr, new AddOp(items));
@@ -751,7 +741,6 @@ export default class ParseObject {
    * if it is not already present in the array. The position of the insert is
    * not guaranteed.
    *
-   * @method addUnique
    * @param attr {String} The key.
    * @param item {} The object to add.
    */
@@ -764,9 +753,8 @@ export default class ParseObject {
    * if it is not already present in the array. The position of the insert is
    * not guaranteed.
    *
-   * @method addAllUnique
    * @param attr {String} The key.
-   * @param items {[]} The objects to add.
+   * @param items {Object[]} The objects to add.
    */
   addAllUnique(attr: string, items: Array<mixed>): ParseObject | boolean {
     return this.set(attr, new AddUniqueOp(items));
@@ -776,7 +764,6 @@ export default class ParseObject {
    * Atomically remove all instances of an object from the array associated
    * with a given key.
    *
-   * @method remove
    * @param attr {String} The key.
    * @param item {} The object to remove.
    */
@@ -788,9 +775,8 @@ export default class ParseObject {
    * Atomically remove all instances of the objects from the array associated
    * with a given key.
    *
-   * @method removeAll
    * @param attr {String} The key.
-   * @param items {[]} The object to remove.
+   * @param items {Object[]} The object to remove.
    */
   removeAll(attr: string, items: Array<mixed>): ParseObject | boolean {
     return this.set(attr, new RemoveOp(items));
@@ -802,7 +788,6 @@ export default class ParseObject {
    * saved. For example, after calling object.increment("x"), calling
    * object.op("x") would return an instance of Parse.Op.Increment.
    *
-   * @method op
    * @param attr {String} The key.
    * @returns {Parse.Op} The operation, or undefined if none.
    */
@@ -817,7 +802,6 @@ export default class ParseObject {
 
   /**
    * Creates a new model with identical attributes to this one, similar to Backbone.Model's clone()
-   * @method clone
    * @return {Parse.Object}
    */
   clone(): any {
@@ -846,7 +830,6 @@ export default class ParseObject {
 
   /**
    * Creates a new instance of this object. Not to be confused with clone()
-   * @method newInstance
    * @return {Parse.Object}
    */
   newInstance(): any {
@@ -869,7 +852,6 @@ export default class ParseObject {
 
   /**
    * Returns true if this object has never been saved to Parse.
-   * @method isNew
    * @return {Boolean}
    */
   isNew(): boolean {
@@ -880,7 +862,6 @@ export default class ParseObject {
    * Returns true if this object was created by the Parse server when the
    * object might have already been there (e.g. in the case of a Facebook
    * login)
-   * @method existed
    * @return {Boolean}
    */
   existed(): boolean {
@@ -897,7 +878,6 @@ export default class ParseObject {
 
   /**
    * Checks if the model is currently in a valid state.
-   * @method isValid
    * @return {Boolean}
    */
   isValid(): boolean {
@@ -910,7 +890,6 @@ export default class ParseObject {
    * to provide additional validation on <code>set</code> and
    * <code>save</code>.  Your implementation should return
    *
-   * @method validate
    * @param {Object} attrs The current data to validate.
    * @return {} False if the data is valid.  An error object otherwise.
    * @see Parse.Object#set
@@ -932,7 +911,6 @@ export default class ParseObject {
 
   /**
    * Returns the ACL for this object.
-   * @method getACL
    * @returns {Parse.ACL} An instance of Parse.ACL.
    * @see Parse.Object#get
    */
@@ -946,7 +924,6 @@ export default class ParseObject {
 
   /**
    * Sets the ACL to be used for this object.
-   * @method setACL
    * @param {Parse.ACL} acl An instance of Parse.ACL.
    * @param {Object} options Optional Backbone-like options object to be
    *     passed in to set.
@@ -959,7 +936,6 @@ export default class ParseObject {
 
   /**
    * Clears any changes to this object made since the last call to save()
-   * @method revert
    */
   revert(): void {
     this._clearPendingOps();
@@ -967,7 +943,7 @@ export default class ParseObject {
 
   /**
    * Clears all attributes on a model
-   * @method clear
+   * @return {(ParseObject | boolean)}
    */
   clear(): ParseObject | boolean {
     var attributes = this.attributes;
@@ -988,7 +964,6 @@ export default class ParseObject {
    * Fetch the model from the server. If the server's representation of the
    * model differs from its current attributes, they will be overriden.
    *
-   * @method fetch
    * @param {Object} options A Backbone-style callback object.
    * Valid options are:<ul>
    *   <li>success: A Backbone-style success callback.
@@ -1048,7 +1023,6 @@ export default class ParseObject {
    *     // The save failed.  Error is an instance of Parse.Error.
    *   });</pre>
    *
-   * @method save
    * @param {Object} options A Backbone-style callback object.
    * Valid options are:<ul>
    *   <li>success: A Backbone-style success callback.
@@ -1124,7 +1098,6 @@ export default class ParseObject {
    * If `wait: true` is passed, waits for the server to respond
    * before removal.
    *
-   * @method destroy
    * @param {Object} options A Backbone-style callback object.
    * Valid options are:<ul>
    *   <li>success: A Backbone-style success callback
@@ -1177,7 +1150,6 @@ export default class ParseObject {
    *   });
    * </pre>
    *
-   * @method fetchAll
    * @param {Array} list A list of <code>Parse.Object</code>.
    * @param {Object} options A Backbone-style callback object.
    * @static
@@ -1218,7 +1190,6 @@ export default class ParseObject {
    *   });
    * </pre>
    *
-   * @method fetchAllIfNeeded
    * @param {Array} list A list of <code>Parse.Object</code>.
    * @param {Object} options A Backbone-style callback object.
    * @static
@@ -1286,7 +1257,6 @@ export default class ParseObject {
    *   });
    * </pre>
    *
-   * @method destroyAll
    * @param {Array} list A list of <code>Parse.Object</code>.
    * @param {Object} options A Backbone-style callback object.
    * @static
@@ -1330,7 +1300,6 @@ export default class ParseObject {
    *   });
    * </pre>
    *
-   * @method saveAll
    * @param {Array} list A list of <code>Parse.Object</code>.
    * @param {Object} options A Backbone-style callback object.
    * @static
@@ -1367,7 +1336,6 @@ export default class ParseObject {
    *  pointerToFoo.id = "myObjectId";
    * </pre>
    *
-   * @method createWithoutData
    * @param {String} id The ID of the object to create a reference to.
    * @static
    * @return {Parse.Object} A Parse.Object reference.
@@ -1380,7 +1348,6 @@ export default class ParseObject {
 
   /**
    * Creates a new instance of a Parse Object from a JSON representation.
-   * @method fromJSON
    * @param {Object} json The JSON map of the Object's data
    * @param {boolean} override In single instance mode, all old server data
    *   is overwritten if this is set to true
@@ -1425,7 +1392,6 @@ export default class ParseObject {
    * When objects of that class are retrieved from a query, they will be
    * instantiated with this subclass.
    * This is only necessary when using ES6 subclassing.
-   * @method registerSubclass
    * @param {String} className The class name of the subclass
    * @param {Class} constructor The subclass
    */
@@ -1478,7 +1444,6 @@ export default class ParseObject {
    *         <i>Class properties</i>
    *     });</pre></p>
    *
-   * @method extend
    * @param {String} className The name of the Parse class backing this model.
    * @param {Object} protoProps Instance properties to add to instances of the
    *     class returned from this method.
@@ -1577,7 +1542,7 @@ export default class ParseObject {
    * share the same attributes, and stay synchronized with each other.
    * This is disabled by default in server environments, since it can lead to
    * security issues.
-   * @method enableSingleInstance
+   * @static
    */
   static enableSingleInstance() {
     singleInstance = true;
@@ -1589,7 +1554,7 @@ export default class ParseObject {
    * share the same attributes, and stay synchronized with each other.
    * When disabled, you can have two instances of the same object in memory
    * without them sharing attributes.
-   * @method disableSingleInstance
+   * @static
    */
   static disableSingleInstance() {
     singleInstance = false;
@@ -1888,3 +1853,5 @@ var DefaultController = {
 }
 
 CoreManager.setObjectController(DefaultController);
+
+export default ParseObject;

--- a/src/ParsePolygon.js
+++ b/src/ParsePolygon.js
@@ -17,9 +17,7 @@ import ParseGeoPoint from './ParseGeoPoint';
  *   new Polygon([[0,0],[0,1],[1,1],[1,0]])
  *   new Polygon([GeoPoint, GeoPoint, GeoPoint])
  *   </pre>
- * @class Parse.GeoPoint
- * @constructor
- *
+ * 
  * <p>Represents a coordinates that may be associated
  * with a key in a ParseObject or used as a reference point for geo queries.
  * This allows proximity-based queries on the key.</p>
@@ -29,10 +27,14 @@ import ParseGeoPoint from './ParseGeoPoint';
  *   var object = new Parse.Object("PlaceObject");
  *   object.set("area", polygon);
  *   object.save();</pre></p>
+ * @alias Parse.Polygon
  */
-export default class ParsePolygon {
+class ParsePolygon {
   _coordinates: Array;
 
+  /**
+   * @param {(Number[][]|Parse.GeoPoint[])} coordinates An Array of coordinate pairs
+   */
   constructor(
     arg1: Array,
   ) {
@@ -55,7 +57,7 @@ export default class ParsePolygon {
 
   /**
    * Returns a JSON representation of the GeoPoint, suitable for Parse.
-   * @method toJSON
+
    * @return {Object}
    */
   toJSON(): { __type: string; coordinates: Array;} {
@@ -145,3 +147,5 @@ export default class ParsePolygon {
     return points;
   }
 }
+
+export default ParsePolygon;

--- a/src/ParsePolygon.js
+++ b/src/ParsePolygon.js
@@ -57,7 +57,6 @@ class ParsePolygon {
 
   /**
    * Returns a JSON representation of the GeoPoint, suitable for Parse.
-
    * @return {Object}
    */
   toJSON(): { __type: string; coordinates: Array;} {
@@ -68,6 +67,11 @@ class ParsePolygon {
     };
   }
 
+  /**
+   * Checks if two polygons are equal
+   * @param {(Parse.Polygon|Object)} other
+   * @returns {Boolean}
+   */
   equals(other: mixed): boolean {
     if (!(other instanceof ParsePolygon) || (this.coordinates.length !== other.coordinates.length)) {
       return false;
@@ -84,6 +88,11 @@ class ParsePolygon {
     return isEqual;
   }
 
+  /**
+   * 
+   * @param {Parse.GeoPoint} point 
+   * @returns {Boolean} wether the points is contained into the polygon
+   */
   containsPoint(point: ParseGeoPoint): boolean {
     let minX = this._coordinates[0][0];
     let maxX = this._coordinates[0][0];
@@ -121,8 +130,9 @@ class ParsePolygon {
   }
 
   /**
-   * Throws an exception if the given lat-long is out of bounds.
-   * @return {Array}
+   * Validates that the list of coordinates can form a valid polygon
+   * @param {Array} coords the list of coordinated to validate as a polygon
+   * @throws {TypeError}
    */
   static _validate(coords: Array) {
     if (!Array.isArray(coords)) {

--- a/src/ParsePromise.js
+++ b/src/ParsePromise.js
@@ -7,6 +7,9 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
+ /**
+  * @private
+  */
 var isPromisesAPlusCompliant = true;
 
 /**
@@ -22,10 +25,9 @@ var isPromisesAPlusCompliant = true;
  *    });
  * </pre></p>
  *
- * @class Parse.Promise
- * @constructor
+ * @alias Parse.Promise
  */
-export default class ParsePromise {
+class ParsePromise {
   constructor(executor) {
     this._resolved = false;
     this._rejected = false;
@@ -39,7 +41,7 @@ export default class ParsePromise {
 
   /**
    * Marks this promise as fulfilled, firing any callbacks waiting on it.
-   * @method resolve
+
    * @param {Object} result the result to pass to the callbacks.
    */
   resolve(...results) {
@@ -61,7 +63,7 @@ export default class ParsePromise {
 
   /**
    * Marks this promise as fulfilled, firing any callbacks waiting on it.
-   * @method reject
+
    * @param {Object} error the error to pass to the callbacks.
    */
   reject(error) {
@@ -86,7 +88,7 @@ export default class ParsePromise {
    * chaining. If the callback itself returns a Promise, then the one returned
    * by "then" will not be fulfilled until that one returned by the callback
    * is fulfilled.
-   * @method then
+
    * @param {Function} resolvedCallback Function that is called when this
    * Promise is resolved. Once the callback is complete, then the Promise
    * returned by "then" will also be fulfilled.
@@ -191,7 +193,7 @@ export default class ParsePromise {
   /**
    * Add handlers to be called when the promise
    * is either resolved or rejected
-   * @method always
+
    */
   always(callback) {
     return this.then(callback, callback);
@@ -199,7 +201,7 @@ export default class ParsePromise {
 
   /**
    * Add handlers to be called when the Promise object is resolved
-   * @method done
+
    */
   done(callback) {
     return this.then(callback);
@@ -208,7 +210,7 @@ export default class ParsePromise {
   /**
    * Add handlers to be called when the Promise object is rejected
    * Alias for catch().
-   * @method fail
+
    */
   fail(callback) {
     return this.then(null, callback);
@@ -216,7 +218,7 @@ export default class ParsePromise {
 
   /**
    * Add handlers to be called when the Promise object is rejected
-   * @method catch
+
    */
   catch(callback) {
     return this.then(null, callback);
@@ -224,7 +226,7 @@ export default class ParsePromise {
 
   /**
    * Run the given callbacks after this promise is fulfilled.
-   * @method _thenRunCallbacks
+
    * @param optionsOrCallback {} A Backbone-style options callback, or a
    * callback function. If this is an options object and contains a "model"
    * attributes, that will be passed to error callbacks as the first argument.
@@ -276,7 +278,7 @@ export default class ParsePromise {
    * array of results for its first argument, or the error as its second,
    * depending on whether this Promise was rejected or resolved. Returns a
    * new Promise, like "then" would.
-   * @method _continueWith
+
    * @param {Function} continuation the callback.
    */
   _continueWith(continuation) {
@@ -289,7 +291,7 @@ export default class ParsePromise {
 
   /**
    * Returns true iff the given object fulfils the Promise interface.
-   * @method is
+
    * @param {Object} promise The object to test
    * @static
    * @return {Boolean}
@@ -303,7 +305,7 @@ export default class ParsePromise {
 
   /**
    * Returns a new promise that is resolved with a given value.
-   * @method as
+
    * @param value The value to resolve the promise with
    * @static
    * @return {Parse.Promise} the new promise.
@@ -319,7 +321,7 @@ export default class ParsePromise {
    * If that value is a thenable Promise (has a .then() prototype
    * method), the new promise will be chained to the end of the
    * value.
-   * @method resolve
+
    * @param value The value to resolve the promise with
    * @static
    * @return {Parse.Promise} the new promise.
@@ -336,7 +338,7 @@ export default class ParsePromise {
 
   /**
    * Returns a new promise that is rejected with a given error.
-   * @method error
+
    * @param error The error to reject the promise with
    * @static
    * @return {Parse.Promise} the new promise.
@@ -351,7 +353,7 @@ export default class ParsePromise {
    * Returns a new promise that is rejected with a given error.
    * This is an alias for Parse.Promise.error, for compliance with
    * the ES6 implementation.
-   * @method reject
+
    * @param error The error to reject the promise with
    * @static
    * @return {Parse.Promise} the new promise.
@@ -383,7 +385,7 @@ export default class ParsePromise {
    *     console.log(results);  // prints [1,2,3]
    *   });
    * </pre>
-   * @method when
+
    * @param {Array} promises a list of promises to wait for.
    * @static
    * @return {Parse.Promise} the new promise.
@@ -464,7 +466,7 @@ export default class ParsePromise {
    *     console.log(r3);  // prints 3
    *   });</pre>
    *
-   * @method all
+
    * @param {Iterable} promises an iterable of promises to wait for.
    * @static
    * @return {Parse.Promise} the new promise.
@@ -521,7 +523,7 @@ export default class ParsePromise {
    * complete is rejected, the returned promise will be rejected with the
    * same reason.
    *
-   * @method race
+
    * @param {Iterable} promises an iterable of promises to wait for.
    * @static
    * @return {Parse.Promise} the new promise.
@@ -557,7 +559,7 @@ export default class ParsePromise {
    * Runs the given asyncFunction repeatedly, as long as the predicate
    * function returns a truthy value. Stops repeating if asyncFunction returns
    * a rejected promise.
-   * @method _continueWhile
+
    * @param {Function} predicate should return false when ready to stop.
    * @param {Function} asyncFunction should return a Promise.
    * @static
@@ -583,3 +585,5 @@ export default class ParsePromise {
     isPromisesAPlusCompliant = false;
   }
 }
+
+export default ParsePromise;

--- a/src/ParseQuery.js
+++ b/src/ParseQuery.js
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2015-present, Parse, LLC.
  * All rights reserved.
  *
@@ -40,12 +40,13 @@ export type QueryJSON = {
  * Converts a string into a regex that matches it.
  * Surrounding with \Q .. \E does this, we just need to escape any \E's in
  * the text separately.
+ * @private
  */
 function quote(s: string) {
   return '\\Q' + s.replace('\\E', '\\E\\\\E\\Q') + '\\E';
 }
 
-/**
+/*
  * Handles pre-populating the result data of a query with select fields,
  * making sure that the data object contains keys for all objects that have
  * been requested with a select, so that our cached state updates correctly.
@@ -116,61 +117,63 @@ function handleSelectResult(data: any, select: Array<string>){
 
 /**
  * Creates a new parse Parse.Query for the given Parse.Object subclass.
- * @class Parse.Query
- * @constructor
- * @param {} objectClass An instance of a subclass of Parse.Object, or a Parse className string.
  *
  * <p>Parse.Query defines a query that is used to fetch Parse.Objects. The
  * most common use case is finding all objects that match a query through the
- * <code>find</code> method. For example, this sample code fetches all objects
- * of class <code>MyClass</code>. It calls a different function depending on
+ * <code>find</code> method. for example, this sample code fetches all objects
+ * of class <code>myclass</code>. it calls a different function depending on
  * whether the fetch succeeded or not.
  *
  * <pre>
- * var query = new Parse.Query(MyClass);
+ * var query = new parse.query(myclass);
  * query.find({
  *   success: function(results) {
- *     // results is an array of Parse.Object.
+ *     // results is an array of parse.object.
  *   },
  *
  *   error: function(error) {
- *     // error is an instance of Parse.Error.
+ *     // error is an instance of parse.error.
  *   }
  * });</pre></p>
  *
- * <p>A Parse.Query can also be used to retrieve a single object whose id is
- * known, through the get method. For example, this sample code fetches an
- * object of class <code>MyClass</code> and id <code>myId</code>. It calls a
+ * <p>a parse.query can also be used to retrieve a single object whose id is
+ * known, through the get method. for example, this sample code fetches an
+ * object of class <code>myclass</code> and id <code>myid</code>. it calls a
  * different function depending on whether the fetch succeeded or not.
  *
  * <pre>
- * var query = new Parse.Query(MyClass);
- * query.get(myId, {
+ * var query = new parse.query(myclass);
+ * query.get(myid, {
  *   success: function(object) {
- *     // object is an instance of Parse.Object.
+ *     // object is an instance of parse.object.
  *   },
  *
  *   error: function(object, error) {
- *     // error is an instance of Parse.Error.
+ *     // error is an instance of parse.error.
  *   }
  * });</pre></p>
  *
- * <p>A Parse.Query can also be used to count the number of objects that match
- * the query without retrieving all of those objects. For example, this
- * sample code counts the number of objects of the class <code>MyClass</code>
+ * <p>a parse.query can also be used to count the number of objects that match
+ * the query without retrieving all of those objects. for example, this
+ * sample code counts the number of objects of the class <code>myclass</code>
  * <pre>
- * var query = new Parse.Query(MyClass);
+ * var query = new parse.query(myclass);
  * query.count({
  *   success: function(number) {
- *     // There are number instances of MyClass.
+ *     // there are number instances of myclass.
  *   },
  *
  *   error: function(error) {
  *     // error is an instance of Parse.Error.
  *   }
  * });</pre></p>
+ * @alias Parse.Query
  */
-export default class ParseQuery {
+class ParseQuery {
+  /**
+   * @property className
+   * @type String
+   */
   className: string;
   _where: any;
   _include: Array<string>;
@@ -180,6 +183,9 @@ export default class ParseQuery {
   _order: Array<string>;
   _extraOptions: { [key: string]: mixed };
 
+  /**
+   * @param {(String|Parse.Object)} objectClass An instance of a subclass of Parse.Object, or a Parse className string.
+   */
   constructor(objectClass: string | ParseObject) {
     if (typeof objectClass === 'string') {
       if (objectClass === 'User' && CoreManager.get('PERFORM_USER_REWRITE')) {
@@ -211,7 +217,6 @@ export default class ParseQuery {
 
   /**
    * Adds constraint that at least one of the passed in queries matches.
-   * @method _orQuery
    * @param {Array} queries
    * @return {Parse.Query} Returns the query, so you can chain this call.
    */
@@ -237,7 +242,6 @@ export default class ParseQuery {
 
   /**
    * Returns a JSON representation of this query.
-   * @method toJSON
    * @return {Object} The JSON representation of the query.
    */
   toJSON(): QueryJSON {
@@ -284,7 +288,6 @@ export default class ParseQuery {
    *
    * and continue to query...
    * query.skip(100).find().then(...);
-   * @method withJSON
    * @param {QueryJSON} json from Parse.Query.toJSON() method
    * @return {Parse.Query} Returns the query, so you can chain this call.
    */
@@ -341,7 +344,6 @@ export default class ParseQuery {
    * the server.  Either options.success or options.error is called when the
    * find completes.
    *
-   * @method get
    * @param {String} objectId The id of the object to be fetched.
    * @param {Object} options A Backbone-style options object.
    * Valid options are:<ul>
@@ -385,7 +387,6 @@ export default class ParseQuery {
    * Either options.success or options.error is called when the find
    * completes.
    *
-   * @method find
    * @param {Object} options A Backbone-style options object. Valid options
    * are:<ul>
    *   <li>success: Function to call when the find completes successfully.
@@ -444,7 +445,6 @@ export default class ParseQuery {
    * Either options.success or options.error is called when the count
    * completes.
    *
-   * @method count
    * @param {Object} options A Backbone-style options object. Valid options
    * are:<ul>
    *   <li>success: Function to call when the count completes successfully.
@@ -490,7 +490,6 @@ export default class ParseQuery {
    * Either options.success or options.error is called when it completes.
    * success is passed the object if there is one. otherwise, undefined.
    *
-   * @method first
    * @param {Object} options A Backbone-style options object. Valid options
    * are:<ul>
    *   <li>success: Function to call when the find completes successfully.
@@ -553,7 +552,6 @@ export default class ParseQuery {
    * promise, then iteration will stop with that error. The items are
    * processed in an unspecified order. The query may not have any sort order,
    * and may not use limit or skip.
-   * @method each
    * @param {Function} callback Callback that will be called with each result
    *     of the query.
    * @param {Object} options A Backbone-style options object. Valid options
@@ -647,7 +645,6 @@ export default class ParseQuery {
   /**
    * Adds a constraint to the query that requires a particular key's value to
    * be equal to the provided value.
-   * @method equalTo
    * @param {String} key The key to check.
    * @param value The value that the Parse.Object must contain.
    * @return {Parse.Query} Returns the query, so you can chain this call.
@@ -664,7 +661,6 @@ export default class ParseQuery {
   /**
    * Adds a constraint to the query that requires a particular key's value to
    * be not equal to the provided value.
-   * @method notEqualTo
    * @param {String} key The key to check.
    * @param value The value that must not be equalled.
    * @return {Parse.Query} Returns the query, so you can chain this call.
@@ -676,7 +672,6 @@ export default class ParseQuery {
   /**
    * Adds a constraint to the query that requires a particular key's value to
    * be less than the provided value.
-   * @method lessThan
    * @param {String} key The key to check.
    * @param value The value that provides an upper bound.
    * @return {Parse.Query} Returns the query, so you can chain this call.
@@ -688,7 +683,6 @@ export default class ParseQuery {
   /**
    * Adds a constraint to the query that requires a particular key's value to
    * be greater than the provided value.
-   * @method greaterThan
    * @param {String} key The key to check.
    * @param value The value that provides an lower bound.
    * @return {Parse.Query} Returns the query, so you can chain this call.
@@ -700,7 +694,6 @@ export default class ParseQuery {
   /**
    * Adds a constraint to the query that requires a particular key's value to
    * be less than or equal to the provided value.
-   * @method lessThanOrEqualTo
    * @param {String} key The key to check.
    * @param value The value that provides an upper bound.
    * @return {Parse.Query} Returns the query, so you can chain this call.
@@ -712,7 +705,6 @@ export default class ParseQuery {
   /**
    * Adds a constraint to the query that requires a particular key's value to
    * be greater than or equal to the provided value.
-   * @method greaterThanOrEqualTo
    * @param {String} key The key to check.
    * @param value The value that provides an lower bound.
    * @return {Parse.Query} Returns the query, so you can chain this call.
@@ -724,7 +716,6 @@ export default class ParseQuery {
   /**
    * Adds a constraint to the query that requires a particular key's value to
    * be contained in the provided list of values.
-   * @method containedIn
    * @param {String} key The key to check.
    * @param {Array} values The values that will match.
    * @return {Parse.Query} Returns the query, so you can chain this call.
@@ -736,7 +727,6 @@ export default class ParseQuery {
   /**
    * Adds a constraint to the query that requires a particular key's value to
    * not be contained in the provided list of values.
-   * @method notContainedIn
    * @param {String} key The key to check.
    * @param {Array} values The values that will not match.
    * @return {Parse.Query} Returns the query, so you can chain this call.
@@ -748,7 +738,6 @@ export default class ParseQuery {
   /**
    * Adds a constraint to the query that requires a particular key's value to
    * contain each one of the provided list of values.
-   * @method containsAll
    * @param {String} key The key to check.  This key's value must be an array.
    * @param {Array} values The values that will match.
    * @return {Parse.Query} Returns the query, so you can chain this call.
@@ -759,7 +748,6 @@ export default class ParseQuery {
 
   /**
    * Adds a constraint for finding objects that contain the given key.
-   * @method exists
    * @param {String} key The key that should exist.
    * @return {Parse.Query} Returns the query, so you can chain this call.
    */
@@ -769,7 +757,6 @@ export default class ParseQuery {
 
   /**
    * Adds a constraint for finding objects that do not contain a given key.
-   * @method doesNotExist
    * @param {String} key The key that should not exist
    * @return {Parse.Query} Returns the query, so you can chain this call.
    */
@@ -781,7 +768,6 @@ export default class ParseQuery {
    * Adds a regular expression constraint for finding string values that match
    * the provided regular expression.
    * This may be slow for large datasets.
-   * @method matches
    * @param {String} key The key that the string to match is stored in.
    * @param {RegExp} regex The regular expression pattern to match.
    * @return {Parse.Query} Returns the query, so you can chain this call.
@@ -806,7 +792,6 @@ export default class ParseQuery {
   /**
    * Adds a constraint that requires that a key's value matches a Parse.Query
    * constraint.
-   * @method matchesQuery
    * @param {String} key The key that the contains the object to match the
    *                     query.
    * @param {Parse.Query} query The query that should match.
@@ -821,7 +806,6 @@ export default class ParseQuery {
   /**
    * Adds a constraint that requires that a key's value not matches a
    * Parse.Query constraint.
-   * @method doesNotMatchQuery
    * @param {String} key The key that the contains the object to match the
    *                     query.
    * @param {Parse.Query} query The query that should not match.
@@ -836,7 +820,6 @@ export default class ParseQuery {
   /**
    * Adds a constraint that requires that a key's value matches a value in
    * an object returned by a different Parse.Query.
-   * @method matchesKeyInQuery
    * @param {String} key The key that contains the value that is being
    *                     matched.
    * @param {String} queryKey The key in the objects returned by the query to
@@ -856,7 +839,6 @@ export default class ParseQuery {
   /**
    * Adds a constraint that requires that a key's value not match a value in
    * an object returned by a different Parse.Query.
-   * @method doesNotMatchKeyInQuery
    * @param {String} key The key that contains the value that is being
    *                     excluded.
    * @param {String} queryKey The key in the objects returned by the query to
@@ -876,7 +858,6 @@ export default class ParseQuery {
   /**
    * Adds a constraint for finding string values that contain a provided
    * string.  This may be slow for large datasets.
-   * @method contains
    * @param {String} key The key that the string to match is stored in.
    * @param {String} substring The substring that the value must contain.
    * @return {Parse.Query} Returns the query, so you can chain this call.
@@ -892,7 +873,6 @@ export default class ParseQuery {
    * Adds a constraint for finding string values that start with a provided
    * string.  This query will use the backend index, so it will be fast even
    * for large datasets.
-   * @method startsWith
    * @param {String} key The key that the string to match is stored in.
    * @param {String} prefix The substring that the value must start with.
    * @return {Parse.Query} Returns the query, so you can chain this call.
@@ -907,7 +887,6 @@ export default class ParseQuery {
   /**
    * Adds a constraint for finding string values that end with a provided
    * string.  This will be slow for large datasets.
-   * @method endsWith
    * @param {String} key The key that the string to match is stored in.
    * @param {String} suffix The substring that the value must end with.
    * @return {Parse.Query} Returns the query, so you can chain this call.
@@ -922,7 +901,6 @@ export default class ParseQuery {
   /**
    * Adds a proximity based constraint for finding objects with key point
    * values near the point given.
-   * @method near
    * @param {String} key The key that the Parse.GeoPoint is stored in.
    * @param {Parse.GeoPoint} point The reference Parse.GeoPoint that is used.
    * @return {Parse.Query} Returns the query, so you can chain this call.
@@ -938,7 +916,6 @@ export default class ParseQuery {
   /**
    * Adds a proximity based constraint for finding objects with key point
    * values near the point given and within the maximum distance given.
-   * @method withinRadians
    * @param {String} key The key that the Parse.GeoPoint is stored in.
    * @param {Parse.GeoPoint} point The reference Parse.GeoPoint that is used.
    * @param {Number} maxDistance Maximum distance (in radians) of results to
@@ -954,7 +931,6 @@ export default class ParseQuery {
    * Adds a proximity based constraint for finding objects with key point
    * values near the point given and within the maximum distance given.
    * Radius of earth used is 3958.8 miles.
-   * @method withinMiles
    * @param {String} key The key that the Parse.GeoPoint is stored in.
    * @param {Parse.GeoPoint} point The reference Parse.GeoPoint that is used.
    * @param {Number} maxDistance Maximum distance (in miles) of results to
@@ -969,7 +945,6 @@ export default class ParseQuery {
    * Adds a proximity based constraint for finding objects with key point
    * values near the point given and within the maximum distance given.
    * Radius of earth used is 6371.0 kilometers.
-   * @method withinKilometers
    * @param {String} key The key that the Parse.GeoPoint is stored in.
    * @param {Parse.GeoPoint} point The reference Parse.GeoPoint that is used.
    * @param {Number} maxDistance Maximum distance (in kilometers) of results
@@ -984,7 +959,6 @@ export default class ParseQuery {
    * Adds a constraint to the query that requires a particular key's
    * coordinates be contained within a given rectangular geographic bounding
    * box.
-   * @method withinGeoBox
    * @param {String} key The key to be constrained.
    * @param {Parse.GeoPoint} southwest
    *     The lower-left inclusive corner of the box.
@@ -1010,7 +984,6 @@ export default class ParseQuery {
    *
    * Polygon must have at least 3 points
    *
-   * @method withinPolygon
    * @param {String} key The key to be constrained.
    * @param {Array} array of geopoints
    * @return {Parse.Query} Returns the query, so you can chain this call.
@@ -1023,7 +996,6 @@ export default class ParseQuery {
    * Add a constraint to the query that requires a particular key's
    * coordinates that contains a ParseGeoPoint
    *
-   * @method polygonContains
    * @param {String} key The key to be constrained.
    * @param {Parse.GeoPoint} GeoPoint
    * @return {Parse.Query} Returns the query, so you can chain this call.
@@ -1037,8 +1009,7 @@ export default class ParseQuery {
   /**
    * Sorts the results in ascending order by the given key.
    *
-   * @method ascending
-   * @param {(String|String[]|...String} key The key to order by, which is a
+   * @param {(String|String[]|...String)} key The key to order by, which is a
    * string of comma separated values, or an Array of keys, or multiple keys.
    * @return {Parse.Query} Returns the query, so you can chain this call.
    */
@@ -1051,8 +1022,7 @@ export default class ParseQuery {
    * Sorts the results in ascending order by the given key,
    * but can also add secondary sort descriptors without overwriting _order.
    *
-   * @method addAscending
-   * @param {(String|String[]|...String} key The key to order by, which is a
+   * @param {(String|String[]|...String)} key The key to order by, which is a
    * string of comma separated values, or an Array of keys, or multiple keys.
    * @return {Parse.Query} Returns the query, so you can chain this call.
    */
@@ -1073,8 +1043,7 @@ export default class ParseQuery {
   /**
    * Sorts the results in descending order by the given key.
    *
-   * @method descending
-   * @param {(String|String[]|...String} key The key to order by, which is a
+   * @param {(String|String[]|...String)} key The key to order by, which is a
    * string of comma separated values, or an Array of keys, or multiple keys.
    * @return {Parse.Query} Returns the query, so you can chain this call.
    */
@@ -1087,8 +1056,7 @@ export default class ParseQuery {
    * Sorts the results in descending order by the given key,
    * but can also add secondary sort descriptors without overwriting _order.
    *
-   * @method addDescending
-   * @param {(String|String[]|...String} key The key to order by, which is a
+   * @param {(String|String[]|...String)} key The key to order by, which is a
    * string of comma separated values, or an Array of keys, or multiple keys.
    * @return {Parse.Query} Returns the query, so you can chain this call.
    */
@@ -1116,7 +1084,6 @@ export default class ParseQuery {
    * Sets the number of results to skip before returning any results.
    * This is useful for pagination.
    * Default is to skip zero results.
-   * @method skip
    * @param {Number} n the number of results to skip.
    * @return {Parse.Query} Returns the query, so you can chain this call.
    */
@@ -1131,7 +1098,6 @@ export default class ParseQuery {
   /**
    * Sets the limit of the number of results to return. The default limit is
    * 100, with a maximum of 1000 results being returned at a time.
-   * @method limit
    * @param {Number} n the number of results to limit to.
    * @return {Parse.Query} Returns the query, so you can chain this call.
    */
@@ -1146,7 +1112,6 @@ export default class ParseQuery {
   /**
    * Includes nested Parse.Objects for the provided key.  You can use dot
    * notation to specify which fields in the included object are also fetched.
-   * @method include
    * @param {String} key The name of the key to include.
    * @return {Parse.Query} Returns the query, so you can chain this call.
    */
@@ -1165,7 +1130,6 @@ export default class ParseQuery {
    * Restricts the fields of the returned Parse.Objects to include only the
    * provided keys.  If this is called multiple times, then all of the keys
    * specified in each of the calls will be included.
-   * @method select
    * @param {Array} keys The names of the keys to include.
    * @return {Parse.Query} Returns the query, so you can chain this call.
    */
@@ -1185,7 +1149,6 @@ export default class ParseQuery {
 
   /**
    * Subscribe this query to get liveQuery updates
-   * @method subscribe
    * @return {LiveQuerySubscription} Returns the liveQuerySubscription, it's an event emitter
    * which can be used to get liveQuery updates.
    */
@@ -1201,7 +1164,6 @@ export default class ParseQuery {
    *
    * will create a compoundQuery that is an or of the query1, query2, and
    * query3.
-   * @method or
    * @param {...Parse.Query} var_args The list of queries to OR.
    * @static
    * @return {Parse.Query} The query that is the OR of the passed in queries.
@@ -1238,3 +1200,5 @@ var DefaultController = {
 };
 
 CoreManager.setQueryController(DefaultController);
+
+export default ParseQuery;

--- a/src/ParseRelation.js
+++ b/src/ParseRelation.js
@@ -17,29 +17,30 @@ import ParseQuery from './ParseQuery';
  * Creates a new Relation for the given parent object and key. This
  * constructor should rarely be used directly, but rather created by
  * Parse.Object.relation.
- * @class Parse.Relation
- * @constructor
- * @param {Parse.Object} parent The parent of this relation.
- * @param {String} key The key for this relation on the parent.
  *
  * <p>
  * A class that is used to access all of the children of a many-to-many
  * relationship.  Each instance of Parse.Relation is associated with a
  * particular parent object and key.
  * </p>
+ * @alias Parse.Relation
  */
-export default class ParseRelation {
+class ParseRelation {
   parent: ?ParseObject;
   key: ?string;
   targetClassName: ?string;
 
+  /**
+   * @param {Parse.Object} parent The parent of this relation.
+   * @param {String} key The key for this relation on the parent.
+   */
   constructor(parent: ?ParseObject, key: ?string) {
     this.parent = parent;
     this.key = key;
     this.targetClassName = null;
   }
 
-  /**
+  /*
    * Makes sure that this relation has the right parent and key.
    */
   _ensureParentAndKey(parent: ParseObject, key: string) {
@@ -71,7 +72,7 @@ export default class ParseRelation {
 
   /**
    * Adds a Parse.Object or an array of Parse.Objects to the relation.
-   * @method add
+
    * @param {} objects The item or items to add.
    */
   add(objects: ParseObject | Array<ParseObject | string>): ParseObject {
@@ -91,7 +92,7 @@ export default class ParseRelation {
 
   /**
    * Removes a Parse.Object or an array of Parse.Objects from this relation.
-   * @method remove
+
    * @param {} objects The item or items to remove.
    */
   remove(objects: ParseObject | Array<ParseObject | string>) {
@@ -109,7 +110,7 @@ export default class ParseRelation {
 
   /**
    * Returns a JSON version of the object suitable for saving to disk.
-   * @method toJSON
+
    * @return {Object}
    */
   toJSON(): { __type: 'Relation', className: ?string } {
@@ -122,7 +123,7 @@ export default class ParseRelation {
   /**
    * Returns a Parse.Query that is limited to objects in this
    * relation.
-   * @method query
+
    * @return {Parse.Query}
    */
   query(): ParseQuery {
@@ -147,3 +148,5 @@ export default class ParseRelation {
     return query;
   }
 }
+
+export default ParseRelation;

--- a/src/ParseRole.js
+++ b/src/ParseRole.js
@@ -25,14 +25,16 @@ import type ParseRelation from './ParseRelation';
  *
  * <p>Roles must have a name (which cannot be changed after creation of the
  * role), and must specify an ACL.</p>
- * @class Parse.Role
- * @constructor
- * @param {String} name The name of the Role to create.
- * @param {Parse.ACL} acl The ACL for this role. Roles must have an ACL.
- * A Parse.Role is a local representation of a role persisted to the Parse
- * cloud.
+ * @alias Parse.Role
+ * @extends Parse.Object
  */
-export default class ParseRole extends ParseObject {
+class ParseRole extends ParseObject {
+  /**
+   * @param {String} name The name of the Role to create.
+   * @param {Parse.ACL} acl The ACL for this role. Roles must have an ACL.
+   * A Parse.Role is a local representation of a role persisted to the Parse
+   * cloud.
+   */
   constructor(name: string, acl: ParseACL) {
     super('_Role');
     if (typeof name === 'string' && (acl instanceof ParseACL)) {
@@ -44,7 +46,7 @@ export default class ParseRole extends ParseObject {
   /**
    * Gets the name of the role.  You can alternatively call role.get("name")
    *
-   * @method getName
+
    * @return {String} the name of the role.
    */
   getName(): ?string {
@@ -67,7 +69,7 @@ export default class ParseRole extends ParseObject {
    *
    * <p>This is equivalent to calling role.set("name", name)</p>
    *
-   * @method setName
+
    * @param {String} name The name of the role.
    * @param {Object} options Standard options object with success and error
    *     callbacks.
@@ -84,7 +86,7 @@ export default class ParseRole extends ParseObject {
    *
    * <p>This is equivalent to calling role.relation("users")</p>
    *
-   * @method getUsers
+
    * @return {Parse.Relation} the relation for the users belonging to this
    *     role.
    */
@@ -100,7 +102,7 @@ export default class ParseRole extends ParseObject {
    *
    * <p>This is equivalent to calling role.relation("roles")</p>
    *
-   * @method getRoles
+
    * @return {Parse.Relation} the relation for the roles belonging to this
    *     role.
    */
@@ -144,3 +146,5 @@ export default class ParseRole extends ParseObject {
 }
 
 ParseObject.registerSubclass('_Role', ParseRole);
+
+export default ParseRole;

--- a/src/ParseSession.js
+++ b/src/ParseSession.js
@@ -19,14 +19,17 @@ import type { AttributeMap } from './ObjectStateMutations';
 import type { RequestOptions, FullOptions } from './RESTController';
 
 /**
- * @class Parse.Session
- * @constructor
- *
  * <p>A Parse.Session object is a local representation of a revocable session.
  * This class is a subclass of a Parse.Object, and retains the same
  * functionality of a Parse.Object.</p>
+ * @alias Parse.Session
+ * @extends Parse.Object
  */
-export default class ParseSession extends ParseObject {
+class ParseSession extends ParseObject {
+  /**
+   * 
+   * @param {Object} attributes The initial set of data to store in the user.
+   */
   constructor(attributes: ?AttributeMap) {
     super('_Session');
     if (attributes && typeof attributes === 'object'){
@@ -38,7 +41,7 @@ export default class ParseSession extends ParseObject {
 
   /**
    * Returns the session token string.
-   * @method getSessionToken
+
    * @return {String}
    */
   getSessionToken(): string {
@@ -62,7 +65,7 @@ export default class ParseSession extends ParseObject {
 
   /**
    * Retrieves the Session object for the currently logged in session.
-   * @method current
+
    * @static
    * @return {Parse.Promise} A promise that is resolved with the Parse.Session
    *   object after it has been fetched. If there is no current user, the
@@ -92,7 +95,7 @@ export default class ParseSession extends ParseObject {
    * use revocable sessions. If you are migrating an app that uses the Parse
    * SDK in the browser only, please use Parse.User.enableRevocableSession()
    * instead, so that sessions can be automatically upgraded.
-   * @method isCurrentSessionRevocable
+
    * @static
    * @return {Boolean}
    */
@@ -123,3 +126,5 @@ var DefaultController = {
 };
 
 CoreManager.setSessionController(DefaultController);
+
+export default ParseSession;

--- a/src/ParseUser.js
+++ b/src/ParseUser.js
@@ -76,7 +76,6 @@ class ParseUser extends ParseObject {
   /**
    * Unlike in the Android/iOS SDKs, logInWith is unnecessary, since you can
    * call linkWith on the user (even if it doesn't exist yet on the server).
-
    */
   _linkWith(provider: any, options: { authData?: AuthData }): ParsePromise {
     var authType;
@@ -677,6 +676,7 @@ class ParseUser extends ParseObject {
    *     forgot their password.
    * @param {Object} options A Backbone-style options object.
    * @static
+   * @returns {Parse.Promise}
    */
   static requestPasswordReset(email, options) {
     options = options || {};

--- a/src/ParseUser.js
+++ b/src/ParseUser.js
@@ -30,16 +30,18 @@ var currentUserCache = null;
 var authProviders = {};
 
 /**
- * @class Parse.User
- * @constructor
- *
  * <p>A Parse.User object is a local representation of a user persisted to the
  * Parse cloud. This class is a subclass of a Parse.Object, and retains the
  * same functionality of a Parse.Object, but also extends it with various
  * user specific methods, like authentication, signing up, and validation of
  * uniqueness.</p>
+ * @alias Parse.User
+ * @extends Parse.Object
  */
-export default class ParseUser extends ParseObject {
+class ParseUser extends ParseObject {
+  /**
+   * @param {Object} attributes The initial set of data to store in the user.
+   */
   constructor(attributes: ?AttributeMap) {
     super('_User');
     if (attributes && typeof attributes === 'object'){
@@ -51,7 +53,7 @@ export default class ParseUser extends ParseObject {
 
   /**
    * Request a revocable session token to replace the older style of token.
-   * @method _upgradeToRevocableSession
+
    * @param {Object} options A Backbone-style options object.
    * @return {Parse.Promise} A promise that is resolved when the replacement
    *   token has been fetched.
@@ -74,7 +76,7 @@ export default class ParseUser extends ParseObject {
   /**
    * Unlike in the Android/iOS SDKs, logInWith is unnecessary, since you can
    * call linkWith on the user (even if it doesn't exist yet on the server).
-   * @method _linkWith
+
    */
   _linkWith(provider: any, options: { authData?: AuthData }): ParsePromise {
     var authType;
@@ -128,7 +130,7 @@ export default class ParseUser extends ParseObject {
   /**
    * Synchronizes auth data for a provider (e.g. puts the access token in the
    * right place to be used by the Facebook SDK).
-   * @method _synchronizeAuthData
+
    */
   _synchronizeAuthData(provider: string) {
     if (!this.isCurrent() || !provider) {
@@ -153,7 +155,7 @@ export default class ParseUser extends ParseObject {
 
   /**
    * Synchronizes authData for all providers.
-   * @method _synchronizeAllAuthData
+
    */
   _synchronizeAllAuthData() {
     var authData = this.get('authData');
@@ -169,7 +171,7 @@ export default class ParseUser extends ParseObject {
   /**
    * Removes null values from authData (which exist temporarily for
    * unlinking)
-   * @method _cleanupAuthData
+
    */
   _cleanupAuthData() {
     if (!this.isCurrent()) {
@@ -189,7 +191,7 @@ export default class ParseUser extends ParseObject {
 
   /**
    * Unlinks a user from a service.
-   * @method _unlinkFrom
+
    */
   _unlinkFrom(provider: any, options?: FullOptions) {
     var authType;
@@ -207,7 +209,7 @@ export default class ParseUser extends ParseObject {
 
   /**
    * Checks whether a user is linked to a service.
-   * @method _isLinked
+
    */
   _isLinked(provider: any): boolean {
     var authType;
@@ -225,7 +227,7 @@ export default class ParseUser extends ParseObject {
 
   /**
    * Deauthenticates all providers.
-   * @method _logOutWithAll
+
    */
   _logOutWithAll() {
     var authData = this.get('authData');
@@ -241,7 +243,7 @@ export default class ParseUser extends ParseObject {
   /**
    * Deauthenticates a single provider (e.g. removing access tokens from the
    * Facebook SDK).
-   * @method _logOutWith
+
    */
   _logOutWith(provider: any) {
     if (!this.isCurrent()) {
@@ -267,7 +269,7 @@ export default class ParseUser extends ParseObject {
 
   /**
    * Returns true if <code>current</code> would return this user.
-   * @method isCurrent
+
    * @return {Boolean}
    */
   isCurrent(): boolean {
@@ -277,7 +279,7 @@ export default class ParseUser extends ParseObject {
 
   /**
    * Returns get("username").
-   * @method getUsername
+
    * @return {String}
    */
   getUsername(): ?string {
@@ -290,7 +292,7 @@ export default class ParseUser extends ParseObject {
 
   /**
    * Calls set("username", username, options) and returns the result.
-   * @method setUsername
+
    * @param {String} username
    * @param {Object} options A Backbone-style options object.
    * @return {Boolean}
@@ -308,7 +310,7 @@ export default class ParseUser extends ParseObject {
 
   /**
    * Calls set("password", password, options) and returns the result.
-   * @method setPassword
+
    * @param {String} password
    * @param {Object} options A Backbone-style options object.
    * @return {Boolean}
@@ -319,7 +321,7 @@ export default class ParseUser extends ParseObject {
 
   /**
    * Returns get("email").
-   * @method getEmail
+
    * @return {String}
    */
   getEmail(): ?string {
@@ -332,7 +334,7 @@ export default class ParseUser extends ParseObject {
 
   /**
    * Calls set("email", email, options) and returns the result.
-   * @method setEmail
+
    * @param {String} email
    * @param {Object} options A Backbone-style options object.
    * @return {Boolean}
@@ -345,7 +347,7 @@ export default class ParseUser extends ParseObject {
    * Returns the session token for this user, if the user has been logged in,
    * or if it is the result of a query with the master key. Otherwise, returns
    * undefined.
-   * @method getSessionToken
+
    * @return {String} the session token, or undefined
    */
   getSessionToken(): ?string {
@@ -358,7 +360,7 @@ export default class ParseUser extends ParseObject {
 
   /**
    * Checks whether this user is the current user and has been authenticated.
-   * @method authenticated
+
    * @return (Boolean) whether this user is the current user and is logged in.
    */
   authenticated(): boolean {
@@ -380,7 +382,7 @@ export default class ParseUser extends ParseObject {
    *
    * <p>Calls options.success or options.error on completion.</p>
    *
-   * @method signUp
+
    * @param {Object} attrs Extra fields to set on the new user, or null.
    * @param {Object} options A Backbone-style options object.
    * @return {Parse.Promise} A promise that is fulfilled when the signup
@@ -414,7 +416,7 @@ export default class ParseUser extends ParseObject {
    *
    * <p>Calls options.success or options.error on completion.</p>
    *
-   * @method logIn
+
    * @param {Object} options A Backbone-style options object.
    * @return {Parse.Promise} A promise that is fulfilled with the user when
    *     the login is complete.
@@ -479,7 +481,7 @@ export default class ParseUser extends ParseObject {
 
   /**
    * Adds functionality to the existing Parse.User class
-   * @method extend
+
    * @param {Object} protoProps A set of properties to add to the prototype
    * @param {Object} classProps A set of static properties to add to the class
    * @static
@@ -518,7 +520,7 @@ export default class ParseUser extends ParseObject {
   /**
    * Retrieves the currently logged in ParseUser with a valid session,
    * either from memory or localStorage, if necessary.
-   * @method current
+
    * @static
    * @return {Parse.Object} The currently logged in Parse.User.
    */
@@ -532,7 +534,7 @@ export default class ParseUser extends ParseObject {
 
   /**
    * Retrieves the currently logged in ParseUser from asynchronous Storage.
-   * @method currentAsync
+
    * @static
    * @return {Parse.Promise} A Promise that is resolved with the currently
    *   logged in Parse User
@@ -553,7 +555,7 @@ export default class ParseUser extends ParseObject {
    *
    * <p>Calls options.success or options.error on completion.</p>
    *
-   * @method signUp
+
    * @param {String} username The username (or email) to sign up with.
    * @param {String} password The password to sign up with.
    * @param {Object} attrs Extra fields to set on the new user.
@@ -577,7 +579,7 @@ export default class ParseUser extends ParseObject {
    *
    * <p>Calls options.success or options.error on completion.</p>
    *
-   * @method logIn
+
    * @param {String} username The username (or email) to log in with.
    * @param {String} password The password to log in with.
    * @param {Object} options A Backbone-style options object.
@@ -613,7 +615,7 @@ export default class ParseUser extends ParseObject {
    *
    * <p>Calls options.success or options.error on completion.</p>
    *
-   * @method become
+
    * @param {String} sessionToken The sessionToken to log in with.
    * @param {Object} options A Backbone-style options object.
    * @static
@@ -647,7 +649,7 @@ export default class ParseUser extends ParseObject {
    * Logs out the currently logged in user session. This will remove the
    * session from disk, log out of linked services, and future calls to
    * <code>current</code> will return <code>null</code>.
-   * @method logOut
+
    * @static
    * @return {Parse.Promise} A promise that is resolved when the session is
    *   destroyed on the server.
@@ -670,7 +672,7 @@ export default class ParseUser extends ParseObject {
    *
    * <p>Calls options.success or options.error on completion.</p>
    *
-   * @method requestPasswordReset
+
    * @param {String} email The email address associated with the user that
    *     forgot their password.
    * @param {Object} options A Backbone-style options object.
@@ -696,7 +698,7 @@ export default class ParseUser extends ParseObject {
    * User to _User for legacy reasons. This allows developers to
    * override that behavior.
    *
-   * @method allowCustomUserClass
+
    * @param {Boolean} isAllowed Whether or not to allow custom User class
    * @static
    */
@@ -711,7 +713,7 @@ export default class ParseUser extends ParseObject {
    * It is not necessary to call this method from cloud code unless you are
    * handling user signup or login from the server side. In a cloud code call,
    * this function will not attempt to upgrade the current token.
-   * @method enableRevocableSession
+
    * @param {Object} options A Backbone-style options object.
    * @static
    * @return {Parse.Promise} A promise that is resolved when the process has
@@ -734,7 +736,7 @@ export default class ParseUser extends ParseObject {
    * Enables the use of become or the current user in a server
    * environment. These features are disabled by default, since they depend on
    * global objects that are not memory-safe for most servers.
-   * @method enableUnsafeCurrentUser
+
    * @static
    */
   static enableUnsafeCurrentUser() {
@@ -745,7 +747,7 @@ export default class ParseUser extends ParseObject {
    * Disables the use of become or the current user in any environment.
    * These features are disabled on servers by default, since they depend on
    * global objects that are not memory-safe for most servers.
-   * @method disableUnsafeCurrentUser
+
    * @static
    */
   static disableUnsafeCurrentUser() {
@@ -1029,3 +1031,5 @@ var DefaultController = {
 };
 
 CoreManager.setUserController(DefaultController);
+
+export default ParseUser;

--- a/src/Push.js
+++ b/src/Push.js
@@ -27,11 +27,13 @@ export type PushData = {
  * Contains functions to deal with Push in Parse.
  * @class Parse.Push
  * @static
+ * @hideconstructor
  */
 
  /**
   * Sends a push notification.
   * @method send
+  * @name Parse.Push.send
   * @param {Object} data -  The data of the push notification.  Valid fields
   * are:
   *   <ol>

--- a/src/escape.js
+++ b/src/escape.js
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2015-present, Parse, LLC.
  * All rights reserved.
  *


### PR DESCRIPTION
This PR fixes a few issues when generating docs with JS docs, See the generated docs here:

https://flovilmart.github.io/parse-js-docs-demo/index.html

If we're all ok with it, I'll push to the gh-pages branch and automate the release on tags.