### PR TITLE
Support Parse.File getData cancel

### DIFF
--- a/integration/test/ParseFileTest.js
+++ b/integration/test/ParseFileTest.js
@@ -39,6 +39,16 @@ describe('Parse.File', () => {
     assert.equal(file2.url(), result.get('file2').url());
   });
 
+  it('can cancel save file with uri', async () => {
+    const parseLogo = 'https://raw.githubusercontent.com/parse-community/parse-server/master/.github/parse-server-logo.png';
+    const file = new Parse.File('parse-server-logo', { uri: parseLogo });
+    file.save().then(() => {
+      assert.equal(file.name(), undefined);
+      assert.equal(file.url(), undefined);
+    });
+    file.cancel();
+  });
+
   it('can not get data from unsaved file', async () => {
     const file = new Parse.File('parse-server-logo', [61, 170, 236, 120]);
     file._data = null;

--- a/src/ParseFile.js
+++ b/src/ParseFile.js
@@ -259,6 +259,9 @@ class ParseFile {
     }
   }
 
+  /**
+   * Aborts the request if it has already been sent.
+   */
   cancel() {
     if (this._requestTask && typeof this._requestTask.abort === 'function') {
       this._requestTask.abort();
@@ -403,7 +406,6 @@ const DefaultController = {
           base64: ParseFile.encodeBase64(bytes),
           contentType: xhr.getResponseHeader('content-type'),
         });
-      };
       };
       options.requestTask(xhr);
       xhr.send();

--- a/src/ParseFile.js
+++ b/src/ParseFile.js
@@ -228,7 +228,7 @@ class ParseFile {
         });
       } else if (this._source.format === 'uri') {
         this._previousSave = controller.download(this._source.uri, options).then((result) => {
-          if (!result || !result.base64) {
+          if (!(result && result.base64)) {
             return {};
           }
           const newSource = {

--- a/src/Xhr.weapp.js
+++ b/src/Xhr.weapp.js
@@ -48,6 +48,7 @@ module.exports = class XhrWeapp {
     }
     this.requestTask.abort();
     this.status = 0;
+    this.response = undefined;
     this.onabort();
     this.onreadystatechange();
   }

--- a/src/Xhr.weapp.js
+++ b/src/Xhr.weapp.js
@@ -1,7 +1,13 @@
 module.exports = class XhrWeapp {
   constructor() {
+    this.UNSENT = 0;
+    this.OPENED = 1;
+    this.HEADERS_RECEIVED = 2;
+    this.LOADING = 3;
+    this.DONE = 4;
+
     this.header = {};
-    this.readyState = 4;
+    this.readyState = this.DONE;
     this.status = 0;
     this.response = '';
     this.responseType = '';

--- a/src/__tests__/ParseConfig-test.js
+++ b/src/__tests__/ParseConfig-test.js
@@ -130,7 +130,6 @@ describe('ParseConfig', () => {
   it('can save a config object that be retrieved with masterkey only', async () => {
     CoreManager.setRESTController({
       request(method, path, body, options) {
-        console.log(method, path, body, options);
         if (method === 'PUT') {
           expect(method).toBe('PUT');
           expect(path).toBe('config');

--- a/src/__tests__/ParseFile-test.js
+++ b/src/__tests__/ParseFile-test.js
@@ -423,7 +423,7 @@ describe('FileController', () => {
     spy.mockRestore();
   });
 
-  fit('download with ajax', async () => {
+  it('download with ajax', async () => {
     const mockXHR = function () {
       return {
         DONE: 4,

--- a/src/__tests__/ParseFile-test.js
+++ b/src/__tests__/ParseFile-test.js
@@ -423,9 +423,10 @@ describe('FileController', () => {
     spy.mockRestore();
   });
 
-  it('download with ajax', async () => {
+  fit('download with ajax', async () => {
     const mockXHR = function () {
       return {
+        DONE: 4,
         open: jest.fn(),
         send: jest.fn().mockImplementation(function() {
           this.response = [61, 170, 236, 120];
@@ -461,7 +462,8 @@ describe('FileController', () => {
           return 'image/png';
         },
         abort: function() {
-          this.onabort();
+          this.status = 0;
+          this.response = undefined;
           this.readyState = 4;
           this.onreadystatechange()
         }


### PR DESCRIPTION
Allow to cancel downloading file data or uploading via uri (uri is first downloaded to base64 then uploaded to the server).