### PR TITLE
LiveQuery subscribe with sessionToken

### DIFF
--- a/integration/test/ParseLiveQueryTest.js
+++ b/integration/test/ParseLiveQueryTest.js
@@ -137,7 +137,7 @@ describe('Parse LiveQuery', () => {
     assert.equal(count, 1);
   });
 
-  it('can subscribe to ACL', async () => {
+  it('can subscribe to ACL', async (done) => {
     const user = await Parse.User.signUp('ooo', 'password');
     const ACL = new Parse.ACL(user);
 
@@ -148,14 +148,11 @@ describe('Parse LiveQuery', () => {
     const query = new Parse.Query(TestObject);
     query.equalTo('objectId', object.id);
     const subscription = await query.subscribe(user.getSessionToken());
-    let count = 0;
-    subscription.on('update', object => {
-      count++;
+    subscription.on('update', async (object) => {
       assert.equal(object.get('foo'), 'bar');
+      await Parse.User.logOut();
+      done();
     })
     await object.save({ foo: 'bar' });
-    await sleep(1000);
-    assert.equal(count, 1);
-    await Parse.User.logOut();
   });
 });

--- a/integration/test/ParseLiveQueryTest.js
+++ b/integration/test/ParseLiveQueryTest.js
@@ -156,5 +156,6 @@ describe('Parse LiveQuery', () => {
     await object.save({ foo: 'bar' });
     await sleep(1000);
     assert.equal(count, 1);
+    await Parse.User.logOut();
   });
 });

--- a/src/ParseQuery.js
+++ b/src/ParseQuery.js
@@ -1481,13 +1481,15 @@ class ParseQuery {
   /**
    * Subscribe this query to get liveQuery updates
    *
+   * @param {String} sessionToken (optional) Defaults to the currentUser
    * @return {Promise<LiveQuerySubscription>} Returns the liveQuerySubscription, it's an event emitter
    * which can be used to get liveQuery updates.
    */
-  async subscribe(): Promise<LiveQuerySubscription> {
+  async subscribe(sessionToken?: string): Promise<LiveQuerySubscription> {
     const currentUser = await CoreManager.getUserController().currentUserAsync();
-    const sessionToken =  currentUser ? currentUser.getSessionToken() : undefined;
-
+    if (!sessionToken) {
+      sessionToken =  currentUser ? currentUser.getSessionToken() : undefined;
+    }
     const liveQueryClient = await CoreManager.getLiveQueryController().getDefaultLiveQueryClient();
     if (liveQueryClient.shouldOpen()) {
       liveQueryClient.open();

--- a/src/__tests__/ParseQuery-test.js
+++ b/src/__tests__/ParseQuery-test.js
@@ -2718,4 +2718,31 @@ describe('ParseQuery LocalDatastore', () => {
     expect(subscription.sessionToken).toBeUndefined();
     expect(subscription.query).toEqual(query);
   });
+
+  it('can subscribe to query with sessionToken parameter', async () => {
+    const mockLiveQueryClient = {
+      shouldOpen: function() {
+        return true;
+      },
+      open: function() {},
+      subscribe: function(query, sessionToken) {
+        return new LiveQuerySubscription('0', query, sessionToken);
+      },
+    };
+    CoreManager.set('UserController', {
+      currentUserAsync() {
+        return Promise.resolve(null);
+      }
+    });
+    CoreManager.set('LiveQueryController', {
+      getDefaultLiveQueryClient() {
+        return Promise.resolve(mockLiveQueryClient);
+      }
+    });
+    const query = new ParseQuery('TestObject');
+    const subscription = await query.subscribe('r:test');
+    expect(subscription.id).toBe('0');
+    expect(subscription.sessionToken).toBe('r:test');
+    expect(subscription.query).toEqual(query);
+  });
 });


### PR DESCRIPTION
Adds sessionToken parameter to `query.subscribe()`
As described in the guide for Advanced API https://docs.parseplatform.org/js/guide/#sessiontoken

This is also a failing test for https://github.com/parse-community/Parse-SDK-JS/issues/778

