### PR TITLE
Fixed object save method params documentation

### DIFF
--- a/src/ParseObject.js
+++ b/src/ParseObject.js
@@ -1081,6 +1081,8 @@ class ParseObject {
    * You can either call it as:<pre>
    *   object.save();</pre>
    * or<pre>
+   *   object.save(attrs);</pre>
+   * or<pre>
    *   object.save(null, options);</pre>
    * or<pre>
    *   object.save(attrs, options);</pre>
@@ -1097,13 +1099,36 @@ class ParseObject {
    *     // The save failed.  Error is an instance of Parse.Error.
    *   });</pre>
    *
-   * @param {Object} options
+   * @param {String|Object|null} [attrs]
    * Valid options are:<ul>
-   *   <li>useMasterKey: In Cloud Code and Node only, causes the Master Key to
+   *   <li>`Object` - Key/value pairs to update on the object.</li>
+   *   <li>`String` Key - Key of attribute to update (requires arg2 to also be string)</li>
+   *   <li>`null` - Passing null for arg1 allows you to save the object with options passed in arg2.</li>
+   * </ul>
+   *
+   * @param {String|Object} [options]
+   * <ul>
+   *   <li>`String` Value - If arg1 was passed as a key, arg2 is the value that should be set on that key.</li>
+   *   <li>`Object` Options - Valid options are:
+   *     <ul>
+   *       <li>useMasterKey: In Cloud Code and Node only, causes the Master Key to
    *     be used for this request.
+   *       <li>sessionToken: A valid session token, used for making a request on
+   *       behalf of a specific user.
+   *     </ul>
+   *   </li>
+   * </ul>
+   *
+   * @param {Object} [options]
+   * Used to pass option parameters to method if arg1 and arg2 were both passed as strings.
+   * Valid options are:
+   * <ul>
+   *   <li>useMasterKey: In Cloud Code and Node only, causes the Master Key to
+   *       be used for this request.
    *   <li>sessionToken: A valid session token, used for making a request on
    *       behalf of a specific user.
    * </ul>
+   *
    * @return {Promise} A promise that is fulfilled when the save
    *     completes.
    */


### PR DESCRIPTION
The documentation for the params required for Object's save method describes 1 param (options), but you cannot actually pass just options as an object to the save method. The correct use of the save method is described with examples in the documentation, but the additional 2 params are not documented. As the save method does accept 3 arguments (in the code as value: function (arg1, arg2, arg3) {), these params need to be added to the documentation and not just mentioned in the examples.