### PR TITLE
UserSubclass.become should return subclass

### DIFF
--- a/integration/test/ParseUserTest.js
+++ b/integration/test/ParseUserTest.js
@@ -658,6 +658,17 @@ describe('Parse User', () => {
     expect(user.doSomething()).toBe(5);
   });
 
+  it('can become user with subclass static', async () => {
+    Parse.User.enableUnsafeCurrentUser();
+
+    let user = await CustomUser.signUp('username', 'password');
+    const token = user.getSessionToken();
+
+    user = await CustomUser.become(token)
+    expect(user instanceof CustomUser).toBe(true);
+    expect(user.doSomething()).toBe(5);
+  });
+
   it('can link without master key', async () => {
     Parse.User.enableUnsafeCurrentUser();
 

--- a/src/ParseUser.js
+++ b/src/ParseUser.js
@@ -649,7 +649,8 @@ class ParseUser extends ParseObject {
     }
 
     const controller = CoreManager.getUserController();
-    return controller.become(becomeOptions);
+    const user = new this();
+    return controller.become(user, becomeOptions);
   }
 
   /**
@@ -990,8 +991,7 @@ const DefaultController = {
     });
   },
 
-  become(options: RequestOptions): Promise<ParseUser> {
-    const user = new ParseUser();
+  become(user: ParseUser, options: RequestOptions): Promise<ParseUser> {
     const RESTController = CoreManager.getRESTController();
     return RESTController.request(
       'GET', 'users/me', {}, options


### PR DESCRIPTION
This is a follow-up to https://github.com/parse-community/Parse-SDK-JS/pull/756 to add the same functionality to `become`.

Let me know if there's anything I'm missing.