### PR TITLE
Ability to ignore constructor class map 

### DIFF
--- a/src/ParseObject.js
+++ b/src/ParseObject.js
@@ -1403,8 +1403,8 @@ class ParseObject {
    * @param {Object} json The JSON map of the Object's data
    * @param {boolean} override In single instance mode, all old server data
    *   is overwritten if this is set to true
-   * @param {ignoreClassMap} ignores current classMap, object will be returned as instance
-   *   of Parse.Object
+   * @param {boolean} ignoreClassMap ignores current classMap. Object will be
+   *   returned as an instance of Parse.Object
    * @static
    * @return {Parse.Object} A Parse.Object reference
    */

--- a/src/ParseObject.js
+++ b/src/ParseObject.js
@@ -1403,14 +1403,16 @@ class ParseObject {
    * @param {Object} json The JSON map of the Object's data
    * @param {boolean} override In single instance mode, all old server data
    *   is overwritten if this is set to true
+   * @param {ignoreClassMap} ignores current classMap, object will be returned as instance
+   *   of Parse.Object
    * @static
    * @return {Parse.Object} A Parse.Object reference
    */
-  static fromJSON(json, override) {
+  static fromJSON(json, override, ignoreClassMap = false) {
     if (!json.className) {
       throw new Error('Cannot create an object without a className');
     }
-    var constructor = classMap[json.className];
+    var constructor = ignoreClassMap ? undefined : classMap[json.className];
     var o = constructor ? new constructor() : new ParseObject(json.className);
     var otherAttributes = {};
     for (var attr in json) {


### PR DESCRIPTION
Adds the ability to ignore classMap when creating object. Object will be returned as an instance of ParseObject if ignoresClassMap is set to true.

My use case is i need to load a Session object from an already exported json object.
`Parse.Object.fromJson({ className: '_Session', sessionToken: "r:123..", ...otherStuff })`
Currently this will throw an error preventing readonly keys from being edited.

This should be safe since most restrictions are aleady being checked in server side.