### PR TITLE
RestController  - Use GET requests when possible

### DIFF
--- a/src/RESTController.js
+++ b/src/RESTController.js
@@ -186,7 +186,7 @@ const RESTController = {
       payload._method = method;
       method = 'POST';
     } else {
-      url += "?" + serialize(payload)
+      url += "?" + serialize(payload);
     }
 
     headers["X-Parse-Application-Id"] = CoreManager.get('APPLICATION_ID');
@@ -203,7 +203,7 @@ const RESTController = {
     }
     if (useMasterKey) {
       if (CoreManager.get('MASTER_KEY')) {
-        delete headers["X-Parse-REST-API-Key"]
+        delete headers["X-Parse-REST-API-Key"];
         headers["X-Parse-Master-Key"] = CoreManager.get('MASTER_KEY');
         } else {
         throw new Error('Cannot use the Master Key, it has not been provided.');
@@ -224,7 +224,7 @@ const RESTController = {
     }
 
     return installationIdPromise.then((iid) => {
-      headers["X-Parse-Installation-Id"] = iid
+      headers["X-Parse-Installation-Id"] = iid;
       var userController = CoreManager.getUserController();
       if (options && typeof options.sessionToken === 'string') {
         return Promise.resolve(options.sessionToken);
@@ -239,7 +239,7 @@ const RESTController = {
       return Promise.resolve(null);
     }).then((token) => {
       if (token) {
-        headers["X-Parse-Session-Token"] = token
+        headers["X-Parse-Session-Token"] = token;
       }
 
       var payloadString = JSON.stringify(payload);


### PR DESCRIPTION
**Note: I'll be happy to edit the tests impacted if it's considered for merging**

This PR intends to use GET requests whenever possible instead of forcing POST requests.

While this probably makes very little difference for server-to-server requests, using GET requests allows for browser-caching and "CDN caching" when used in a web browser.
Right now, parse-server sends back ETag for POST requests, which is of no use for the web browser. Putting the API behind a service like Cloudfront isn't useful if all the requests made are POST requests, as they cannot be cached.

Incidentally, this makes Parse JS use its own REST API as per its specifications with regards to using the HTTP Headers (https://docs.parseplatform.org/rest/guide/)

We might want to actually properly map all the other HTTP methods properly as well. (DELETE, PUT)