### PR TITLE
Fix flaky tests

### DIFF
--- a/integration/test/ParseACLTest.js
+++ b/integration/test/ParseACLTest.js
@@ -22,575 +22,509 @@ describe('Parse.ACL', () => {
     assert.equal(user.setACL(`Ceci n'est pas un ACL.`), false);
   });
 
-  it('can refresh object with acl', (done) => {
+  it('can refresh object with acl', async () => {
     const user = new Parse.User();
     const object = new TestObject();
     user.set('username', 'alice');
     user.set('password', 'wonderland');
-    user.signUp().then(() => {
-      const acl = new Parse.ACL(user);
-      object.setACL(acl);
-      return object.save();
-    }).then(() => {
-      return object.fetch();
-    }).then((o) => {
-      assert(o);
-      done();
-    });
+    await user.signUp();
+    const acl = new Parse.ACL(user);
+    object.setACL(acl);
+    await object.save();
+
+    const o = await object.fetch();
+    assert(o);
   });
 
-  it('disables public get access', (done) => {
+  it('disables public get access', async () => {
     const user = new Parse.User();
     const object = new TestObject();
     user.set('username', 'getter');
     user.set('password', 'secret');
-    user.signUp().then(() => {
-      const acl = new Parse.ACL(user);
-      object.setACL(acl);
-      return object.save();
-    }).then(() => {
-      assert.equal(object.getACL().getReadAccess(user), true);
-      assert.equal(object.getACL().getWriteAccess(user), true);
-      assert.equal(object.getACL().getPublicReadAccess(), false);
-      assert.equal(object.getACL().getPublicWriteAccess(), false);
+    await user.signUp();
 
-      Parse.User.logOut();
+    const acl = new Parse.ACL(user);
+    object.setACL(acl);
+    await object.save();
 
-      return new Parse.Query(TestObject).get(object.id);
-    }).catch((e) => {
+    assert.equal(object.getACL().getReadAccess(user), true);
+    assert.equal(object.getACL().getWriteAccess(user), true);
+    assert.equal(object.getACL().getPublicReadAccess(), false);
+    assert.equal(object.getACL().getPublicWriteAccess(), false);
+
+    await await Parse.User.logOut();
+    try {
+      const query = new Parse.Query(TestObject);
+      await query.get(object.id);
+    } catch (e) {
       assert.equal(e.code, Parse.Error.OBJECT_NOT_FOUND);
-      done();
-    });
+    }
   });
 
-  it('disables public find access', (done) => {
+  it('disables public find access', async () => {
     const user = new Parse.User();
     const object = new Parse.Object('UniqueObject');
     user.set('username', 'finder');
     user.set('password', 'secret');
-    user.signUp().then(() => {
-      const acl = new Parse.ACL(user);
-      object.setACL(acl);
-      return object.save();
-    }).then(() => {
-      assert.equal(object.getACL().getReadAccess(user), true);
-      assert.equal(object.getACL().getWriteAccess(user), true);
-      assert.equal(object.getACL().getPublicReadAccess(), false);
-      assert.equal(object.getACL().getPublicWriteAccess(), false);
+    await user.signUp();
 
-      Parse.User.logOut();
+    const acl = new Parse.ACL(user);
+    object.setACL(acl);
+    await object.save();
 
-      return new Parse.Query('UniqueObject').find();
-    }).then((o) => {
-      assert.equal(o.length, 0);
-      done();
-    });
+    assert.equal(object.getACL().getReadAccess(user), true);
+    assert.equal(object.getACL().getWriteAccess(user), true);
+    assert.equal(object.getACL().getPublicReadAccess(), false);
+    assert.equal(object.getACL().getPublicWriteAccess(), false);
+
+    await Parse.User.logOut();
+    const query = new Parse.Query('UniqueObject');
+    const o = await query.find();
+    assert.equal(o.length, 0);
   });
 
-  it('disables public update access', (done) => {
+  it('disables public update access', async () => {
     const user = new Parse.User();
     const object = new Parse.Object('UniqueObject');
     user.set('username', 'updater');
     user.set('password', 'secret');
-    user.signUp().then(() => {
-      const acl = new Parse.ACL(user);
-      object.setACL(acl);
-      return object.save();
-    }).then(() => {
-      assert.equal(object.getACL().getReadAccess(user), true);
-      assert.equal(object.getACL().getWriteAccess(user), true);
-      assert.equal(object.getACL().getPublicReadAccess(), false);
-      assert.equal(object.getACL().getPublicWriteAccess(), false);
+    await user.signUp();
 
-      Parse.User.logOut();
+    const acl = new Parse.ACL(user);
+    object.setACL(acl);
+    await object.save();
 
-      object.set('score', 10);
-      return object.save();
-    }).catch((e) => {
+    assert.equal(object.getACL().getReadAccess(user), true);
+    assert.equal(object.getACL().getWriteAccess(user), true);
+    assert.equal(object.getACL().getPublicReadAccess(), false);
+    assert.equal(object.getACL().getPublicWriteAccess(), false);
+
+    await Parse.User.logOut();
+
+    object.set('score', 10);
+    try {
+      await object.save();
+    } catch (e) {
       assert.equal(e.code, Parse.Error.OBJECT_NOT_FOUND);
-      done();
-    });
+    }
   });
 
-  it('disables public delete access', (done) => {
+  it('disables public delete access', async () => {
     const user = new Parse.User();
     const object = new Parse.Object(TestObject);
     user.set('username', 'deleter');
     user.set('password', 'secret');
-    user.signUp().then(() => {
-      const acl = new Parse.ACL(user);
-      object.setACL(acl);
-      return object.save();
-    }).then(() => {
-      assert.equal(object.getACL().getReadAccess(user), true);
-      assert.equal(object.getACL().getWriteAccess(user), true);
-      assert.equal(object.getACL().getPublicReadAccess(), false);
-      assert.equal(object.getACL().getPublicWriteAccess(), false);
+    await user.signUp();
 
-      Parse.User.logOut();
+    const acl = new Parse.ACL(user);
+    object.setACL(acl);
+    await object.save();
 
-      return object.destroy();
-    }).catch((e) => {
+    assert.equal(object.getACL().getReadAccess(user), true);
+    assert.equal(object.getACL().getWriteAccess(user), true);
+    assert.equal(object.getACL().getPublicReadAccess(), false);
+    assert.equal(object.getACL().getPublicWriteAccess(), false);
+
+    await Parse.User.logOut();
+
+    try {
+      await object.destroy();
+    } catch (e) {
       assert.equal(e.code, Parse.Error.OBJECT_NOT_FOUND);
-      done();
-    });
+    }
   });
 
-  it('allows logged in get', (done) => {
+  it('allows logged in get', async () => {
     const user = new Parse.User();
     const object = new TestObject();
     user.set('username', 'getter2');
     user.set('password', 'secret');
-    user.signUp().then(() => {
-      const acl = new Parse.ACL(user);
-      object.setACL(acl);
-      return object.save();
-    }).then(() => {
-      return new Parse.Query(TestObject).get(object.id);
-    }).then((o) => {
-      assert(o);
-      done();
-    });
+    await user.signUp();
+
+    const acl = new Parse.ACL(user);
+    object.setACL(acl);
+    await object.save();
+
+    const o = await new Parse.Query(TestObject).get(object.id);
+    assert(o);
   });
 
-  it('allows logged in find', (done) => {
+  it('allows logged in find', async () => {
     const user = new Parse.User();
     const object = new Parse.Object('UniqueObject');
     user.set('username', 'finder2');
     user.set('password', 'secret');
-    user.signUp().then(() => {
-      const acl = new Parse.ACL(user);
-      object.setACL(acl);
-      return object.save();
-    }).then(() => {
-      return new Parse.Query('UniqueObject').find();
-    }).then((o) => {
-      assert(o.length > 0);
-      done();
-    });
+    await user.signUp();
+
+    const acl = new Parse.ACL(user);
+    object.setACL(acl);
+    await object.save();
+
+    const o = await new Parse.Query('UniqueObject').find();
+    assert(o.length > 0);
   });
 
-  it('allows logged in update', (done) => {
+  it('allows logged in update', async () => {
     const user = new Parse.User();
     const object = new Parse.Object('UniqueObject');
     user.set('username', 'updater2');
     user.set('password', 'secret');
-    user.signUp().then(() => {
-      const acl = new Parse.ACL(user);
-      object.setACL(acl);
-      return object.save();
-    }).then(() => {
-      object.set('score', 10);
-      return object.save();
-    }).then(() => {
-      assert.equal(object.get('score'), 10);
-      done();
-    });
+    await user.signUp();
+    const acl = new Parse.ACL(user);
+    object.setACL(acl);
+    await object.save();
+    object.set('score', 10);
+    await object.save();
+    assert.equal(object.get('score'), 10);
   });
 
-  it('allows logged in delete', (done) => {
+  it('allows logged in delete', async () => {
     const user = new Parse.User();
     const object = new Parse.Object(TestObject);
     user.set('username', 'deleter2');
     user.set('password', 'secret');
-    user.signUp().then(() => {
-      const acl = new Parse.ACL(user);
-      object.setACL(acl);
-      return object.save();
-    }).then(() => {
-      return object.destroy();
-    }).then(() => {
-      done();
-    });
+    await user.signUp();
+
+    const acl = new Parse.ACL(user);
+    object.setACL(acl);
+
+    await object.save();
+    await object.destroy();
   });
 
-  it('enables get with public read', (done) => {
+  it('enables get with public read', async () => {
     const user = new Parse.User();
     const object = new TestObject();
     user.set('username', 'getter3');
     user.set('password', 'secret');
-    user.signUp().then(() => {
-      const acl = new Parse.ACL(user);
-      object.setACL(acl);
-      return object.save();
-    }).then(() => {
-      object.getACL().setPublicReadAccess(true);
-      return object.save();
-    }).then(() => {
-      Parse.User.logOut();
-      return new Parse.Query(TestObject).get(object.id);
-    }).then((o) => {
-      assert(o);
-      done();
-    });
+    await user.signUp();
+    const acl = new Parse.ACL(user);
+    object.setACL(acl);
+    await object.save();
+
+    object.getACL().setPublicReadAccess(true);
+    await object.save();
+
+    Parse.User.logOut();
+    const o = await new Parse.Query(TestObject).get(object.id);
+    assert(o);
   });
 
-  it('enables find with public read', (done) => {
+  it('enables find with public read', async () => {
     const user = new Parse.User();
     const object = new Parse.Object('AlsoUniqueObject');
     user.set('username', 'finder3');
     user.set('password', 'secret');
-    user.signUp().then(() => {
-      const acl = new Parse.ACL(user);
-      object.setACL(acl);
-      return object.save();
-    }).then(() => {
-      object.getACL().setPublicReadAccess(true);
-      return object.save();
-    }).then(() => {
-      Parse.User.logOut();
-      return new Parse.Query('AlsoUniqueObject').find();
-    }).then((o) => {
-      assert(o.length > 0);
-      done();
-    });
+    await user.signUp();
+    const acl = new Parse.ACL(user);
+    object.setACL(acl);
+    await object.save();
+
+    object.getACL().setPublicReadAccess(true);
+    await object.save();
+
+    Parse.User.logOut();
+    const o = await new Parse.Query('AlsoUniqueObject').find();
+
+    assert(o.length > 0);
   });
 
-  it('does not enable update with public read', (done) => {
+  it('does not enable update with public read', async () => {
     const user = new Parse.User();
     const object = new Parse.Object('UniqueObject');
     user.set('username', 'updater3');
     user.set('password', 'secret');
-    user.signUp().then(() => {
-      const acl = new Parse.ACL(user);
-      object.setACL(acl);
-      return object.save();
-    }).then(() => {
-      object.getACL().setPublicReadAccess(true);
-      return object.save();
-    }).then(() => {
-      Parse.User.logOut();
-      object.set('score', 10);
-      return object.save();
-    }).catch((e) => {
+    await user.signUp();
+    const acl = new Parse.ACL(user);
+    object.setACL(acl);
+    await object.save();
+
+    object.getACL().setPublicReadAccess(true);
+    await object.save();
+
+    Parse.User.logOut();
+    object.set('score', 10);
+    try {
+      await object.save();
+    } catch (e) {
       assert.equal(e.code, Parse.Error.OBJECT_NOT_FOUND);
-      done();
-    });
+    }
   });
 
-  it('does not enable delete with public read', (done) => {
+  it('does not enable delete with public read', async () => {
     const user = new Parse.User();
     const object = new Parse.Object(TestObject);
     user.set('username', 'deleter3');
     user.set('password', 'secret');
-    user.signUp().then(() => {
-      const acl = new Parse.ACL(user);
-      object.setACL(acl);
-      return object.save();
-    }).then(() => {
-      object.getACL().setPublicReadAccess(true);
-      return object.save();
-    }).then(() => {
-      Parse.User.logOut();
-      return object.destroy();
-    }).catch((e) => {
+    await user.signUp();
+    const acl = new Parse.ACL(user);
+    object.setACL(acl);
+    await object.save();
+
+    object.getACL().setPublicReadAccess(true);
+    await object.save();
+
+    Parse.User.logOut();
+    try {
+      await object.destroy();
+    } catch (e) {
       assert.equal(e.code, Parse.Error.OBJECT_NOT_FOUND);
-      done();
-    });
+    }
   });
 
-  it('does not enable get with public write', (done) => {
+  it('does not enable get with public write', async () => {
     const user = new Parse.User();
     const object = new TestObject();
     user.set('username', 'getter4');
     user.set('password', 'secret');
-    user.signUp().then(() => {
-      const acl = new Parse.ACL(user);
-      object.setACL(acl);
-      return object.save();
-    }).then(() => {
-      object.getACL().setPublicWriteAccess(true);
-      return object.save();
-    }).then(() => {
-      Parse.User.logOut();
-      return new Parse.Query(TestObject).get(object.id);
-    }).catch((e) => {
+    await user.signUp();
+    const acl = new Parse.ACL(user);
+    object.setACL(acl);
+    await object.save();
+
+    object.getACL().setPublicWriteAccess(true);
+    await object.save();
+
+    await Parse.User.logOut();
+    try {
+      await new Parse.Query(TestObject).get(object.id);
+    } catch (e) {
       assert.equal(e.code, Parse.Error.OBJECT_NOT_FOUND);
-      done();
-    });
+    }
   });
 
-  it('does not enable find with public write', (done) => {
+  it('does not enable find with public write', async () => {
     const user = new Parse.User();
     const object = new Parse.Object('AnotherUniqueObject');
     user.set('username', 'finder4');
     user.set('password', 'secret');
-    user.signUp().then(() => {
-      const acl = new Parse.ACL(user);
-      object.setACL(acl);
-      return object.save();
-    }).then(() => {
-      object.getACL().setPublicWriteAccess(true);
-      return object.save();
-    }).then(() => {
-      Parse.User.logOut();
-      return new Parse.Query('AnotherUniqueObject').find();
-    }).then((o) => {
-      assert.equal(o.length, 0);
-      done();
-    });
+    await user.signUp();
+    const acl = new Parse.ACL(user);
+    object.setACL(acl);
+    await object.save();
+
+    object.getACL().setPublicWriteAccess(true);
+    await object.save();
+
+    await Parse.User.logOut();
+    const o = await new Parse.Query('AnotherUniqueObject').find();
+    assert.equal(o.length, 0);
   });
 
-  it('enables update with public read', (done) => {
+  it('enables update with public read', async () => {
     const user = new Parse.User();
     const object = new Parse.Object('UniqueObject');
     user.set('username', 'updater4');
     user.set('password', 'secret');
-    user.signUp().then(() => {
-      const acl = new Parse.ACL(user);
-      object.setACL(acl);
-      return object.save();
-    }).then(() => {
-      object.getACL().setPublicWriteAccess(true);
-      return object.save();
-    }).then(() => {
-      Parse.User.logOut();
-      object.set('score', 10);
-      return object.save();
-    }).then(() => {
-      done();
-    });
+    await user.signUp();
+    const acl = new Parse.ACL(user);
+    object.setACL(acl);
+    await object.save();
+
+    object.getACL().setPublicWriteAccess(true);
+    await object.save();
+
+    await Parse.User.logOut();
+    object.set('score', 10);
+    await object.save();
   });
 
-  it('enables delete with public read', (done) => {
+  it('enables delete with public read', async () => {
     const user = new Parse.User();
     const object = new TestObject();
     user.set('username', 'deleter4');
     user.set('password', 'secret');
-    user.signUp().then(() => {
-      const acl = new Parse.ACL(user);
-      object.setACL(acl);
-      return object.save();
-    }).then(() => {
-      object.getACL().setPublicWriteAccess(true);
-      return object.save();
-    }).then(() => {
-      Parse.User.logOut();
-      return object.destroy();
-    }).then(() => {
-      done();
-    });
+    await user.signUp();
+    const acl = new Parse.ACL(user);
+    object.setACL(acl);
+    await object.save();
+
+    object.getACL().setPublicWriteAccess(true);
+    await object.save();
+
+    await Parse.User.logOut();
+    await object.destroy();
   });
 
-  it('can grant get access to another user', (done) => {
-    let user1, user2;
+  it('can grant get access to another user', async () => {
     const object = new TestObject();
-    Parse.User.signUp('aaa', 'password').then((u) => {
-      user1 = u;
-      Parse.User.logOut();
+    const user1 = await Parse.User.signUp('aaa', 'password');
+    await Parse.User.logOut();
 
-      return Parse.User.signUp('bbb', 'password');
-    }).then((u) => {
-      user2 = u;
-      const acl = new Parse.ACL(user2);
-      acl.setWriteAccess(user1, true);
-      acl.setReadAccess(user1, true);
-      object.setACL(acl);
-      return object.save();
-    }).then(() => {
-      return Parse.User.logIn('aaa', 'password');
-    }).then(() => {
-      const query = new Parse.Query(TestObject);
-      return query.get(object.id);
-    }).then((o) => {
-      assert.equal(o.id, object.id);
-      done();
-    });
+    const user2 = await Parse.User.signUp('bbb', 'password');
+
+    const acl = new Parse.ACL(user2);
+    acl.setWriteAccess(user1, true);
+    acl.setReadAccess(user1, true);
+    object.setACL(acl);
+    await object.save();
+
+    await Parse.User.logIn('aaa', 'password');
+
+    const query = new Parse.Query(TestObject);
+    const o = await query.get(object.id);
+    assert.equal(o.id, object.id);
   });
 
-  it('can grant find access to another user', (done) => {
-    let user1, user2;
+  it('can grant find access to another user', async () => {
     const object = new Parse.Object('ThatOneObject');
-    Parse.User.signUp('ccc', 'password').then((u) => {
-      user1 = u;
-      Parse.User.logOut();
+    const user1 = await Parse.User.signUp('ccc', 'password');
+    await Parse.User.logOut();
 
-      return Parse.User.signUp('ddd', 'password');
-    }).then((u) => {
-      user2 = u;
-      const acl = new Parse.ACL(user2);
-      acl.setWriteAccess(user1, true);
-      acl.setReadAccess(user1, true);
-      object.setACL(acl);
-      return object.save();
-    }).then(() => {
-      return Parse.User.logIn('ccc', 'password');
-    }).then(() => {
-      const query = new Parse.Query('ThatOneObject');
-      return query.find();
-    }).then((o) => {
-      assert(o.length > 0);
-      done();
-    });
+    const user2 = await Parse.User.signUp('ddd', 'password');
+
+    const acl = new Parse.ACL(user2);
+    acl.setWriteAccess(user1, true);
+    acl.setReadAccess(user1, true);
+    object.setACL(acl);
+    await object.save();
+
+    await Parse.User.logIn('ccc', 'password');
+
+    const query = new Parse.Query('ThatOneObject');
+    const o = await query.find();
+    assert(o.length > 0);
   });
 
-  it('can grant update access to another user', (done) => {
-    let user1, user2;
+  it('can grant update access to another user', async () => {
     const object = new TestObject();
-    Parse.User.signUp('eee', 'password').then((u) => {
-      user1 = u;
-      Parse.User.logOut();
+    const user1 = await Parse.User.signUp('eee', 'password');
 
-      return Parse.User.signUp('fff', 'password');
-    }).then((u) => {
-      user2 = u;
-      const acl = new Parse.ACL(user2);
-      acl.setWriteAccess(user1, true);
-      acl.setReadAccess(user1, true);
-      object.setACL(acl);
-      return object.save();
-    }).then(() => {
-      return Parse.User.logIn('eee', 'password');
-    }).then(() => {
-      object.set('score', 10);
-      return object.save();
-    }).then((o) => {
-      assert.equal(o.get('score'), 10);
-      done();
-    });
+    await Parse.User.logOut();
+
+    const user2 = await Parse.User.signUp('fff', 'password');
+
+    const acl = new Parse.ACL(user2);
+    acl.setWriteAccess(user1, true);
+    acl.setReadAccess(user1, true);
+    object.setACL(acl);
+    await object.save();
+
+    await Parse.User.logIn('eee', 'password');
+
+    object.set('score', 10);
+    const o = await object.save();
+    assert.equal(o.get('score'), 10);
   });
 
-  it('can grant delete access to another user', (done) => {
-    let user1, user2;
+  it('can grant delete access to another user', async () => {
     const object = new TestObject();
-    Parse.User.signUp('ggg', 'password').then((u) => {
-      user1 = u;
-      Parse.User.logOut();
+    const user1 = await Parse.User.signUp('ggg', 'password')
+    await Parse.User.logOut();
 
-      return Parse.User.signUp('hhh', 'password');
-    }).then((u) => {
-      user2 = u;
-      const acl = new Parse.ACL(user2);
-      acl.setWriteAccess(user1, true);
-      acl.setReadAccess(user1, true);
-      object.setACL(acl);
-      return object.save();
-    }).then(() => {
-      return Parse.User.logIn('ggg', 'password');
-    }).then(() => {
-      return object.destroy();
-    }).then(() => {
-      done();
-    });
+    const user2 = await Parse.User.signUp('hhh', 'password');
+
+    const acl = new Parse.ACL(user2);
+    acl.setWriteAccess(user1, true);
+    acl.setReadAccess(user1, true);
+    object.setACL(acl);
+    await object.save();
+
+    await Parse.User.logIn('ggg', 'password');
+    await object.destroy();
   });
 
-  it('does not grant public get access with another user acl', (done) => {
-    let user1, user2;
+  it('does not grant public get access with another user acl', async () => {
     const object = new TestObject();
-    Parse.User.signUp('iii', 'password').then((u) => {
-      user1 = u;
-      Parse.User.logOut();
+    const user1 = await Parse.User.signUp('iii', 'password');
+    await Parse.User.logOut();
 
-      return Parse.User.signUp('jjj', 'password');
-    }).then((u) => {
-      user2 = u;
-      const acl = new Parse.ACL(user2);
-      acl.setWriteAccess(user1, true);
-      acl.setReadAccess(user1, true);
-      object.setACL(acl);
-      return object.save();
-    }).then(() => {
-      return Parse.User.logOut();
-    }).then(() => {
+    const user2 = await Parse.User.signUp('jjj', 'password');
+
+    const acl = new Parse.ACL(user2);
+    acl.setWriteAccess(user1, true);
+    acl.setReadAccess(user1, true);
+    object.setACL(acl);
+    await object.save();
+
+    await Parse.User.logOut();
+
+    try {
       const query = new Parse.Query(TestObject);
-      return query.get(object.id);
-    }).catch((e) => {
+      await query.get(object.id);
+    } catch (e) {
       assert.equal(e.code, Parse.Error.OBJECT_NOT_FOUND);
-      done();
-    });
+    }
   });
 
-  it('does not grant public find access with another user acl', (done) => {
-    let user1, user2;
+  it('does not grant public find access with another user acl', async () => {
     const object = new Parse.Object('ThatOneObject');
-    Parse.User.signUp('kkk', 'password').then((u) => {
-      user1 = u;
-      Parse.User.logOut();
+    const user1 = await Parse.User.signUp('kkk', 'password');
+    await Parse.User.logOut();
 
-      return Parse.User.signUp('lll', 'password');
-    }).then((u) => {
-      user2 = u;
-      const acl = new Parse.ACL(user2);
-      acl.setWriteAccess(user1, true);
-      acl.setReadAccess(user1, true);
-      object.setACL(acl);
-      return object.save();
-    }).then(() => {
-      return Parse.User.logOut();
-    }).then(() => {
-      const query = new Parse.Query('ThatOneObject');
-      return query.find();
-    }).then((o) => {
-      assert.equal(o.length, 0);
-      done();
-    });
+    const user2 = await Parse.User.signUp('lll', 'password');
+
+    const acl = new Parse.ACL(user2);
+    acl.setWriteAccess(user1, true);
+    acl.setReadAccess(user1, true);
+    object.setACL(acl);
+    await object.save();
+
+    await Parse.User.logOut();
+
+    const query = new Parse.Query('ThatOneObject');
+    const o = await query.find();
+
+    assert.equal(o.length, 0);
   });
 
-  it('does not grant public update access with another user acl', (done) => {
-    let user1, user2;
+  it('does not grant public update access with another user acl', async () => {
     const object = new TestObject();
-    Parse.User.signUp('mmm', 'password').then((u) => {
-      user1 = u;
-      Parse.User.logOut();
+    const user1 = await Parse.User.signUp('mmm', 'password');
 
-      return Parse.User.signUp('nnn', 'password');
-    }).then((u) => {
-      user2 = u;
-      const acl = new Parse.ACL(user2);
-      acl.setWriteAccess(user1, true);
-      acl.setReadAccess(user1, true);
-      object.setACL(acl);
-      return object.save();
-    }).then(() => {
-      return Parse.User.logOut();
-    }).then(() => {
-      object.set('score', 10);
-      return object.save();
-    }).catch((e) => {
+    await Parse.User.logOut();
+
+    const user2 = await Parse.User.signUp('nnn', 'password');
+    const acl = new Parse.ACL(user2);
+    acl.setWriteAccess(user1, true);
+    acl.setReadAccess(user1, true);
+    object.setACL(acl);
+    await object.save();
+
+    await Parse.User.logOut();
+
+    object.set('score', 10);
+    try {
+      await object.save();
+    } catch (e) {
       assert.equal(e.code, Parse.Error.OBJECT_NOT_FOUND);
-      done();
-    });
+    }
   });
 
-  it('does not grant public destroy access with another user acl', (done) => {
-    let user1, user2;
+  it('does not grant public destroy access with another user acl', async () => {
     const object = new TestObject();
-    Parse.User.signUp('ooo', 'password').then((u) => {
-      user1 = u;
-      Parse.User.logOut();
+    const user1 = await Parse.User.signUp('ooo', 'password');
 
-      return Parse.User.signUp('ppp', 'password');
-    }).then((u) => {
-      user2 = u;
-      const acl = new Parse.ACL(user2);
-      acl.setWriteAccess(user1, true);
-      acl.setReadAccess(user1, true);
-      object.setACL(acl);
-      return object.save();
-    }).then(() => {
-      return Parse.User.logOut();
-    }).then(() => {
-      return object.destroy();
-    }).catch((e) => {
+    await Parse.User.logOut();
+
+    const user2 = await Parse.User.signUp('ppp', 'password');
+
+    const acl = new Parse.ACL(user2);
+    acl.setWriteAccess(user1, true);
+    acl.setReadAccess(user1, true);
+    object.setACL(acl);
+    await object.save();
+
+    await Parse.User.logOut();
+
+    try {
+      await object.destroy();
+    } catch (e) {
       assert.equal(e.code, Parse.Error.OBJECT_NOT_FOUND);
-      done();
-    });
+    }
   });
 
-  it('allows access with an empty acl', (done) => {
-    Parse.User.signUp('tdurden', 'mayhem', {
+  it('allows access with an empty acl', async () => {
+    await Parse.User.signUp('tdurden', 'mayhem', {
       ACL: new Parse.ACL(),
       foo: 'bar'
-    }).then(() => {
-      Parse.User.logOut();
-      return Parse.User.logIn('tdurden', 'mayhem');
-    }).then((user) => {
-      assert.equal(user.get('foo'), 'bar');
-      done();
     });
+    await Parse.User.logOut();
+    const user = await Parse.User.logIn('tdurden', 'mayhem');
+    assert.equal(user.get('foo'), 'bar');
   });
 
-  it('fetches the ACL with included pointers', (done) => {
+  it('fetches the ACL with included pointers', async () => {
     const obj1 = new Parse.Object('TestClass1');
     const obj2 = new Parse.Object('TestClass2');
     const acl = new Parse.ACL();
@@ -598,18 +532,14 @@ describe('Parse.ACL', () => {
     acl.setPublicReadAccess(true);
     obj2.set('ACL', acl);
     obj1.set('other', obj2);
-    obj1.save().then(() => {
-      const query = new Parse.Query('TestClass1');
-      return query.first();
-    }).then((obj1again) => {
-      assert(obj1again);
-      assert(!obj1again.get('other').get('ACL'));
-      const query = new Parse.Query('TestClass1');
-      query.include('other');
-      return query.first();
-    }).then((obj1withInclude) => {
-      assert(obj1withInclude.get('other').get('ACL'));
-      done();
-    }).catch(done.fail);
+    await obj1.save();
+    let query = new Parse.Query('TestClass1');
+    const obj1again = await query.first();
+    assert(obj1again);
+    assert(!obj1again.get('other').get('ACL'));
+    query = new Parse.Query('TestClass1');
+    query.include('other');
+    const obj1withInclude = await query.first();
+    assert(obj1withInclude.get('other').get('ACL'));
   });
 });

--- a/src/__tests__/ParseLiveQuery-test.js
+++ b/src/__tests__/ParseLiveQuery-test.js
@@ -197,6 +197,9 @@ describe('ParseLiveQuery', () => {
       // so we need to give it a chance to complete before finishing
       setTimeout(() => {
         try {
+          client.socket = {
+            send() {}
+          }
           client.connectPromise.resolve();
           const actualSubscription = client.subscriptions.get(1);
 
@@ -236,6 +239,15 @@ describe('ParseLiveQuery', () => {
   });
 
   it('should not throw on usubscribe', (done) => {
+    CoreManager.set('UserController', {
+      currentUserAsync() {
+        return Promise.resolve({
+          getSessionToken() {
+            return 'token';
+          }
+        });
+      }
+    });
     const query = new ParseQuery("ObjectType");
     query.equalTo("test", "value");
     const subscription = new LiveQuerySubscription('0', query, 'token');


### PR DESCRIPTION
* Fixes unhandled promise rejection in LiveQuery-tests
```
(node:5669) UnhandledPromiseRejectionWarning: TypeError: Cannot read property 'send' of undefined
(node:5669) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). 
```

* ParseACLTest weren't waiting for Parse.User.logOut, there were so many I decided to rewrite the tests
```
Failures:
1) Parse.ACL allows logged in get
  Message:
    Unhandled promise rejection: ParseError: 101 Object not found for delete.
  Stack:
    error properties: Object({ code: 101 })
    Error: Object not found for delete.
        at /home/travis/build/parse-community/Parse-SDK-JS/lib/node/RESTController.js:324:19
        at <Jasmine>
        at process._tickDomainCallback (internal/process/next_tick.js:228:7)
2) Parse.ACL allows logged in find
  Message:
    Unhandled promise rejection: ParseError: 107 schema class name does not revalidate
  Stack:
    error properties: Object({ code: 107 })
    Error: schema class name does not revalidate
        at /home/travis/build/parse-community/Parse-SDK-JS/lib/node/RESTController.js:324:19
        at <Jasmine>
        at process._tickDomainCallback (internal/process/next_tick.js:228:7)
3) Parse.ACL allows logged in update
  Message:
    Unhandled promise rejection: ParseError: 107 schema class name does not revalidate
  Stack:
    error properties: Object({ code: 107 })
    Error: schema class name does not revalidate
        at /home/travis/build/parse-community/Parse-SDK-JS/lib/node/RESTController.js:324:19
        at <Jasmine>
        at process._tickDomainCallback (internal/process/next_tick.js:228:7)
4) Parse.ACL allows logged in delete
  Message:
    Unhandled promise rejection: ParseError: 107 schema class name does not revalidate
  Stack:
    error properties: Object({ code: 107 })
    Error: schema class name does not revalidate
        at /home/travis/build/parse-community/Parse-SDK-JS/lib/node/RESTController.js:324:19
        at <Jasmine>
        at process._tickDomainCallback (internal/process/next_tick.js:228:7)
5) Parse.ACL enables get with public read
  Message:
    Unhandled promise rejection: ParseError: 107 schema class name does not revalidate
  Stack:
    error properties: Object({ code: 107 })
    Error: schema class name does not revalidate
        at /home/travis/build/parse-community/Parse-SDK-JS/lib/node/RESTController.js:324:19
        at <Jasmine>
        at process._tickDomainCallback (internal/process/next_tick.js:228:7)
6) Parse.ACL enables find with public read
  Message:
    Unhandled promise rejection: ParseError: 101 Object not found.
  Stack:
    error properties: Object({ code: 101 })
    Error: Object not found.
        at /home/travis/build/parse-community/Parse-SDK-JS/lib/node/RESTController.js:324:19
        at <Jasmine>
        at process._tickDomainCallback (internal/process/next_tick.js:228:7)
7) Parse.ACL does not enable update with public read
  Message:
    Unhandled promise rejection: AssertionError [ERR_ASSERTION]: false == true
  Stack:
    error properties: Object({ generatedMessage: true, code: 'ERR_ASSERTION', actual: false, expected: true, operator: '==' })
        at <Jasmine>
        at user.signUp.then.then.then.then (/home/travis/build/parse-community/Parse-SDK-JS/integration/test/ParseACLTest.js:244:7)
        at <Jasmine>
        at process._tickDomainCallback (internal/process/next_tick.js:228:7)
Pending:
```