### PR TITLE
Add a warning in 2.0.0.md about Promise.finally

### DIFF
--- a/2.0.0.md
+++ b/2.0.0.md
@@ -91,3 +91,15 @@ Promise.all([promise1, promise2, promise3])
 
 });
 ```
+
+:warning: Whereas `Parse.Promise.always`, `Promise.finally` callback don't receive any arguments, and don't resolve with a new argument to pass to the next promise in chain.
+
+```js
+// before
+Parse.Promise.as(1).always((val) => val + 1).then((result) => console.log(result))
+// will print 2
+
+// after
+Promise.resolve(1).finally(() => 2).then((result) => console.log(result))
+// will print 1
+```


### PR DESCRIPTION
Whereas `Parse.Promise.always`, `Promise.finally` callback don't receive any arguments, and don't resolve with a new argument to pass to the next promise in chain.