### PR TITLE
Fix disappearing SERVER_RENDERING env var

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -29,7 +29,8 @@ var PRESETS = {
   'react-native': ['@babel/preset-react'],
 };
 var PLUGINS = {
-  'browser': [transformRuntime, '@babel/plugin-transform-flow-comments', '@babel/plugin-proposal-class-properties', 'inline-package-json', 'transform-inline-environment-variables'],
+  'browser': [transformRuntime, '@babel/plugin-transform-flow-comments', '@babel/plugin-proposal-class-properties', 'inline-package-json',
+    ['transform-inline-environment-variables', {'exclude': ['SERVER_RENDERING']}]],
   'node': ['@babel/plugin-transform-flow-comments', 'inline-package-json', 'transform-inline-environment-variables'],
   'react-native': ['@babel/plugin-transform-flow-comments', 'inline-package-json', 'transform-inline-environment-variables'],
 };


### PR DESCRIPTION
Getting this warning over and over again in my [Next.JS](https://nextjs.org/) project:

    It looks like you're using the browser version of the SDK in a node.js environment. You should require('parse/node') instead.

Was driving me a bit crazy, as I most certainly do have `SERVER_RENDERING=1` set for my app. I've confirmed this via `console.log()` directly before the `Parse.Initialize()` call.

![image](https://user-images.githubusercontent.com/14284827/61628281-f8947080-acd5-11e9-879e-73c5e00c9387.png)

Looking at my `./node_modules/parse/lib/browser/Parse.js` shows this (odd) line:

    if ("browser" === 'browser' && _CoreManager.default.get('IS_NODE') && !undefined) {
      ...

Given that it's most definitely being written correctly [here](https://github.com/parse-community/Parse-SDK-JS/blob/master/src/Parse.js#L34), I was able to track it down to the slightly misconfigured [env transform plugin](https://www.npmjs.com/package/babel-plugin-transform-inline-environment-variables) you'll see in the diff.

Have confirmed that this is the only variable that needs to be excluded from the 3 different build types (`PARSE_BUILD` is the main target for this inline replacement):

    dev@kidd.life:~/environment/Parse-SDK-JS (master) $ grep -r process.env. . --exclude-dir=node_modules
    ./gulpfile.js:var BUILD = process.env.PARSE_BUILD || 'browser';
    ./src/ParseFile.js:    } else if (process.env.PARSE_BUILD === 'node') {
    ./src/__tests__/ParseFile-test.js:    process.env.PARSE_BUILD = 'node';
    ./src/__tests__/ParseFile-test.js:    process.env.PARSE_BUILD = 'browser';
    ./src/EventEmitter.js:if (process.env.PARSE_BUILD === 'react-native') {
    ./src/Parse.js:    if (process.env.PARSE_BUILD === 'browser' && CoreManager.get('IS_NODE') && !process.env.SERVER_RENDERING) {
    ./src/Parse.js:if (process.env.PARSE_BUILD === 'node') {
    ./src/LiveQueryClient.js:    if (process.env.PARSE_BUILD === 'node') {
    ./src/LiveQueryClient.js:    } else if (process.env.PARSE_BUILD === 'browser') {
    ./src/LiveQueryClient.js:    } else if (process.env.PARSE_BUILD === 'react-native') {
    ./src/LocalDatastore.js:if (process.env.PARSE_BUILD === 'react-native') {
    ./src/LocalDatastore.js:} else if (process.env.PARSE_BUILD === 'browser') {
    ./src/RESTController.js:if (process.env.PARSE_BUILD === 'node') {
    ./src/Storage.js:if (process.env.PARSE_BUILD === 'react-native') {
    ./src/Storage.js:} else if (process.env.PARSE_BUILD === 'browser') {

All tests pass as expected - I didn't touch any actual code.

Here's the full run-down to prove the fix works:

    dev@kidd.life:~/environment/Parse-SDK-JS (master) $ sed -n 34p src/Parse.js
        if (process.env.PARSE_BUILD === 'browser' && CoreManager.get('IS_NODE') && !process.env.SERVER_RENDERING) {
    dev@kidd.life:~/environment/Parse-SDK-JS (master) $ npm run build

    > parse@2.5.1 build /home/ec2-user/environment/Parse-SDK-JS
    > ./build_releases.sh

    Building JavaScript SDK v2.5.1...\n
    Cleaning up old builds...\n
    Browser Release:
    [10:23:38] Using gulpfile ~/environment/Parse-SDK-JS/gulpfile.js
    [10:23:38] Starting 'compile'...
    [10:23:46] Finished 'compile' after 8.06 s
    Node.js Release:
    [10:23:46] Using gulpfile ~/environment/Parse-SDK-JS/gulpfile.js
    [10:23:46] Starting 'compile'...
    [10:23:51] Finished 'compile' after 4.92 s
    React Native Release:
    [10:23:52] Using gulpfile ~/environment/Parse-SDK-JS/gulpfile.js
    [10:23:52] Starting 'compile'...
    [10:23:56] Finished 'compile' after 3.49 s
    Bundling and minifying for CDN distribution:
    [10:23:56] Using gulpfile ~/environment/Parse-SDK-JS/gulpfile.js
    [10:23:56] Starting 'browserify'...
    [10:23:57] Finished 'browserify' after 1.3 s
    [10:23:59] Using gulpfile ~/environment/Parse-SDK-JS/gulpfile.js
    [10:23:59] Starting 'minify'...
    [10:24:03] Finished 'minify' after 4.21 s
    dev@kidd.life:~/environment/Parse-SDK-JS (master) $ sed -n 50p lib/browser/Parse.js
        if ("browser" === 'browser' && _CoreManager.default.get('IS_NODE') && !undefined) {
    dev@kidd.life:~/environment/Parse-SDK-JS (master) $ diff gulpfile.js fixed-gulpfile.js
    32c32,33
    <   'browser': [transformRuntime, '@babel/plugin-transform-flow-comments', '@babel/plugin-proposal-class-properties', 'inline-package-json', 'transform-inline-environment-variables'],
    ---
    >   'browser': [transformRuntime, '@babel/plugin-transform-flow-comments', '@babel/plugin-proposal-class-properties', 'inline-package-json',
    >     ['transform-inline-environment-variables', {'exclude': ['SERVER_RENDERING']}]],
    dev@kidd.life:~/environment/Parse-SDK-JS (master) $ mv fixed-gulpfile.js gulpfile.js
    dev@kidd.life:~/environment/Parse-SDK-JS (master) $ npm run build

    > parse@2.5.1 build /home/ec2-user/environment/Parse-SDK-JS
    > ./build_releases.sh

    Building JavaScript SDK v2.5.1...\n
    Cleaning up old builds...\n
    Browser Release:
    [10:24:43] Using gulpfile ~/environment/Parse-SDK-JS/gulpfile.js
    [10:24:43] Starting 'compile'...
    [10:24:51] Finished 'compile' after 8 s
    Node.js Release:
    [10:24:52] Using gulpfile ~/environment/Parse-SDK-JS/gulpfile.js
    [10:24:52] Starting 'compile'...
    [10:24:57] Finished 'compile' after 4.76 s
    React Native Release:
    [10:24:57] Using gulpfile ~/environment/Parse-SDK-JS/gulpfile.js
    [10:24:57] Starting 'compile'...
    [10:25:01] Finished 'compile' after 3.54 s
    Bundling and minifying for CDN distribution:
    [10:25:02] Using gulpfile ~/environment/Parse-SDK-JS/gulpfile.js
    [10:25:02] Starting 'browserify'...
    [10:25:03] Finished 'browserify' after 1.36 s
    [10:25:04] Using gulpfile ~/environment/Parse-SDK-JS/gulpfile.js
    [10:25:04] Starting 'minify'...
    [10:25:08] Finished 'minify' after 4.26 s
    dev@kidd.life:~/environment/Parse-SDK-JS (master) $ sed -n 50p lib/browser/Parse.js
        if ("browser" === 'browser' && _CoreManager.default.get('IS_NODE') && !process.env.SERVER_RENDERING) {

I haven't created an issue but I'm happy to do so if needed.

**Related:**
* https://github.com/parse-community/Parse-SDK-JS/issues/383
* https://github.com/parse-community/Parse-SDK-JS/pull/384