### PR TITLE
(fix) regeneratorRuntime is not defined

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -15,7 +15,7 @@ var VERSION = require('./package.json').version;
 var transformRuntime = ["@babel/plugin-transform-runtime", {
   "corejs": false,
   "helpers": true,
-  "regenerator": false,
+  "regenerator": true,
   "useESModules": false
 }];
 


### PR DESCRIPTION
Closes: https://github.com/parse-community/Parse-SDK-JS/issues/717

If you are in a project that doesn't have a global `regeneratorRuntime` defined i.e Browser an error is thrown.

This fix causes babel to use `@babel/runtime/regenerator` instead of a global variable.

`regenerator` is used whenever async / generator functions are used

Thanks @agoldis