### PR TITLE
Fix for the formatting of the ParseFile comment that has

### DIFF
--- a/src/ParseFile.js
+++ b/src/ParseFile.js
@@ -67,7 +67,8 @@ class ParseFile {
    *     2. an Object like { base64: "..." } with a base64-encoded String.
    *     3. a File object selected with a file upload control. (3) only works
    *        in Firefox 3.6+, Safari 6.0.2+, Chrome 7+, and IE 10+.
-   *        For example:<pre>
+   *        For example:
+   * <pre>
    * var fileUploadControl = $("#profilePhotoFileUpload")[0];
    * if (fileUploadControl.files.length > 0) {
    *   var file = fileUploadControl.files[0];


### PR DESCRIPTION
Currently, for me, the [ParseFile](http://parseplatform.org/Parse-SDK-JS/api/v1.11.1/Parse.File.html) Constructor API docs has a <pre> tag that is not rendering:
<img width="1120" alt="screen shot 2018-07-11 at 4 17 20 pm" src="https://user-images.githubusercontent.com/700572/42598190-6c067ed0-8529-11e8-85a5-a8f7936aa055.png">

this fix, while not ideal, is a good improvement.
<img width="987" alt="screen shot 2018-07-11 at 4 14 00 pm" src="https://user-images.githubusercontent.com/700572/42598116-3ccecb04-8529-11e8-8bd0-602ec85d9106.png">

I'm game to try someother approaches?