### PR TITLE
Fix EventEmitter crash in react-native for v0.61.+ version

### DIFF
--- a/src/EventEmitter.js
+++ b/src/EventEmitter.js
@@ -10,7 +10,7 @@
  */
 
 if (process.env.PARSE_BUILD === 'react-native') {
-  const EventEmitter = require('EventEmitter');
+  const EventEmitter = require('../../../react-native/Libraries/vendor/emitter/EventEmitter');
   EventEmitter.prototype.on = EventEmitter.prototype.addListener;
   module.exports = EventEmitter;
 } else {


### PR DESCRIPTION
This fix the crash when try to require EventEmitter on 0.61 react-native version

Related issue #936 