### PR TITLE
Save Method for Parse.Config

### DIFF
--- a/src/CoreManager.js
+++ b/src/CoreManager.js
@@ -207,7 +207,7 @@ module.exports = {
   },
 
   setConfigController(controller: ConfigController) {
-    requireMethods('ConfigController', ['current', 'get'], controller);
+    requireMethods('ConfigController', ['current', 'get', 'save'], controller);
     config['ConfigController'] = controller;
   },
 

--- a/src/ParseConfig.js
+++ b/src/ParseConfig.js
@@ -88,10 +88,10 @@ class ParseConfig {
    * @return {Promise} A promise that is resolved with a newly-created
    *     configuration object or with the current with the update.
    */
-  static save(attrs,params) {
+  static save(attrs) {
     const controller = CoreManager.getConfigController();
     //To avoid a mismatch with the local and the cloud config we get a new version
-    return controller.save(attrs,params).then(() => {
+    return controller.save(attrs).then(() => {
       return controller.get();
     },(error) => {
       return Promise.reject(error);
@@ -177,15 +177,8 @@ var DefaultController = {
     });
   },
 
-  save(attrs,params) {
+  save(attrs) {
     var RESTController = CoreManager.getRESTController();
-    if(!params || !params.useMasterKey){
-      const error = new ParseError(
-        ParseError.OTHER_CAUSE,
-        'Master Key needed for update Parse.Config.'
-      );
-      return Promise.reject(error);
-    }
     const encodedAttrs = {};
     for(const key in attrs){
       encodedAttrs[key] = encode(attrs[key])

--- a/src/ParseConfig.js
+++ b/src/ParseConfig.js
@@ -11,6 +11,7 @@
 
 import CoreManager from './CoreManager';
 import decode from './decode';
+import encode from './encode';
 import escape from './escape';
 import ParseError from './ParseError';
 import Storage from './Storage';
@@ -66,7 +67,7 @@ class ParseConfig {
    *     exists, else an empty Parse.Config.
    */
   static current() {
-    var controller = CoreManager.getConfigController();
+    const controller = CoreManager.getConfigController();
     return controller.current();
   }
 
@@ -77,8 +78,24 @@ class ParseConfig {
    *     configuration object when the get completes.
    */
   static get() {
-    var controller = CoreManager.getConfigController();
+    const controller = CoreManager.getConfigController();
     return controller.get();
+  }
+
+  /**
+   * Save value keys to the server.
+   * @static
+   * @return {Promise} A promise that is resolved with a newly-created
+   *     configuration object or with the current with the update.
+   */
+  static save(attrs,params) {
+    const controller = CoreManager.getConfigController();
+    //To avoid a mismatch with the local and the cloud config we get a new version
+    return controller.save(attrs,params).then(() => {
+      return controller.get();
+    },(error) => {
+      return Promise.reject(error);
+    });
   }
 }
 
@@ -88,7 +105,7 @@ var CURRENT_CONFIG_KEY = 'currentConfig';
 
 function decodePayload(data) {
   try {
-    var json = JSON.parse(data);
+    const json = JSON.parse(data);
     if (json && typeof json === 'object') {
       return decode(json);
     }
@@ -103,14 +120,14 @@ var DefaultController = {
       return currentConfig;
     }
 
-    var config = new ParseConfig();
-    var storagePath = Storage.generatePath(CURRENT_CONFIG_KEY);
-    var configData;
+    const config = new ParseConfig();
+    const storagePath = Storage.generatePath(CURRENT_CONFIG_KEY);
+    let configData;
     if (!Storage.async()) {
       configData = Storage.getItem(storagePath);
 
       if (configData) {
-        var attributes = decodePayload(configData);
+        const attributes = decodePayload(configData);
         if (attributes) {
           config.attributes = attributes;
           currentConfig = config;
@@ -121,7 +138,7 @@ var DefaultController = {
     // Return a promise for async storage controllers
     return Storage.getItemAsync(storagePath).then((configData) => {
       if (configData) {
-        var attributes = decodePayload(configData);
+        const attributes = decodePayload(configData);
         if (attributes) {
           config.attributes = attributes;
           currentConfig = config;
@@ -132,22 +149,22 @@ var DefaultController = {
   },
 
   get() {
-    var RESTController = CoreManager.getRESTController();
+    const RESTController = CoreManager.getRESTController();
 
     return RESTController.request(
       'GET', 'config', {}, {}
     ).then((response) => {
       if (!response || !response.params) {
-        var error = new ParseError(
+        const error = new ParseError(
           ParseError.INVALID_JSON,
           'Config JSON response invalid.'
         );
         return Promise.reject(error);
       }
 
-      var config = new ParseConfig();
+      const config = new ParseConfig();
       config.attributes = {};
-      for (var attr in response.params) {
+      for (const attr in response.params) {
         config.attributes[attr] = decode(response.params[attr]);
       }
       currentConfig = config;
@@ -161,35 +178,32 @@ var DefaultController = {
   },
 
   save(attrs,params) {
+    var RESTController = CoreManager.getRESTController();
     if(!params || !params.useMasterKey){
-      return Promise.reject('Master Key needed for update Parse.Config')
+      const error = new ParseError(
+        ParseError.OTHER_CAUSE,
+        'Master Key needed for update Parse.Config.'
+      );
+      return Promise.reject(error);
     }
     const encodedAttrs = {};
-    for(let key in attrs){
-      encodedParams[key] = Parse._encode(attrs[key])
+    for(const key in attrs){
+      encodedAttrs[key] = encode(attrs[key])
     }
-    return Parse._request(
+    return RESTController.request(
       'PUT',
       'config',
       { params: encodedAttrs },
       { useMasterKey: true }
     ).then(response => {
       if(response && response.result){
-        for(let key in encodedParams){
-          currentConfig.attributes[key] = decode(encodedParams[key]);
-        }
-        const encodedConfig = {}
-        for(let key in currentConfig.attributes){
-          encodedConfig[key] = Parse._encode(currentConfig.attributes[key])
-        }
-        return Storage.setItemAsync(
-          Storage.generatePath(CURRENT_CONFIG_KEY),
-          JSON.stringify(encodedConfig)
-        ).then(() => {
-          return currentConfig;
-        });
+        return Promise.resolve()
       } else {
-        return Promise.reject('Error occured updating Config')
+        const error = new ParseError(
+          ParseError.INTERNAL_SERVER_ERROR,
+          'Error occured updating Config.'
+        );
+        return Promise.reject(error)
       }
     })
   }

--- a/src/ParseConfig.js
+++ b/src/ParseConfig.js
@@ -158,6 +158,40 @@ var DefaultController = {
         return config;
       });
     });
+  },
+
+  save(attrs,params) {
+    if(!params || !params.useMasterKey){
+      return Promise.reject('Master Key needed for update Parse.Config')
+    }
+    const encodedAttrs = {};
+    for(let key in attrs){
+      encodedParams[key] = Parse._encode(attrs[key])
+    }
+    return Parse._request(
+      'PUT',
+      'config',
+      { params: encodedAttrs },
+      { useMasterKey: true }
+    ).then(response => {
+      if(response && response.result){
+        for(let key in encodedParams){
+          currentConfig.attributes[key] = decode(encodedParams[key]);
+        }
+        const encodedConfig = {}
+        for(let key in currentConfig.attributes){
+          encodedConfig[key] = Parse._encode(currentConfig.attributes[key])
+        }
+        return Storage.setItemAsync(
+          Storage.generatePath(CURRENT_CONFIG_KEY),
+          JSON.stringify(encodedConfig)
+        ).then(() => {
+          return currentConfig;
+        });
+      } else {
+        return Promise.reject('Error occured updating Config')
+      }
+    })
   }
 };
 

--- a/src/__tests__/CoreManager-test.js
+++ b/src/__tests__/CoreManager-test.js
@@ -87,14 +87,16 @@ describe('CoreManager', () => {
 
     expect(CoreManager.setConfigController.bind(null, {
       current: function() {},
-      get: function() {}
+      get: function() {},
+      save : function() {}
     })).not.toThrow();
   });
 
   it('can set and get ConfigController', () => {
     const controller = {
       current: function() {},
-      get: function() {}
+      get: function() {},
+      save : function() {}
     };
 
     CoreManager.setConfigController(controller);

--- a/src/__tests__/ParseConfig-test.js
+++ b/src/__tests__/ParseConfig-test.js
@@ -100,6 +100,58 @@ describe('ParseConfig', () => {
     });
   });
 
+  it('can save a config object with masterkey', (done) => {
+    //Load a request that match the get() & save() request
+    CoreManager.setRESTController({
+      request() {
+        return Promise.resolve({
+          params : {
+            str : 'hello2',
+            num : 46
+          },
+          result: true
+        });
+      },
+      ajax() {}
+    });
+    ParseConfig.save({str: 'hello2','num':46},{useMasterKey:true}).then((config) => {
+      expect(config.get('str')).toBe('hello2');
+      expect(config.get('num')).toBe(46);
+      const path = Storage.generatePath('currentConfig');
+      expect(JSON.parse(Storage.getItem(path))).toEqual({
+        str: 'hello2',
+        num: 46
+      });
+      done();
+    });
+  });
+
+  it('rejects save on invalid response', (done) => {
+    CoreManager.setRESTController({
+      request() {
+        return Promise.resolve({result: false});
+      },
+      ajax() {}
+    });
+    ParseConfig.save({str: 'hello2','num':46},{useMasterKey:true}).then((config) => {
+      expect(config).toBe(1)
+      done();
+    },(error) => {
+      expect(error.code).toBe(1)
+      done();
+    });
+  });
+
+  it('cant save a config object without masterkey', (done) => {
+    ParseConfig.save({str: 'hello2','num':46}).then((config) => {
+      expect(config).toBe(-1)
+      done();
+    },(error) => {
+      expect(error.code).toBe(-1)
+      done();
+    });
+  });
+
   it('rejects the promise when an invalid payload comes back', (done) => {
     CoreManager.setRESTController({
       request() {
@@ -110,7 +162,6 @@ describe('ParseConfig', () => {
     ParseConfig.get().then(null, (error) => {
       expect(error.code).toBe(107);
       expect(error.message).toBe('Config JSON response invalid.');
-
       done();
     });
   });

--- a/src/__tests__/ParseConfig-test.js
+++ b/src/__tests__/ParseConfig-test.js
@@ -114,7 +114,7 @@ describe('ParseConfig', () => {
       },
       ajax() {}
     });
-    ParseConfig.save({str: 'hello2','num':46},{useMasterKey:true}).then((config) => {
+    ParseConfig.save({str: 'hello2','num':46}).then((config) => {
       expect(config.get('str')).toBe('hello2');
       expect(config.get('num')).toBe(46);
       const path = Storage.generatePath('currentConfig');
@@ -133,21 +133,11 @@ describe('ParseConfig', () => {
       },
       ajax() {}
     });
-    ParseConfig.save({str: 'hello2','num':46},{useMasterKey:true}).then((config) => {
+    ParseConfig.save({str: 'hello2','num':46}).then((config) => {
       expect(config).toBe(1)
       done();
     },(error) => {
       expect(error.code).toBe(1)
-      done();
-    });
-  });
-
-  it('cant save a config object without masterkey', (done) => {
-    ParseConfig.save({str: 'hello2','num':46}).then((config) => {
-      expect(config).toBe(-1)
-      done();
-    },(error) => {
-      expect(error.code).toBe(-1)
       done();
     });
   });


### PR DESCRIPTION
Allow to use `.save()` on Parse.Config when a masterKey is defined to avoid the use of `Parse._request` #684 

- [x] Write Method
- [x] Write Test
- [x] Valid the `save()` then `get()` strategy @flovilmart ?
- [x] Write Documentation Guide
- [ ] Write Documentation API