### PR TITLE
Add options for AnonymousUtils

### DIFF
--- a/integration/test/ParseUserTest.js
+++ b/integration/test/ParseUserTest.js
@@ -536,7 +536,6 @@ describe('Parse User', () => {
     Parse.User.enableUnsafeCurrentUser();
 
     await Parse.User.signUp('foobaz', '1234');
-    await Parse.User.logOut();
 
     const user = await Parse.AnonymousUtils.logIn();
     user.set('field', 'hello world');
@@ -550,6 +549,27 @@ describe('Parse User', () => {
     } catch (error) {
       expect(error.message).toBe('Object not found.');
     }
+  });
+
+  it('anonymous user logIn does not use currentUser sessionToken', async () => {
+    Parse.User.enableUnsafeCurrentUser();
+
+    const user1 = await Parse.User.signUp('anon-not', '1234');
+    const user2 = await Parse.AnonymousUtils.logIn();
+    expect(user1.getSessionToken()).toBeDefined();
+    expect(user2.getSessionToken()).toBeDefined();
+    expect(user1.getSessionToken()).not.toBe(user2.getSessionToken());
+  });
+
+  it('facebook logIn does not use currentUser sessionToken', async () => {
+    Parse.User.enableUnsafeCurrentUser();
+    Parse.FacebookUtils.init();
+
+    const user1 = await Parse.User.signUp('facebook-not', '1234');
+    const user2 = await Parse.FacebookUtils.logIn();
+    expect(user1.getSessionToken()).toBeDefined();
+    expect(user2.getSessionToken()).toBeDefined();
+    expect(user1.getSessionToken()).not.toBe(user2.getSessionToken());
   });
 
   it('can signUp user with subclass', async () => {

--- a/src/AnonymousUtils.js
+++ b/src/AnonymousUtils.js
@@ -10,6 +10,7 @@
  */
 import ParseUser from './ParseUser';
 const uuidv4 = require('uuid/v4');
+import type { RequestOptions } from './RESTController';
 
 let registered = false;
 
@@ -62,12 +63,13 @@ const AnonymousUtils = {
    *
    * @method logIn
    * @name Parse.AnonymousUtils.logIn
+   * @param {Object} options MasterKey / SessionToken.
    * @returns {Promise}
    * @static
    */
-  logIn() {
+  logIn(options?: RequestOptions) {
     const provider = this._getAuthProvider();
-    return ParseUser._logInWith(provider.getAuthType(), provider.getAuthData());
+    return ParseUser._logInWith(provider.getAuthType(), provider.getAuthData(), options);
   },
 
   /**
@@ -76,12 +78,13 @@ const AnonymousUtils = {
    * @method link
    * @name Parse.AnonymousUtils.link
    * @param {Parse.User} user User to link. This must be the current user.
+   * @param {Object} options MasterKey / SessionToken.
    * @returns {Promise}
    * @static
    */
-  link(user: ParseUser) {
+  link(user: ParseUser, options?: RequestOptions) {
     const provider = this._getAuthProvider();
-    return user._linkWith(provider.getAuthType(), provider.getAuthData());
+    return user._linkWith(provider.getAuthType(), provider.getAuthData(), options);
   },
 
   _getAuthProvider() {

--- a/src/ParseUser.js
+++ b/src/ParseUser.js
@@ -685,8 +685,8 @@ class ParseUser extends ParseObject {
     return controller.hydrate(userJSON);
   }
 
-  static logInWith(provider: any, options?: RequestOptions) {
-    return ParseUser._logInWith(provider, options);
+  static logInWith(provider: any, options: { authData?: AuthData }, saveOpts?: FullOptions) {
+    return ParseUser._logInWith(provider, options, saveOpts);
   }
 
   /**
@@ -804,9 +804,11 @@ class ParseUser extends ParseObject {
     });
   }
 
-  static _logInWith(provider: any, options?: RequestOptions) {
+  static _logInWith(provider: any, options: { authData?: AuthData }, saveOpts?: FullOptions = {}) {
+    saveOpts.sessionToken = saveOpts.sessionToken || '';
+
     const user = new ParseUser();
-    return user._linkWith(provider, options);
+    return user._linkWith(provider, options, saveOpts);
   }
 
   static _clearCache() {

--- a/src/ParseUser.js
+++ b/src/ParseUser.js
@@ -77,7 +77,8 @@ class ParseUser extends ParseObject {
    * Unlike in the Android/iOS SDKs, logInWith is unnecessary, since you can
    * call linkWith on the user (even if it doesn't exist yet on the server).
    */
-  _linkWith(provider: any, options: { authData?: AuthData }, saveOpts?: FullOptions): Promise<ParseUser> {
+  _linkWith(provider: any, options: { authData?: AuthData }, saveOpts?: FullOptions = {}): Promise<ParseUser> {
+    saveOpts.sessionToken = saveOpts.sessionToken || this.getSessionToken() || '';
     let authType;
     if (typeof provider === 'string') {
       authType = provider;
@@ -804,9 +805,7 @@ class ParseUser extends ParseObject {
     });
   }
 
-  static _logInWith(provider: any, options: { authData?: AuthData }, saveOpts?: FullOptions = {}) {
-    saveOpts.sessionToken = saveOpts.sessionToken || '';
-
+  static _logInWith(provider: any, options: { authData?: AuthData }, saveOpts?: FullOptions) {
     const user = new ParseUser();
     return user._linkWith(provider, options, saveOpts);
   }

--- a/src/__tests__/AnonymousUtils-test.js
+++ b/src/__tests__/AnonymousUtils-test.js
@@ -74,7 +74,7 @@ describe('AnonymousUtils', () => {
     jest.spyOn(user, '_linkWith');
     AnonymousUtils.link(user);
     expect(user._linkWith).toHaveBeenCalledTimes(1);
-    expect(user._linkWith).toHaveBeenCalledWith('anonymous', mockProvider.getAuthData());
+    expect(user._linkWith).toHaveBeenCalledWith('anonymous', mockProvider.getAuthData(), undefined);
     expect(AnonymousUtils._getAuthProvider).toHaveBeenCalledTimes(1);
   });
 
@@ -82,7 +82,7 @@ describe('AnonymousUtils', () => {
     jest.spyOn(MockUser, '_logInWith');
     AnonymousUtils.logIn();
     expect(MockUser._logInWith).toHaveBeenCalledTimes(1);
-    expect(MockUser._logInWith).toHaveBeenCalledWith('anonymous', mockProvider.getAuthData());
+    expect(MockUser._logInWith).toHaveBeenCalledWith('anonymous', mockProvider.getAuthData(), undefined);
     expect(AnonymousUtils._getAuthProvider).toHaveBeenCalledTimes(1);
   });
 });


### PR DESCRIPTION
This PR also addresses an issue.

```
const user1 = await Parse.User.signUp('anon-not', '1234'); // is current user
const user2 = await Parse.AnonymousUtils.logIn(); // request are made with user1 sessionToken
user2.set('foo', 'bar');
// user2 doesn't have a sessionToken because of https://github.com/parse-community/parse-server/pull/5801
// LinkWith sessionToken won't generate new session token
user2.save();
```