### PR TITLE
Fix Parse File upload problem via ajax

### DIFF
--- a/src/ParseFile.js
+++ b/src/ParseFile.js
@@ -254,7 +254,7 @@ var DefaultController = {
       url += '/';
     }
     url += 'files/' + name;
-    return CoreManager.getRESTController().ajax('POST', url, source.file, headers);
+    return CoreManager.getRESTController().ajax('POST', url, source.file, headers).then(res=>res.response)
   },
 
   saveBase64: function(name: string, source: FileSource, options?: { useMasterKey?: boolean, success?: any, error?: any }) {

--- a/src/__tests__/ParseFile-test.js
+++ b/src/__tests__/ParseFile-test.js
@@ -198,8 +198,10 @@ describe('FileController', () => {
     var ajax = function(method, path, data, headers) {
       var name = path.substr(path.indexOf('/') + 1);
       return Promise.resolve({
-        name: name,
-        url: 'https://files.parsetfss.com/a/' + name
+        response: {
+          name: name,
+          url: 'https://files.parsetfss.com/a/' + name
+        }
       });
     };
     CoreManager.setRESTController({ request: request, ajax: ajax });
@@ -211,6 +213,17 @@ describe('FileController', () => {
       expect(f).toBe(file);
       expect(f.name()).toBe('parse.txt');
       expect(f.url()).toBe('https://files.parsetfss.com/a/parse.txt');
+    });
+  });
+
+  it('saves files via ajax', () => {
+    var file = new ParseFile('parse.txt', [61, 170, 236, 120]);
+    file._source.format = 'file';
+
+    return file.save().then(function(f) {
+      expect(f).toBe(file);
+      expect(f.name()).toBe('/api.parse.com/1/files/parse.txt');
+      expect(f.url()).toBe('https://files.parsetfss.com/a//api.parse.com/1/files/parse.txt');
     });
   });
 });


### PR DESCRIPTION
Before this PR: 

```javascript
var parseFile = new Parse.File('filename', file);
parseFile.save().then((f)=>{
    console.log(f.toJSON())  // {__type: "File", name: undefined, url: undefined}
});
```

i think it is a bug and related this issue: #558 
RESTController.ajax method was return with ```response``` object, you can see that Implementation in [here](https://github.com/parse-community/Parse-SDK-JS/blob/master/src/RESTController.js#L55) and [here](https://github.com/parse-community/Parse-SDK-JS/blob/master/src/RESTController.js#L114)