### PR TITLE
Allow any Blob to be uploaded

### DIFF
--- a/src/ParseFile.js
+++ b/src/ParseFile.js
@@ -8,7 +8,7 @@
  *
  * @flow
  */
-/* global XMLHttpRequest, File */
+/* global XMLHttpRequest, Blob */
 import CoreManager from './CoreManager';
 import type { FullOptions } from './RESTController';
 
@@ -19,10 +19,10 @@ if (typeof XMLHttpRequest !== 'undefined') {
 
 type Base64 = { base64: string };
 type Uri = { uri: string };
-type FileData = Array<number> | Base64 | File | Uri;
+type FileData = Array<number> | Base64 | Blob | Uri;
 export type FileSource = {
   format: 'file';
-  file: File;
+  file: Blob;
   type: string
 } | {
   format: 'base64';
@@ -109,7 +109,7 @@ class ParseFile {
           base64: this._data,
           type: specifiedType
         };
-      } else if (typeof File !== 'undefined' && data instanceof File) {
+      } else if (typeof Blob !== 'undefined' && data instanceof Blob) {
         this._source = {
           format: 'file',
           file: data,


### PR DESCRIPTION
`File` is a subclass of `Blob` and thus this will still accept any `File` as before.

The benefit of also allowing `Blob` is that those are user-creatable, and you can get them from a `Canvas` if you are e.g. resizing images in the browser before uploading them.