### PR TITLE
Adds Purge & Polygon to Parse.Schema

### DIFF
--- a/integration/test/ParseSchemaTest.js
+++ b/integration/test/ParseSchemaTest.js
@@ -47,6 +47,7 @@ describe('Schema', () => {
       .addDate('dateField')
       .addFile('fileField')
       .addGeoPoint('geoPointField')
+      .addPolygon('polygonField')
       .addArray('arrayField')
       .addObject('objectField')
       .addPointer('pointerField', '_User')
@@ -62,6 +63,7 @@ describe('Schema', () => {
       assert.equal(result.fields.dateField.type, 'Date');
       assert.equal(result.fields.fileField.type, 'File');
       assert.equal(result.fields.geoPointField.type, 'GeoPoint');
+      assert.equal(result.fields.polygonField.type, 'Polygon');
       assert.equal(result.fields.arrayField.type, 'Array');
       assert.equal(result.fields.objectField.type, 'Object');
       assert.equal(result.fields.pointerField.type, 'Pointer');
@@ -128,6 +130,32 @@ describe('Schema', () => {
     }).then((results) => {
       assert.equal(results.length, 1);
       assert.equal(results[0].className, 'SchemaTest2');
+      done();
+    });
+  });
+
+  it('purge', (done) => {
+    const testSchema = new Parse.Schema('SchemaTest');
+    const obj = new Parse.Object('SchemaTest');
+    obj.save().then(() => {
+        return testSchema.delete().then(() => {
+          // Should never reach here
+          assert.equal(true, false);
+        }).catch((error) => {
+          assert.equal(error.code, Parse.Error.INVALID_SCHEMA_OPERATION);
+          assert.equal(error.message, 'Class SchemaTest is not empty, contains 1 objects, cannot drop schema.');
+          return Parse.Promise.as();
+        });
+    }).then(() => {
+      return testSchema.purge();
+    }).then(() => {
+      const query = new Parse.Query('SchemaTest');
+      return query.count();
+    }).then((count) => {
+      assert.equal(count, 0);
+      // Delete only works on empty schema, extra check
+      return testSchema.delete();
+    }).then(() => {
       done();
     });
   });

--- a/integration/test/ParseSchemaTest.js
+++ b/integration/test/ParseSchemaTest.js
@@ -47,7 +47,6 @@ describe('Schema', () => {
       .addDate('dateField')
       .addFile('fileField')
       .addGeoPoint('geoPointField')
-      .addPolygon('polygonField')
       .addArray('arrayField')
       .addObject('objectField')
       .addPointer('pointerField', '_User')
@@ -63,7 +62,6 @@ describe('Schema', () => {
       assert.equal(result.fields.dateField.type, 'Date');
       assert.equal(result.fields.fileField.type, 'File');
       assert.equal(result.fields.geoPointField.type, 'GeoPoint');
-      assert.equal(result.fields.polygonField.type, 'Polygon');
       assert.equal(result.fields.arrayField.type, 'Array');
       assert.equal(result.fields.objectField.type, 'Object');
       assert.equal(result.fields.pointerField.type, 'Pointer');
@@ -130,32 +128,6 @@ describe('Schema', () => {
     }).then((results) => {
       assert.equal(results.length, 1);
       assert.equal(results[0].className, 'SchemaTest2');
-      done();
-    });
-  });
-
-  it('purge', (done) => {
-    const testSchema = new Parse.Schema('SchemaTest');
-    const obj = new Parse.Object('SchemaTest');
-    obj.save().then(() => {
-        return testSchema.delete().then(() => {
-          // Should never reach here
-          assert.equal(true, false);
-        }).catch((error) => {
-          assert.equal(error.code, Parse.Error.INVALID_SCHEMA_OPERATION);
-          assert.equal(error.message, 'Class SchemaTest is not empty, contains 1 objects, cannot drop schema.');
-          return Parse.Promise.as();
-        });
-    }).then(() => {
-      return testSchema.purge();
-    }).then(() => {
-      const query = new Parse.Query('SchemaTest');
-      return query.count();
-    }).then((count) => {
-      assert.equal(count, 0);
-      // Delete only works on empty schema, extra check
-      return testSchema.delete();
-    }).then(() => {
       done();
     });
   });

--- a/src/CoreManager.js
+++ b/src/CoreManager.js
@@ -78,6 +78,7 @@ type RESTController = {
   ajax: (method: string, url: string, data: any, headers?: any) => ParsePromise;
 };
 type SchemaController = {
+  purge: (className: string) => ParsePromise;
   get: (className: string, options: RequestOptions) => ParsePromise;
   delete: (className: string, options: RequestOptions) => ParsePromise;
   create: (className: string, params: any, options: RequestOptions) => ParsePromise;
@@ -295,7 +296,7 @@ module.exports = {
   },
 
   setSchemaController(controller: SchemaController) {
-    requireMethods('SchemaController', ['get', 'create', 'update', 'delete', 'send'], controller);
+    requireMethods('SchemaController', ['get', 'create', 'update', 'delete', 'send', 'purge'], controller);
     config['SchemaController'] = controller;
   },
 

--- a/src/CoreManager.js
+++ b/src/CoreManager.js
@@ -78,7 +78,6 @@ type RESTController = {
   ajax: (method: string, url: string, data: any, headers?: any) => ParsePromise;
 };
 type SchemaController = {
-  purge: (className: string) => ParsePromise;
   get: (className: string, options: RequestOptions) => ParsePromise;
   delete: (className: string, options: RequestOptions) => ParsePromise;
   create: (className: string, params: any, options: RequestOptions) => ParsePromise;
@@ -296,7 +295,7 @@ module.exports = {
   },
 
   setSchemaController(controller: SchemaController) {
-    requireMethods('SchemaController', ['get', 'create', 'update', 'delete', 'send', 'purge'], controller);
+    requireMethods('SchemaController', ['get', 'create', 'update', 'delete', 'send'], controller);
     config['SchemaController'] = controller;
   },
 

--- a/src/ParseError.js
+++ b/src/ParseError.js
@@ -20,7 +20,7 @@ class ParseError {
     this.code = code;
     this.message = message;
   }
-
+  
   toString() {
     return 'ParseError: ' + this.code + ' ' + this.message;
   }
@@ -465,14 +465,6 @@ ParseError.INVALID_LINKED_SESSION = 251;
  * @final
  */
 ParseError.UNSUPPORTED_SERVICE = 252;
-
-/**
- * Error code indicating an invalid operation occured on schema
- * @property SCHEMA_ERROR
- * @static
- * @final
- */
-ParseError.INVALID_SCHEMA_OPERATION = 255;
 
 /**
  * Error code indicating that there were multiple errors. Aggregate errors

--- a/src/ParseError.js
+++ b/src/ParseError.js
@@ -468,7 +468,7 @@ ParseError.UNSUPPORTED_SERVICE = 252;
 
 /**
  * Error code indicating an invalid operation occured on schema
- * @property SCHEMA_ERROR
+ * @property INVALID_SCHEMA_OPERATION
  * @static
  * @final
  */

--- a/src/ParseError.js
+++ b/src/ParseError.js
@@ -20,7 +20,7 @@ class ParseError {
     this.code = code;
     this.message = message;
   }
-  
+
   toString() {
     return 'ParseError: ' + this.code + ' ' + this.message;
   }
@@ -465,6 +465,14 @@ ParseError.INVALID_LINKED_SESSION = 251;
  * @final
  */
 ParseError.UNSUPPORTED_SERVICE = 252;
+
+/**
+ * Error code indicating an invalid operation occured on schema
+ * @property SCHEMA_ERROR
+ * @static
+ * @final
+ */
+ParseError.INVALID_SCHEMA_OPERATION = 255;
 
 /**
  * Error code indicating that there were multiple errors. Aggregate errors

--- a/src/ParseSchema.js
+++ b/src/ParseSchema.js
@@ -14,7 +14,7 @@ import ParsePromise from './ParsePromise';
 
 import type { RequestOptions, FullOptions } from './RESTController';
 
-const FIELD_TYPES = ['String', 'Number', 'Boolean', 'Date', 'File', 'GeoPoint', 'Polygon', 'Array', 'Object', 'Pointer', 'Relation'];
+const FIELD_TYPES = ['String', 'Number', 'Boolean', 'Date', 'File', 'GeoPoint', 'Array', 'Object', 'Pointer', 'Relation'];
 
 /**
  * A Parse.Schema object is for handling schema data from Parse.
@@ -181,7 +181,6 @@ class ParseSchema {
 
   /**
    * Removing a Schema from Parse
-   * Can only be used on Schema without objects
    *
    * @param {Object} options A Backbone-style options object.
    * Valid options are:<ul>
@@ -203,34 +202,6 @@ class ParseSchema {
     const controller = CoreManager.getSchemaController();
 
     return controller.delete(this.className, options)
-      .then((response) => {
-        return response;
-      })._thenRunCallbacks(options);
-  }
-
-  /**
-   * Removes all objects from a Schema (class) in Parse.
-   * EXERCISE CAUTION, running this will delete all objects for this schema and cannot be reversed
-   *
-   * @param {Object} options A Backbone-style options object.
-   * Valid options are:<ul>
-   *   <li>success: A Backbone-style success callback
-   *   <li>error: An Backbone-style error callback.
-   *   <li>useMasterKey: In Cloud Code and Node only, causes the Master Key to
-   *     be used for this request.
-   *   <li>sessionToken: A valid session token, used for making a request on
-   *       behalf of a specific user.
-   * </ul>
-   *
-   * @return {Parse.Promise} A promise that is resolved with the result when
-   * the query completes.
-   */
-  purge(options: FullOptions) {
-    this.assertClassName();
-
-    const controller = CoreManager.getSchemaController();
-
-    return controller.purge(this.className)
       .then((response) => {
         return response;
       })._thenRunCallbacks(options);
@@ -346,16 +317,6 @@ class ParseSchema {
    */
   addGeoPoint(name: string) {
     return this.addField(name, 'GeoPoint');
-  }
-
-  /**
-   * Adding Polygon Field
-   *
-   * @param {String} name Name of the field that will be created on Parse
-   * @return {Parse.Schema} Returns the schema, so you can chain this call.
-   */
-  addPolygon(name: string) {
-    return this.addField(name, 'Polygon');
   }
 
   /**
@@ -476,16 +437,6 @@ const DefaultController = {
 
   delete(className: string, options: RequestOptions): ParsePromise {
     return this.send(className, 'DELETE', {}, options);
-  },
-
-  purge(className: string): ParsePromise {
-    const RESTController = CoreManager.getRESTController();
-    return RESTController.request(
-      'DELETE',
-      `purge/${className}`,
-      {},
-      { useMasterKey: true }
-    );
   }
 };
 

--- a/src/__tests__/CoreManager-test.js
+++ b/src/__tests__/CoreManager-test.js
@@ -328,8 +328,7 @@ describe('CoreManager', () => {
       get: function() {},
       create: function() {},
       update: function() {},
-      delete: function() {},
-      purge: function() {},
+      delete: function() {}
     })).not.toThrow();
   });
 
@@ -339,8 +338,7 @@ describe('CoreManager', () => {
       get: function() {},
       create: function() {},
       update: function() {},
-      delete: function() {},
-      purge: function() {},
+      delete: function() {}
     };
 
     CoreManager.setSchemaController(controller);

--- a/src/__tests__/CoreManager-test.js
+++ b/src/__tests__/CoreManager-test.js
@@ -328,7 +328,8 @@ describe('CoreManager', () => {
       get: function() {},
       create: function() {},
       update: function() {},
-      delete: function() {}
+      delete: function() {},
+      purge: function() {},
     })).not.toThrow();
   });
 
@@ -338,7 +339,8 @@ describe('CoreManager', () => {
       get: function() {},
       create: function() {},
       update: function() {},
-      delete: function() {}
+      delete: function() {},
+      purge: function() {},
     };
 
     CoreManager.setSchemaController(controller);

--- a/src/__tests__/ParseSchema-test.js
+++ b/src/__tests__/ParseSchema-test.js
@@ -47,6 +47,7 @@ describe('ParseSchema', () => {
       .addDate('dateField')
       .addFile('fileField')
       .addGeoPoint('geoPointField')
+      .addPolygon('polygonField')
       .addArray('arrayField')
       .addObject('objectField')
       .addPointer('pointerField', '_User')
@@ -59,6 +60,7 @@ describe('ParseSchema', () => {
     expect(schema._fields.dateField.type, 'Date');
     expect(schema._fields.fileField.type, 'File');
     expect(schema._fields.geoPointField.type, 'GeoPoint');
+    expect(schema._fields.polygonField.type, 'Polygon');
     expect(schema._fields.arrayField.type, 'Array');
     expect(schema._fields.objectField.type, 'Object');
     expect(schema._fields.pointerField.type, 'Pointer');
@@ -162,19 +164,13 @@ describe('ParseSchema', () => {
     done();
   });
 
-  // CoreManager.setSchemaController({
-  //   send() {},
-  //   get() {},
-  //   create() {},
-  //   update() {},
-  //   delete() {},
-  // });
   it('can save schema', (done) => {
     CoreManager.setSchemaController({
       send() {},
       get() {},
       update() {},
       delete() {},
+      purge() {},
       create(className, params, options) {
         expect(className).toBe('SchemaTest');
         expect(params).toEqual({
@@ -202,6 +198,7 @@ describe('ParseSchema', () => {
       get() {},
       create() {},
       delete() {},
+      purge() {},
       update(className, params, options) {
         expect(className).toBe('SchemaTest');
         expect(params).toEqual({
@@ -229,6 +226,7 @@ describe('ParseSchema', () => {
       create() {},
       update() {},
       get() {},
+      purge() {},
       delete(className, options) {
         expect(className).toBe('SchemaTest');
         expect(options).toEqual({});
@@ -243,12 +241,33 @@ describe('ParseSchema', () => {
     });
   });
 
+  it('can purge schema', (done) => {
+    CoreManager.setSchemaController({
+      send() {},
+      create() {},
+      update() {},
+      get() {},
+      delete() {},
+      purge(className) {
+        expect(className).toBe('SchemaTest');
+        return ParsePromise.as([]);
+      },
+    });
+
+    var schema = new ParseSchema('SchemaTest');
+    schema.purge().then((results) => {
+      expect(results).toEqual([]);
+      done();
+    });
+  });
+
   it('can get schema', (done) => {
     CoreManager.setSchemaController({
       send() {},
       create() {},
       update() {},
       delete() {},
+      purge() {},
       get(className, options) {
         expect(className).toBe('SchemaTest');
         expect(options).toEqual({});
@@ -269,6 +288,7 @@ describe('ParseSchema', () => {
       create() {},
       update() {},
       delete() {},
+      purge() {},
       get(className, options) {
         expect(className).toBe('SchemaTest');
         expect(options).toEqual({ sessionToken: 1234 });
@@ -289,6 +309,7 @@ describe('ParseSchema', () => {
       create() {},
       update() {},
       delete() {},
+      purge() {},
       get(className, options) {
         expect(className).toBe('SchemaTest');
         expect(options).toEqual({});
@@ -313,6 +334,7 @@ describe('ParseSchema', () => {
       create() {},
       update() {},
       delete() {},
+      purge() {},
       get(className, options) {
         expect(className).toBe('');
         expect(options).toEqual({});
@@ -334,6 +356,7 @@ describe('ParseSchema', () => {
       create() {},
       update() {},
       delete() {},
+      purge() {},
       get(className, options) {
         expect(className).toBe('');
         expect(options).toEqual({ sessionToken: 1234 });
@@ -355,6 +378,7 @@ describe('ParseSchema', () => {
       create() {},
       update() {},
       delete() {},
+      purge() {},
       get(className, options) {
         expect(className).toBe('');
         expect(options).toEqual({});
@@ -414,6 +438,14 @@ describe('SchemaController', () => {
   it('delete schema', (done) => {
     var schema = new ParseSchema('SchemaTest');
     schema.delete().then((results) => {
+      expect(results).toEqual([]);
+      done();
+    });
+  });
+
+  it('purge schema', (done) => {
+    var schema = new ParseSchema('SchemaTest');
+    schema.purge().then((results) => {
       expect(results).toEqual([]);
       done();
     });

--- a/src/__tests__/ParseSchema-test.js
+++ b/src/__tests__/ParseSchema-test.js
@@ -47,7 +47,6 @@ describe('ParseSchema', () => {
       .addDate('dateField')
       .addFile('fileField')
       .addGeoPoint('geoPointField')
-      .addPolygon('polygonField')
       .addArray('arrayField')
       .addObject('objectField')
       .addPointer('pointerField', '_User')
@@ -60,7 +59,6 @@ describe('ParseSchema', () => {
     expect(schema._fields.dateField.type, 'Date');
     expect(schema._fields.fileField.type, 'File');
     expect(schema._fields.geoPointField.type, 'GeoPoint');
-    expect(schema._fields.polygonField.type, 'Polygon');
     expect(schema._fields.arrayField.type, 'Array');
     expect(schema._fields.objectField.type, 'Object');
     expect(schema._fields.pointerField.type, 'Pointer');
@@ -164,13 +162,19 @@ describe('ParseSchema', () => {
     done();
   });
 
+  // CoreManager.setSchemaController({
+  //   send() {},
+  //   get() {},
+  //   create() {},
+  //   update() {},
+  //   delete() {},
+  // });
   it('can save schema', (done) => {
     CoreManager.setSchemaController({
       send() {},
       get() {},
       update() {},
       delete() {},
-      purge() {},
       create(className, params, options) {
         expect(className).toBe('SchemaTest');
         expect(params).toEqual({
@@ -198,7 +202,6 @@ describe('ParseSchema', () => {
       get() {},
       create() {},
       delete() {},
-      purge() {},
       update(className, params, options) {
         expect(className).toBe('SchemaTest');
         expect(params).toEqual({
@@ -226,7 +229,6 @@ describe('ParseSchema', () => {
       create() {},
       update() {},
       get() {},
-      purge() {},
       delete(className, options) {
         expect(className).toBe('SchemaTest');
         expect(options).toEqual({});
@@ -241,33 +243,12 @@ describe('ParseSchema', () => {
     });
   });
 
-  it('can purge schema', (done) => {
-    CoreManager.setSchemaController({
-      send() {},
-      create() {},
-      update() {},
-      get() {},
-      delete() {},
-      purge(className) {
-        expect(className).toBe('SchemaTest');
-        return ParsePromise.as([]);
-      },
-    });
-
-    var schema = new ParseSchema('SchemaTest');
-    schema.purge().then((results) => {
-      expect(results).toEqual([]);
-      done();
-    });
-  });
-
   it('can get schema', (done) => {
     CoreManager.setSchemaController({
       send() {},
       create() {},
       update() {},
       delete() {},
-      purge() {},
       get(className, options) {
         expect(className).toBe('SchemaTest');
         expect(options).toEqual({});
@@ -288,7 +269,6 @@ describe('ParseSchema', () => {
       create() {},
       update() {},
       delete() {},
-      purge() {},
       get(className, options) {
         expect(className).toBe('SchemaTest');
         expect(options).toEqual({ sessionToken: 1234 });
@@ -309,7 +289,6 @@ describe('ParseSchema', () => {
       create() {},
       update() {},
       delete() {},
-      purge() {},
       get(className, options) {
         expect(className).toBe('SchemaTest');
         expect(options).toEqual({});
@@ -334,7 +313,6 @@ describe('ParseSchema', () => {
       create() {},
       update() {},
       delete() {},
-      purge() {},
       get(className, options) {
         expect(className).toBe('');
         expect(options).toEqual({});
@@ -356,7 +334,6 @@ describe('ParseSchema', () => {
       create() {},
       update() {},
       delete() {},
-      purge() {},
       get(className, options) {
         expect(className).toBe('');
         expect(options).toEqual({ sessionToken: 1234 });
@@ -378,7 +355,6 @@ describe('ParseSchema', () => {
       create() {},
       update() {},
       delete() {},
-      purge() {},
       get(className, options) {
         expect(className).toBe('');
         expect(options).toEqual({});
@@ -438,14 +414,6 @@ describe('SchemaController', () => {
   it('delete schema', (done) => {
     var schema = new ParseSchema('SchemaTest');
     schema.delete().then((results) => {
-      expect(results).toEqual([]);
-      done();
-    });
-  });
-
-  it('purge schema', (done) => {
-    var schema = new ParseSchema('SchemaTest');
-    schema.purge().then((results) => {
       expect(results).toEqual([]);
       done();
     });


### PR DESCRIPTION
This adds the purge method to ParseSchema. This allows the deletion of all objects without having to run through and query all objects for removal. This was added to ParseSchema as the related delete method requires the class to be first empty of objects.

Polygon type support has also been added to ParseSchema, both via a supported method to add a polygon type field and as a recognized field when asserting types.