### PR TITLE
Support _linkWith if no provider exists

### DIFF
--- a/integration/server.js
+++ b/integration/server.js
@@ -21,7 +21,11 @@ const api = new ParseServer({
     },
     facebook: {
       appIds: "test"
-    }
+    },
+    twitter: {
+      consumer_key: "5QiVwxr8FQHbo5CMw46Z0jquF",
+      consumer_secret: "p05FDlIRAnOtqJtjIt0xcw390jCcjj56QMdE9B52iVgOEb7LuK",
+    },
   },
   verbose: false,
   silent: true,

--- a/integration/test/ParseUserTest.js
+++ b/integration/test/ParseUserTest.js
@@ -720,4 +720,52 @@ describe('Parse User', () => {
     expect(Parse.FacebookUtils.isLinked(user)).toBe(false);
     expect(Parse.AnonymousUtils.isLinked(user)).toBe(true);
   });
+
+  it('can link with twitter', async () => {
+    Parse.User.enableUnsafeCurrentUser();
+    const authData = {
+      id: 227463280,
+      consumer_key: "5QiVwxr8FQHbo5CMw46Z0jquF",
+      consumer_secret: "p05FDlIRAnOtqJtjIt0xcw390jCcjj56QMdE9B52iVgOEb7LuK",
+      auth_token: "227463280-k3XC8S5QzfQlOfEdGN8aHWvhWAUpGoLwzsjYQMnt",
+      auth_token_secret: "uLlXKP6djaP9Fc2IdMcp9QqmsouXvDqcYVdUkWdu6pQpM"
+    };
+    const user = new Parse.User();
+    user.setUsername('Alice');
+    user.setPassword('sekrit');
+    await user.signUp();
+
+    await user._linkWith('twitter', { authData });
+
+    expect(user.get('authData').twitter.id).toBe(authData.id);
+    expect(user._isLinked('twitter')).toBe(true);
+
+    await user._unlinkFrom('twitter');
+    expect(user._isLinked('twitter')).toBe(false);
+  });
+
+  it('can link with twitter and facebook', async () => {
+    Parse.User.enableUnsafeCurrentUser();
+    Parse.FacebookUtils.init();
+    const authData = {
+      id: 227463280,
+      consumer_key: "5QiVwxr8FQHbo5CMw46Z0jquF",
+      consumer_secret: "p05FDlIRAnOtqJtjIt0xcw390jCcjj56QMdE9B52iVgOEb7LuK",
+      auth_token: "227463280-k3XC8S5QzfQlOfEdGN8aHWvhWAUpGoLwzsjYQMnt",
+      auth_token_secret: "uLlXKP6djaP9Fc2IdMcp9QqmsouXvDqcYVdUkWdu6pQpM"
+    };
+    const user = new Parse.User();
+    user.setUsername('Alice');
+    user.setPassword('sekrit');
+    await user.signUp();
+
+    await user._linkWith('twitter', { authData });
+    await Parse.FacebookUtils.link(user);
+
+    expect(Parse.FacebookUtils.isLinked(user)).toBe(true);
+    expect(user._isLinked('twitter')).toBe(true);
+
+    expect(user.get('authData').twitter.id).toBe(authData.id);
+    expect(user.get('authData').facebook.id).toBe('test');
+  });
 });

--- a/src/ParseUser.js
+++ b/src/ParseUser.js
@@ -81,7 +81,20 @@ class ParseUser extends ParseObject {
     let authType;
     if (typeof provider === 'string') {
       authType = provider;
-      provider = authProviders[provider];
+      if (authProviders[provider]) {
+        provider = authProviders[provider];
+      } else {
+        const authProvider = {
+          restoreAuthentication() {
+            return true;
+          },
+          getAuthType() {
+            return authType;
+          },
+        };
+        authProviders[authType] = authProvider;
+        provider = authProvider;
+      }
     } else {
       authType = provider.getAuthType();
     }

--- a/src/__tests__/ParseUser-test.js
+++ b/src/__tests__/ParseUser-test.js
@@ -916,4 +916,31 @@ describe('ParseUser', () => {
 
     expect(user.get('authData')).toEqual({ test: { id: 'id', access_token: 'access_token' } });
   });
+
+  it('can linkWith if no provider', async () => {
+    ParseUser._clearCache();
+    CoreManager.setRESTController({
+      request() {
+        return Promise.resolve({
+          objectId: 'uid6',
+          sessionToken: 'r:123abc',
+          authData: {
+            testProvider: {
+              id: 'test',
+            }
+          }
+        }, 200);
+      },
+      ajax() {}
+    });
+    const user = new ParseUser();
+    await user._linkWith('testProvider', { authData: { id: 'test' } });
+    expect(user.get('authData')).toEqual({ testProvider: { id: 'test' } });
+
+    jest.spyOn(user, '_linkWith');
+
+    await user._unlinkFrom('testProvider');
+    const authProvider = user._linkWith.mock.calls[0][0];
+    expect(authProvider.getAuthType()).toBe('testProvider');
+  });
 });


### PR DESCRIPTION
Closes: https://github.com/parse-community/Parse-SDK-JS/issues/770

Registers a basic auth provider if one doesn't exist.

Users won't have to implement their own Authentication Flow that was required and undocumented before.

Adds test case for linking with twitter