### PR TITLE
feat(ParseObject): Add option `cascadeSave` to save()

### DIFF
--- a/integration/test/ParseObjectTest.js
+++ b/integration/test/ParseObjectTest.js
@@ -941,7 +941,7 @@ describe('Parse Object', () => {
     const parent = new Parent();
     const child1 = new Child();
     const child2 = new Child();
-    const child3 = await new Child().save();
+    const child3 = new Child();
 
     child1.set('name', 'rob');
     child2.set('name', 'sansa');
@@ -949,32 +949,24 @@ describe('Parse Object', () => {
     parent.set('children', [child1, child2]);
     parent.set('bastard', child3);
 
-    await parent.save(null, { cascadeSave: false });
-    const results = await new Parse.Query(Child)
-      .ascending('name')
-      .find();
+    expect(parent.save).toThrow();
+    let results = await new Parse.Query(Child).find();
+    assert.equal(results.length, 0);
 
+    await parent.save(null, { cascadeSave: true });
+    results = await new Parse.Query(Child).find();
     assert.equal(results.length, 3);
-    expect(results[0].get('name')).toBeUndefined();
-    assert.equal(results[1].get('name'), 'rob');
-    assert.equal(results[2].get('name'), 'sansa');
 
     parent.set('dead', true);
     child1.set('dead', true);
     await parent.save(null);
-    const rob = await new Parse.Query(Child)
-      .equalTo('name', 'rob')
-      .first();
-
+    const rob = await new Parse.Query(Child).equalTo('name', 'rob').first();
     expect(rob.get('dead')).toBe(true);
 
     parent.set('lastname', 'stark');
     child3.set('lastname', 'stark');
     await parent.save(null, { cascadeSave: false });
-    const john = await new Parse.Query(Child)
-      .doesNotExist('lastname')
-      .first();
-
+    const john = await new Parse.Query(Child).doesNotExist('lastname').first();
     expect(john.get('lastname')).toBeUndefined();
 
     done();

--- a/src/ParseObject.js
+++ b/src/ParseObject.js
@@ -54,6 +54,10 @@ type SaveParams = {
   body: AttributeMap;
 };
 
+type SaveOptions = FullOptions & {
+  cascadeSave?: boolean
+}
+
 const DEFAULT_BATCH_SIZE = 20;
 
 // Mapping of class names to constructors, so we can populate objects from the
@@ -1131,6 +1135,7 @@ class ParseObject {
    *     be used for this request.
    *       <li>sessionToken: A valid session token, used for making a request on
    *       behalf of a specific user.
+   *       <li>cascadeSave: If `false`, nested objects will not be saved (default is `true`).
    *     </ul>
    *   </li>
    * </ul>
@@ -1143,6 +1148,7 @@ class ParseObject {
    *       be used for this request.
    *   <li>sessionToken: A valid session token, used for making a request on
    *       behalf of a specific user.
+   *   <li>cascadeSave: If `false`, nested objects will not be saved (default is `true`).
    * </ul>
    *
    * @return {Promise} A promise that is fulfilled when the save
@@ -1150,8 +1156,8 @@ class ParseObject {
    */
   save(
     arg1: ?string | { [attr: string]: mixed },
-    arg2: FullOptions | mixed,
-    arg3?: FullOptions
+    arg2: SaveOptions | mixed,
+    arg3?: SaveOptions
   ): Promise {
     let attrs;
     let options;
@@ -1200,7 +1206,8 @@ class ParseObject {
       saveOptions.sessionToken = options.sessionToken;
     }
     const controller = CoreManager.getObjectController();
-    const unsaved = unsavedChildren(this);
+    let unsaved = unsavedChildren(this);
+    unsaved = unsaved.filter(o => o._localId || options.cascadeSave !== false);
     return controller.save(unsaved, saveOptions).then(() => {
       return controller.save(this, saveOptions);
     });

--- a/src/ParseObject.js
+++ b/src/ParseObject.js
@@ -1206,8 +1206,7 @@ class ParseObject {
       saveOptions.sessionToken = options.sessionToken;
     }
     const controller = CoreManager.getObjectController();
-    let unsaved = unsavedChildren(this);
-    unsaved = unsaved && unsaved.filter(o => o._localId || options.cascadeSave !== false) || [];
+    const unsaved = options.cascadeSave !== false ? unsavedChildren(this) : null;
     return controller.save(unsaved, saveOptions).then(() => {
       return controller.save(this, saveOptions);
     });

--- a/src/ParseObject.js
+++ b/src/ParseObject.js
@@ -1207,7 +1207,7 @@ class ParseObject {
     }
     const controller = CoreManager.getObjectController();
     let unsaved = unsavedChildren(this);
-    unsaved = unsaved.filter(o => o._localId || options.cascadeSave !== false);
+    unsaved = unsaved && unsaved.filter(o => o._localId || options.cascadeSave !== false) || [];
     return controller.save(unsaved, saveOptions).then(() => {
       return controller.save(this, saveOptions);
     });


### PR DESCRIPTION
The new feature can be used to prevent cascade saving in nested objects (Only ignores objects that have already been saved previously):

```
parentObject.save(null, { cascadeSave: false });  // Child objects will not be saved (again)
```

Closes #864