### PR TITLE
remove assign authResponse in FB.init

### DIFF
--- a/src/FacebookUtils.js
+++ b/src/FacebookUtils.js
@@ -47,11 +47,6 @@ const provider = {
         (expiration.getTime() - new Date().getTime()) / 1000 :
         0;
 
-      const authResponse = {
-        userID: authData.id,
-        accessToken: authData.access_token,
-        expiresIn: expiresIn
-      };
       const newOptions = {};
       if (initOptions) {
         for (const key in initOptions) {
@@ -67,7 +62,7 @@ const provider = {
       // from a Parse User that logged in with username/password.
       const existingResponse = FB.getAuthResponse();
       if (existingResponse &&
-          existingResponse.userID !== authResponse.userID) {
+          existingResponse.userID !== authData.id) {
         FB.logout();
       }
 

--- a/src/FacebookUtils.js
+++ b/src/FacebookUtils.js
@@ -9,7 +9,6 @@
  * @flow-weak
  */
 /* global FB */
-import parseDate from './parseDate';
 import ParseUser from './ParseUser';
 
 let initialized = false;

--- a/src/FacebookUtils.js
+++ b/src/FacebookUtils.js
@@ -42,11 +42,6 @@ const provider = {
 
   restoreAuthentication(authData) {
     if (authData) {
-      const expiration = parseDate(authData.expiration_date);
-      const expiresIn = expiration ?
-        (expiration.getTime() - new Date().getTime()) / 1000 :
-        0;
-
       const newOptions = {};
       if (initOptions) {
         for (const key in initOptions) {

--- a/src/FacebookUtils.js
+++ b/src/FacebookUtils.js
@@ -58,8 +58,6 @@ const provider = {
           newOptions[key] = initOptions[key];
         }
       }
-      newOptions.authResponse = authResponse;
-
       // Suppress checks for login status from the browser.
       newOptions.status = false;
 


### PR DESCRIPTION
Base on this issue https://github.com/parse-community/Parse-SDK-JS/issues/726

I'm not sure what is the usage for `newOptions.authResponse` in this library. So I remove the line that assign `authResponse` to `newOptions`.

Anyone feel free to comment.