### PR TITLE
Throw an error if there are not `rejected` handlers

### DIFF
--- a/src/ParsePromise.js
+++ b/src/ParsePromise.js
@@ -75,6 +75,9 @@ class ParsePromise {
     }
     this._rejected = true;
     this._error = error;
+    if (this._rejectedCallbacks.length === 0) {
+        throw new Error(error);
+    }
     for (var i = 0; i < this._rejectedCallbacks.length; i++) {
       this._rejectedCallbacks[i](error);
     }


### PR DESCRIPTION
It is quite annoying trying to figure out what is the problem when you don't get any errors just because you don't properly define a `rejected` handler.

Using chained promises is also a problem because you have to define a catch for any `ParsePromise` returned.