### PR TITLE
Allow aggregate stages with same name

### DIFF
--- a/integration/test/ParseQueryAggregateTest.js
+++ b/integration/test/ParseQueryAggregateTest.js
@@ -86,13 +86,12 @@ describe('Parse Aggregate Query', () => {
       },
     }, {
       match: { 'tempPointer.value': 2 },
-    }
-  ];
+    }];
     await Parse.Object.saveAll([pointer1, pointer2, pointer3, obj1, obj2, obj3]);
 
     const query = new Parse.Query(TestObject);
     const results = await query.aggregate(pipeline);
-    console.log(results);
+    
     expect(results.length).toEqual(1);
     expect(results[0].tempPointer.value).toEqual(2);
   });

--- a/integration/test/ParseQueryAggregateTest.js
+++ b/integration/test/ParseQueryAggregateTest.js
@@ -55,6 +55,48 @@ describe('Parse Aggregate Query', () => {
     }
   });
 
+  it('aggregate allow multiple of same stage', async () => {
+    const pointer1 = new TestObject({ value: 1 });
+    const pointer2 = new TestObject({ value: 2 });
+    const pointer3 = new TestObject({ value: 3 });
+
+    const obj1 = new TestObject({ pointer: pointer1, name: 'Hello' });
+    const obj2 = new TestObject({ pointer: pointer2, name: 'Hello' });
+    const obj3 = new TestObject({ pointer: pointer3, name: 'World' });
+
+    const pipeline = [{
+      match: { name: 'Hello' },
+    }, {
+      // Transform className$objectId to objectId and store in new field tempPointer
+      project: {
+        tempPointer: { $substr: ['$_p_pointer', 11, -1] }, // Remove TestObject$
+      },
+    }, {
+      // Left Join, replace objectId stored in tempPointer with an actual object
+      lookup: {
+        from: 'test_TestObject',
+        localField: 'tempPointer',
+        foreignField: '_id',
+        as: 'tempPointer',
+      },
+    }, {
+      // lookup returns an array, Deconstructs an array field to objects
+      unwind: {
+        path: '$tempPointer',
+      },
+    }, {
+      match: { 'tempPointer.value': 2 },
+    }
+  ];
+    await Parse.Object.saveAll([pointer1, pointer2, pointer3, obj1, obj2, obj3]);
+
+    const query = new Parse.Query(TestObject);
+    const results = await query.aggregate(pipeline);
+    console.log(results);
+    expect(results.length).toEqual(1);
+    expect(results[0].tempPointer.value).toEqual(2);
+  });
+
   it('distinct query', () => {
     const query = new Parse.Query(TestObject);
     return query.distinct('score').then((results) => {

--- a/integration/test/ParseQueryAggregateTest.js
+++ b/integration/test/ParseQueryAggregateTest.js
@@ -25,7 +25,7 @@ describe('Parse Aggregate Query', () => {
 
   it('aggregate pipeline object query', (done) => {
     const pipeline = {
-      group: { objectId: '$name' }
+      group: { objectId: '$name' },
     };
     const query = new Parse.Query(TestObject);
     query.aggregate(pipeline).then((results) => {
@@ -74,7 +74,7 @@ describe('Parse Aggregate Query', () => {
     }, {
       // Left Join, replace objectId stored in tempPointer with an actual object
       lookup: {
-        from: 'test_TestObject',
+        from: 'TestObject',
         localField: 'tempPointer',
         foreignField: '_id',
         as: 'tempPointer',
@@ -91,7 +91,7 @@ describe('Parse Aggregate Query', () => {
 
     const query = new Parse.Query(TestObject);
     const results = await query.aggregate(pipeline);
-    
+
     expect(results.length).toEqual(1);
     expect(results[0].tempPointer.value).toEqual(2);
   });

--- a/src/ParseQuery.js
+++ b/src/ParseQuery.js
@@ -579,7 +579,7 @@ class ParseQuery {
     }
     const controller = CoreManager.getQueryController();
 
-    if (!pipeline || !Array.isArray(pipeline) || typeof pipeline !== 'object') {
+    if (!Array.isArray(pipeline) && typeof pipeline !== 'object') {
       throw new Error('Invalid pipeline must be Array or Object');
     }
 

--- a/src/ParseQuery.js
+++ b/src/ParseQuery.js
@@ -572,30 +572,23 @@ class ParseQuery {
     options = options || {};
 
     const aggregateOptions = {
-      useMasterKey: true
+      useMasterKey: true,
     };
     if (options.hasOwnProperty('sessionToken')) {
       aggregateOptions.sessionToken = options.sessionToken;
     }
     const controller = CoreManager.getQueryController();
-    let stages = {};
 
-    if (Array.isArray(pipeline)) {
-      pipeline.forEach((stage) => {
-        for (let op in stage) {
-          stages[op] = stage[op];
-        }
-      });
-    } else if (pipeline && typeof pipeline === 'object') {
-      stages = pipeline;
-    } else {
+    if (!pipeline || !Array.isArray(pipeline) || typeof pipeline !== 'object') {
       throw new Error('Invalid pipeline must be Array or Object');
     }
 
+    const params = { pipeline };
+
     return controller.aggregate(
       this.className,
-      stages,
-      aggregateOptions
+      params,
+      aggregateOptions,
     ).then((results) => {
       return results.results;
     });

--- a/src/__tests__/ParseQuery-test.js
+++ b/src/__tests__/ParseQuery-test.js
@@ -1855,7 +1855,7 @@ describe('ParseQuery', () => {
       aggregate(className, params, options) {
         expect(className).toBe('Item');
         expect(params).toEqual({
-          group: { objectId: '$name' }
+          pipeline: [{ group: { objectId: '$name' } }]
         });
         expect(options).toEqual({ useMasterKey: true });
         return Promise.resolve({
@@ -1880,7 +1880,7 @@ describe('ParseQuery', () => {
       aggregate(className, params, options) {
         expect(className).toBe('Item');
         expect(params).toEqual({
-          group: { objectId: '$name' }
+          pipeline: { group: { objectId: '$name' } }
         });
         expect(options).toEqual({ useMasterKey: true });
         return Promise.resolve({
@@ -1929,7 +1929,7 @@ describe('ParseQuery', () => {
       aggregate(className, params, options) {
         expect(className).toBe('Item');
         expect(params).toEqual({
-          group: { objectId: '$name' }
+          pipeline: [{ group: { objectId: '$name' } }]
         });
         expect(options).toEqual({
           useMasterKey: true,


### PR DESCRIPTION
Instead of converting array to json for the payload just pass it though.

Since I can't pass an array to the RESTController, The pipeline key needs to be added to the server for this to work.