### PR TITLE
Ensure LiveQuery subscribes

### DIFF
--- a/integration/test/ParseLiveQueryTest.js
+++ b/integration/test/ParseLiveQueryTest.js
@@ -40,15 +40,16 @@ describe('Parse LiveQuery', () => {
     const query = new Parse.Query(TestObject);
     query.equalTo('objectId', object.id);
     const client = await Parse.CoreManager.getLiveQueryController().getDefaultLiveQueryClient();
-    client.open();
+    if (client.shouldOpen()) {
+      client.open();
+    }
     const subscription = client.subscribe(query);
 
     subscription.on('update', object => {
       assert.equal(object.get('foo'), 'bar');
       done();
     });
-    // await subscription.subscribePromise;
-    console.log('here');
+    await subscription.subscribePromise;
     object.set({ foo: 'bar' });
     await object.save();
   });

--- a/integration/test/ParseLiveQueryTest.js
+++ b/integration/test/ParseLiveQueryTest.js
@@ -33,6 +33,26 @@ describe('Parse LiveQuery', () => {
     await object.save();
   });
 
+  it('can subscribe to query with client', async (done) => {
+    const object = new TestObject();
+    await object.save();
+
+    const query = new Parse.Query(TestObject);
+    query.equalTo('objectId', object.id);
+    const client = await Parse.CoreManager.getLiveQueryController().getDefaultLiveQueryClient();
+    client.open();
+    const subscription = client.subscribe(query);
+
+    subscription.on('update', object => {
+      assert.equal(object.get('foo'), 'bar');
+      done();
+    });
+    // await subscription.subscribePromise;
+    console.log('here');
+    object.set({ foo: 'bar' });
+    await object.save();
+  });
+
   it('can subscribe to multiple queries', async () => {
     const objectA = new TestObject();
     const objectB = new TestObject();

--- a/src/LiveQueryClient.js
+++ b/src/LiveQueryClient.js
@@ -178,9 +178,9 @@ class LiveQueryClient extends EventEmitter {
    *
    * @param {Object} query - the ParseQuery you want to subscribe to
    * @param {string} sessionToken (optional)
-   * @return {Promise<LiveQuerySubscription>} subscription
+   * @return {LiveQuerySubscription} subscription
    */
-  subscribe(query: Object, sessionToken: ?string): Promise<LiveQuerySubscription> {
+  subscribe(query: Object, sessionToken: ?string): LiveQuerySubscription {
     if (!query) {
       return;
     }
@@ -208,9 +208,8 @@ class LiveQueryClient extends EventEmitter {
     this.connectPromise.then(() => {
       this.socket.send(JSON.stringify(subscribeRequest));
     });
-    return subscription.subscribePromise.then(() => {
-      return subscription;
-    });
+
+    return subscription;
   }
 
   /**
@@ -440,7 +439,7 @@ class LiveQueryClient extends EventEmitter {
 
     // handle case when both close/error occur at frequent rates we ensure we do not reconnect unnecessarily.
     // we're unable to distinguish different between close/error when we're unable to reconnect therefore
-    // we try to reonnect in both cases
+    // we try to reconnect in both cases
     // server side ws and browser WebSocket behave differently in when close/error get triggered
 
     if (this.reconnectHandle) {

--- a/src/LiveQueryClient.js
+++ b/src/LiveQueryClient.js
@@ -360,7 +360,6 @@ class LiveQueryClient extends EventEmitter {
       break;
     case OP_EVENTS.SUBSCRIBED:
       if (subscription) {
-        console.log(subscription);
         subscription.subscribed = true;
         subscription.subscribePromise.resolve();
         subscription.emit(SUBSCRIPTION_EMMITER_TYPES.OPEN);

--- a/src/LiveQuerySubscription.js
+++ b/src/LiveQuerySubscription.js
@@ -10,6 +10,7 @@
 
 import EventEmitter from './EventEmitter';
 import CoreManager from './CoreManager';
+import { resolvingPromise } from './promiseUtils';
 
 /**
  * Creates a new LiveQuery Subscription.
@@ -101,6 +102,8 @@ class Subscription extends EventEmitter {
     this.id = id;
     this.query = query;
     this.sessionToken = sessionToken;
+    this.subscribePromise = resolvingPromise();
+    this.subscribed = false;
 
     // adding listener so process does not crash
     // best practice is for developer to register their own listener

--- a/src/ParseQuery.js
+++ b/src/ParseQuery.js
@@ -1618,7 +1618,9 @@ class ParseQuery {
       liveQueryClient.open();
     }
     const subscription = liveQueryClient.subscribe(this, sessionToken);
-    return subscription;
+    return subscription.subscribePromise.then(() => {
+      return subscription;
+    });
   }
 
   /**

--- a/src/__tests__/LiveQueryClient-test.js
+++ b/src/__tests__/LiveQueryClient-test.js
@@ -214,6 +214,39 @@ describe('LiveQueryClient', () => {
     expect(isChecked).toBe(true);
   });
 
+  it('can handle WebSocket error while subscribing', () => {
+    const liveQueryClient = new LiveQueryClient({
+      applicationId: 'applicationId',
+      serverURL: 'ws://test',
+      javascriptKey: 'javascriptKey',
+      masterKey: 'masterKey',
+      sessionToken: 'sessionToken'
+    });
+    const subscription = new events.EventEmitter();
+    subscription.subscribePromise = resolvingPromise();
+    liveQueryClient.subscriptions.set(1, subscription);
+
+    const data = {
+      op: 'error',
+      clientId: 1,
+      requestId: 1,
+      error: 'error thrown'
+    };
+    const event = {
+      data: JSON.stringify(data)
+    }
+    // Register checked in advance
+    let isChecked = false;
+    subscription.on('error', function(error) {
+      isChecked = true;
+      expect(error).toEqual('error thrown');
+    });
+
+    liveQueryClient._handleWebSocketMessage(event);
+
+    expect(isChecked).toBe(true);
+  });
+
   it('can handle WebSocket event response message', () => {
     const liveQueryClient = new LiveQueryClient({
       applicationId: 'applicationId',

--- a/src/__tests__/ParseQuery-test.js
+++ b/src/__tests__/ParseQuery-test.js
@@ -2849,7 +2849,9 @@ describe('ParseQuery LocalDatastore', () => {
         return false;
       },
       subscribe: function(query, sessionToken) {
-        return new LiveQuerySubscription('0', query, sessionToken);
+        const subscription = new LiveQuerySubscription('0', query, sessionToken);
+        subscription.subscribePromise.resolve();
+        return subscription;
       },
     };
     CoreManager.set('UserController', {
@@ -2880,7 +2882,9 @@ describe('ParseQuery LocalDatastore', () => {
       },
       open: function() {},
       subscribe: function(query, sessionToken) {
-        return new LiveQuerySubscription('0', query, sessionToken);
+        const subscription = new LiveQuerySubscription('0', query, sessionToken);
+        subscription.subscribePromise.resolve();
+        return subscription;
       },
     };
     CoreManager.set('UserController', {
@@ -2911,7 +2915,9 @@ describe('ParseQuery LocalDatastore', () => {
       },
       open: function() {},
       subscribe: function(query, sessionToken) {
-        return new LiveQuerySubscription('0', query, sessionToken);
+        const subscription = new LiveQuerySubscription('0', query, sessionToken);
+        subscription.subscribePromise.resolve();
+        return subscription;
       },
     };
     CoreManager.set('UserController', {
@@ -2938,7 +2944,9 @@ describe('ParseQuery LocalDatastore', () => {
       },
       open: function() {},
       subscribe: function(query, sessionToken) {
-        return new LiveQuerySubscription('0', query, sessionToken);
+        const subscription = new LiveQuerySubscription('0', query, sessionToken);
+        subscription.subscribePromise.resolve();
+        return subscription;
       },
     };
     CoreManager.set('UserController', {


### PR DESCRIPTION
Its a known issue that query.subscribe instantly returns a subscription without waiting until it subscribes. This PR fixes that.

This PR will make it easier to write Live Query tests on Parse Server.

