### PR TITLE
:zap: Release v2.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Parse-SDK-JS
 
+## 2.2.1
+
+- Addresses issue with babel runtime regenerator ([#740](https://github.com/parse-community/Parse-SDK-JS/pull/740))
+
 ## 2.2.0
 
 - Support for Local Datastore ([#612](https://github.com/parse-community/parse-server/pull/612))

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "parse",
-  "version": "2.2.0",
+  "version": "2.2.1",
   "description": "The Parse JavaScript SDK",
   "homepage": "https://www.parse.com",
   "keywords": [


### PR DESCRIPTION
Fixes a critical issue that makes Parse unusable for some users.