### PR TITLE
Add options to _linkWith(provider) for masterKey

### DIFF
--- a/integration/server.js
+++ b/integration/server.js
@@ -1,22 +1,27 @@
 const express = require('express');
 const ParseServer = require('parse-server').ParseServer;
 const app = express();
+const CustomAuth = require('./test/CustomAuth');
 
-// Specify the connection string for your mongodb database
-// and the location to your Parse cloud code
 const api = new ParseServer({
   databaseURI: 'mongodb://localhost:27017/integration',
   appId: 'integration',
   masterKey: 'notsosecret',
-  serverURL: 'http://localhost:1337/parse', // Don't forget to change to https if needed
+  serverURL: 'http://localhost:1337/parse',
   cloud: `${__dirname}/cloud/main.js`,
   liveQuery: {
     classNames: ['TestObject', 'DiffObject'],
   },
   startLiveQueryServer: true,
+  auth: {
+    myAuth: {
+      module: CustomAuth,
+      option1: 'hello',
+      option2: 'world',
+    }
+  }
 });
 
-// Serve the Parse API on the /parse URL prefix
 app.use('/parse', api);
 
 const TestUtils = require('parse-server').TestUtils;

--- a/integration/test/CustomAuth.js
+++ b/integration/test/CustomAuth.js
@@ -1,0 +1,13 @@
+/* eslint-disable */
+function validateAuthData(authData, options) {
+  return Promise.resolve({})
+}
+
+function validateAppId(appIds, authData, options) {
+  return Promise.resolve({});
+}
+
+module.exports = {
+  validateAppId,
+  validateAuthData,
+};

--- a/integration/test/ParseUserTest.js
+++ b/integration/test/ParseUserTest.js
@@ -562,4 +562,34 @@ describe('Parse User', () => {
     expect(user instanceof CustomUser).toBe(true);
     expect(user.doSomething()).toBe(5);
   });
+
+  it('can link with master key', async () => {
+    const provider = {
+      authenticate: () => Promise.resolve(),
+      restoreAuthentication() {
+        return true;
+      },
+
+      getAuthType() {
+        return 'test';
+      },
+
+      getAuthData() {
+        return {
+          authData: {
+            id: 1234,
+          },
+        };
+      },
+    };
+    Parse.User._registerAuthenticationProvider(provider);
+    const user = new Parse.User();
+    user.setUsername('Alice');
+    user.setPassword('sekrit');
+    await user.save();
+    // times out.  getting stuck somewhere?
+    await user._linkWith(provider, {})
+    // const f = async () => user._linkWith(provider, null);
+    // expect(await f).not.toThrow();
+  });
 });

--- a/integration/test/ParseUserTest.js
+++ b/integration/test/ParseUserTest.js
@@ -618,4 +618,35 @@ describe('Parse User', () => {
     await user._unlinkFrom(provider, { sessionToken });
     expect(user._isLinked(provider)).toBe(false);
   });
+
+  it('can link with custom auth', async () => {
+    Parse.User.enableUnsafeCurrentUser();
+    const provider = {
+      authenticate: () => Promise.resolve(),
+      restoreAuthentication() {
+        return true;
+      },
+
+      getAuthType() {
+        return 'myAuth';
+      },
+
+      getAuthData() {
+        return {
+          authData: {
+            id: 1234,
+          },
+        };
+      },
+    };
+    Parse.User._registerAuthenticationProvider(provider);
+    const user = new Parse.User();
+    user.setUsername('Alice');
+    user.setPassword('sekrit');
+    await user.signUp();
+    await user._linkWith(provider.getAuthType(), provider.getAuthData());
+    expect(user._isLinked(provider)).toBe(true);
+    await user._unlinkFrom(provider);
+    expect(user._isLinked(provider)).toBe(false);
+  });
 });

--- a/src/ParseObject.js
+++ b/src/ParseObject.js
@@ -1158,10 +1158,6 @@ class ParseObject {
     if (options.hasOwnProperty('sessionToken') && typeof options.sessionToken === 'string') {
       saveOptions.sessionToken = options.sessionToken;
     }
-    // Pass sessionToken if saving currentUser
-    if (typeof this.getSessionToken === 'function' && this.getSessionToken()) {
-      saveOptions.sessionToken = this.getSessionToken();
-    }
     const controller = CoreManager.getObjectController();
     const unsaved = unsavedChildren(this);
     return controller.save(unsaved, saveOptions).then(() => {

--- a/src/ParseUser.js
+++ b/src/ParseUser.js
@@ -77,7 +77,7 @@ class ParseUser extends ParseObject {
    * Unlike in the Android/iOS SDKs, logInWith is unnecessary, since you can
    * call linkWith on the user (even if it doesn't exist yet on the server).
    */
-  _linkWith(provider: any, options: { authData?: AuthData }, saveOpts: object): Promise {
+  _linkWith(provider: any, options: { authData?: AuthData }, saveOpts?: FullOptions): Promise {
     let authType;
     if (typeof provider === 'string') {
       authType = provider;
@@ -179,16 +179,14 @@ class ParseUser extends ParseObject {
     }
   }
 
-  // FIXME: add master key option to unlink.
   /**
    * Unlinks a user from a service.
-
    */
-  _unlinkFrom(provider: any) {
+  _unlinkFrom(provider: any, options?: FullOptions) {
     if (typeof provider === 'string') {
       provider = authProviders[provider];
     }
-    return this._linkWith(provider, { authData: null }).then(() => {
+    return this._linkWith(provider, { authData: null }, options).then(() => {
       this._synchronizeAuthData(provider);
       return Promise.resolve(this);
     });
@@ -1056,7 +1054,7 @@ const DefaultController = {
     });
   },
 
-  linkWith(user: ParseUser, authData: AuthData, options: object) {
+  linkWith(user: ParseUser, authData: AuthData, options: FullOptions) {
     return user.save({ authData }, options).then(() => {
       if (canUseCurrentUser) {
         return DefaultController.setCurrentUser(user);

--- a/src/ParseUser.js
+++ b/src/ParseUser.js
@@ -104,7 +104,7 @@ class ParseUser extends ParseObject {
           success: (provider, result) => {
             const opts = {};
             opts.authData = result;
-            this._linkWith(provider, opts).then(() => {
+            this._linkWith(provider, opts, saveOpts).then(() => {
               resolve(this);
             }, (error) => {
               reject(error);
@@ -179,6 +179,7 @@ class ParseUser extends ParseObject {
     }
   }
 
+  // FIXME: add master key option to unlink.
   /**
    * Unlinks a user from a service.
 

--- a/src/ParseUser.js
+++ b/src/ParseUser.js
@@ -77,7 +77,7 @@ class ParseUser extends ParseObject {
    * Unlike in the Android/iOS SDKs, logInWith is unnecessary, since you can
    * call linkWith on the user (even if it doesn't exist yet on the server).
    */
-  _linkWith(provider: any, options: { authData?: AuthData }): Promise {
+  _linkWith(provider: any, options: { authData?: AuthData }, saveOpts: object): Promise {
     let authType;
     if (typeof provider === 'string') {
       authType = provider;
@@ -95,7 +95,8 @@ class ParseUser extends ParseObject {
       const controller = CoreManager.getUserController();
       return controller.linkWith(
         this,
-        authData
+        authData,
+        saveOpts
       );
     } else {
       return new Promise((resolve, reject) => {
@@ -1054,8 +1055,8 @@ const DefaultController = {
     });
   },
 
-  linkWith(user: ParseUser, authData: AuthData) {
-    return user.save({ authData }).then(() => {
+  linkWith(user: ParseUser, authData: AuthData, options: object) {
+    return user.save({ authData }, options).then(() => {
       if (canUseCurrentUser) {
         return DefaultController.setCurrentUser(user);
       }

--- a/src/__tests__/ParseUser-test.js
+++ b/src/__tests__/ParseUser-test.js
@@ -767,6 +767,31 @@ describe('ParseUser', () => {
     expect(user.destroy).toHaveBeenCalledTimes(1);
   });
 
+  it('can unlink', async () => {
+    const provider = AnonymousUtils._getAuthProvider();
+    ParseUser._registerAuthenticationProvider(provider);
+    const user = new ParseUser();
+    jest.spyOn(user, '_linkWith');
+    user._unlinkFrom(provider);
+    expect(user._linkWith).toHaveBeenCalledTimes(1);
+    expect(user._linkWith).toHaveBeenCalledWith(provider, { authData: null }, undefined);
+  });
+
+  it('can unlink with options', async () => {
+    const provider = AnonymousUtils._getAuthProvider();
+    ParseUser._registerAuthenticationProvider(provider);
+    const user = new ParseUser();
+    jest.spyOn(user, '_linkWith')
+      .mockImplementationOnce((authProvider, authData, saveOptions) => {
+        expect(authProvider).toEqual(provider);
+        expect(authData).toEqual({ authData: null});
+        expect(saveOptions).toEqual({ useMasterKey: true });
+        return Promise.resolve();
+      });
+    user._unlinkFrom(provider.getAuthType(), { useMasterKey: true });
+    expect(user._linkWith).toHaveBeenCalledTimes(1);
+  });
+
   it('can destroy anonymous user when login new user', async () => {
     ParseUser.enableUnsafeCurrentUser();
     ParseUser._clearCache();
@@ -850,5 +875,45 @@ describe('ParseUser', () => {
       expect(u2.get('number')).toBe(undefined);
       done();
     });
+  });
+
+  it('can linkWith options', async () => {
+    ParseUser._clearCache();
+    CoreManager.setRESTController({
+      request(method, path, body, options) {
+        expect(options).toEqual({ useMasterKey: true });
+        return Promise.resolve({
+          objectId: 'uid5',
+          sessionToken: 'r:123abc',
+          authData: {
+            test: {
+              id: 'id',
+              access_token: 'access_token'
+            }
+          }
+        }, 200);
+      },
+      ajax() {}
+    });
+    const provider = {
+      authenticate(options) {
+        if (options.success) {
+          options.success(this, {
+            id: 'id',
+            access_token: 'access_token'
+          });
+        }
+      },
+      restoreAuthentication() {},
+      getAuthType() {
+        return 'test';
+      },
+      deauthenticate() {}
+    };
+
+    const user = new ParseUser();
+    await user._linkWith(provider, null, { useMasterKey: true });
+
+    expect(user.get('authData')).toEqual({ test: { id: 'id', access_token: 'access_token' } });
   });
 });

--- a/src/__tests__/ParseUser-test.js
+++ b/src/__tests__/ParseUser-test.js
@@ -742,31 +742,6 @@ describe('ParseUser', () => {
     spy.mockRestore();
   });
 
-  it('can pass sessionToken on save', async () => {
-    ParseUser.enableUnsafeCurrentUser();
-    ParseUser._clearCache();
-    CoreManager.setRESTController({
-      request() {
-        return Promise.resolve({
-          objectId: 'uid5',
-          sessionToken: 'r:123abc',
-          authData: {
-            anonymous: {
-              id: 'anonymousId',
-            }
-          }
-        }, 200);
-      },
-      ajax() {}
-    });
-    const user = await AnonymousUtils.logIn();
-    user.set('field', 'hello');
-    jest.spyOn(user, 'getSessionToken');
-
-    await user.save();
-    expect(user.getSessionToken).toHaveBeenCalledTimes(2);
-  });
-
   it('can destroy anonymous user on logout', async () => {
     ParseUser.enableUnsafeCurrentUser();
     ParseUser._clearCache();


### PR DESCRIPTION
1. without the master key it is not possible to link a user with an auth provider in cloud code
2. remove a recent addition to pass the sessionToken which was added for anonymous auth, but not necessary and causing problems.  Also remove the related test.
