### PR TITLE
Added route to reset password with token

### DIFF
--- a/src/CoreManager.js
+++ b/src/CoreManager.js
@@ -124,6 +124,7 @@ type UserController = {
   become: (options: RequestOptions) => Promise;
   logOut: () => Promise;
   requestPasswordReset: (email: string, options: RequestOptions) => Promise;
+  resetPasswordSetNew: (username: string, token: string, new_password: string, options: RequestOptions) => Promise;
   updateUserOnDisk: (user: ParseUser) => Promise;
   upgradeToRevocableSession: (user: ParseUser, options: RequestOptions) => Promise;
   linkWith: (user: ParseUser, authData: AuthData) => Promise;
@@ -378,6 +379,7 @@ module.exports = {
       'become',
       'logOut',
       'requestPasswordReset',
+      'resetPasswordSetNew',
       'upgradeToRevocableSession',
       'linkWith',
     ], controller);

--- a/src/ParseUser.js
+++ b/src/ParseUser.js
@@ -691,6 +691,34 @@ class ParseUser extends ParseObject {
   }
 
   /**
+   * Sets new password for specified user that already requested password reset,
+   * using his token
+   *
+   * <p>Calls options.success or options.error on completion.</p>
+   *
+
+   * @param {String} username Username associated with the user that forgot
+   *     their password.
+   * @param {String} token Verification token for password reset
+   * @param {String} new_password New password, chosen by user
+   * @param {Object} options
+   * @static
+   * @returns {Promise}
+   */
+  static resetPasswordSetNew(username, token, new_password, options) {
+    options = options || {};
+    var requestOptions = {};
+    if (options.hasOwnProperty('useMasterKey')) {
+      requestOptions.useMasterKey = options.useMasterKey;
+    }
+
+    var controller = CoreManager.getUserController();
+    return controller.resetPasswordSetNew(
+      username, token, new_password
+    );
+  }
+
+    /**
    * Allow someone to define a custom User class without className
    * being rewritten to _User. The default behavior is to rewrite
    * User to _User for legacy reasons. This allows developers to
@@ -984,6 +1012,16 @@ const DefaultController = {
       'POST',
       'requestPasswordReset',
       { email: email },
+      options
+    );
+  },
+
+  resetPasswordSetNew(username: string, token: string, new_password: string, options: RequestOptions) {
+    var RESTController = CoreManager.getRESTController();
+    return RESTController.request(
+      'POST',
+      'resetPasswordSetNew',
+      {username: username, token: token, new_password: new_password},
       options
     );
   },

--- a/src/ParseUser.js
+++ b/src/ParseUser.js
@@ -707,7 +707,7 @@ class ParseUser extends ParseObject {
    */
   static resetPasswordSetNew(username, token, new_password, options) {
     options = options || {};
-    let requestOptions = {};
+    const requestOptions = {};
     if (options.hasOwnProperty('useMasterKey')) {
       requestOptions.useMasterKey = options.useMasterKey;
     }

--- a/src/ParseUser.js
+++ b/src/ParseUser.js
@@ -707,18 +707,18 @@ class ParseUser extends ParseObject {
    */
   static resetPasswordSetNew(username, token, new_password, options) {
     options = options || {};
-    var requestOptions = {};
+    let requestOptions = {};
     if (options.hasOwnProperty('useMasterKey')) {
       requestOptions.useMasterKey = options.useMasterKey;
     }
 
-    var controller = CoreManager.getUserController();
+    const controller = CoreManager.getUserController();
     return controller.resetPasswordSetNew(
       username, token, new_password
     );
   }
 
-    /**
+  /**
    * Allow someone to define a custom User class without className
    * being rewritten to _User. The default behavior is to rewrite
    * User to _User for legacy reasons. This allows developers to
@@ -1017,7 +1017,7 @@ const DefaultController = {
   },
 
   resetPasswordSetNew(username: string, token: string, new_password: string, options: RequestOptions) {
-    var RESTController = CoreManager.getRESTController();
+    const RESTController = CoreManager.getRESTController();
     return RESTController.request(
       'POST',
       'resetPasswordSetNew',


### PR DESCRIPTION
Implemented another route for password reset flow, that allows setting new password from client side using the user's token that he receives by email with link.

This allows setting password through Parse function on client side, instead of manually sending request to server's public API router, avoiding direct interaction between user and server. 

The pull request that adds server-side route is here: https://github.com/parse-community/parse-server/pull/5288