### PR TITLE
Fix: Remove options from Parse.Schema

### DIFF
--- a/src/ParseSchema.js
+++ b/src/ParseSchema.js
@@ -10,7 +10,6 @@
  */
 
 import CoreManager from './CoreManager';
-import type { RequestOptions, FullOptions } from './RESTController';
 
 const FIELD_TYPES = ['String', 'Number', 'Boolean', 'Date', 'File', 'GeoPoint', 'Polygon', 'Array', 'Object', 'Pointer', 'Relation'];
 
@@ -21,7 +20,7 @@ const FIELD_TYPES = ['String', 'Number', 'Boolean', 'Date', 'File', 'GeoPoint', 
  * <pre>
  * const schema = new Parse.Schema('MyClass');
  * schema.addString('field');
- * schema.addIndex('index_name', {'field', 1});
+ * schema.addIndex('index_name', { 'field': 1 });
  * schema.save();
  * </pre>
  * </p>
@@ -51,22 +50,12 @@ class ParseSchema {
   /**
    * Static method to get all schemas
    *
-   * @param {Object} options
-   * Valid options are:<ul>
-   *   <li>useMasterKey: In Cloud Code and Node only, causes the Master Key to
-   *     be used for this request.
-   *   <li>sessionToken: A valid session token, used for making a request on
-   *       behalf of a specific user.
-   * </ul>
-   *
    * @return {Promise} A promise that is resolved with the result when
    * the query completes.
    */
-  static all(options: FullOptions) {
-    options = options || {};
+  static all() {
     const controller = CoreManager.getSchemaController();
-
-    return controller.get('', options)
+    return controller.get('')
       .then((response) => {
         if (response.results.length === 0) {
           throw new Error('Schema not found.');
@@ -78,24 +67,14 @@ class ParseSchema {
   /**
    * Get the Schema from Parse
    *
-   * @param {Object} options
-   * Valid options are:<ul>
-   *   <li>useMasterKey: In Cloud Code and Node only, causes the Master Key to
-   *     be used for this request.
-   *   <li>sessionToken: A valid session token, used for making a request on
-   *       behalf of a specific user.
-   * </ul>
-   *
    * @return {Promise} A promise that is resolved with the result when
    * the query completes.
    */
-  get(options: FullOptions) {
+  get() {
     this.assertClassName();
 
-    options = options || {};
     const controller = CoreManager.getSchemaController();
-
-    return controller.get(this.className, options)
+    return controller.get(this.className)
       .then((response) => {
         if (!response) {
           throw new Error('Schema not found.');
@@ -107,21 +86,12 @@ class ParseSchema {
   /**
    * Create a new Schema on Parse
    *
-   * @param {Object} options
-   * Valid options are:<ul>
-   *   <li>useMasterKey: In Cloud Code and Node only, causes the Master Key to
-   *     be used for this request.
-   *   <li>sessionToken: A valid session token, used for making a request on
-   *       behalf of a specific user.
-   * </ul>
-   *
    * @return {Promise} A promise that is resolved with the result when
    * the query completes.
    */
-  save(options: FullOptions) {
+  save() {
     this.assertClassName();
 
-    options = options || {};
     const controller = CoreManager.getSchemaController();
     const params = {
       className: this.className,
@@ -129,30 +99,18 @@ class ParseSchema {
       indexes: this._indexes,
     };
 
-    return controller.create(this.className, params, options)
-      .then((response) => {
-        return response;
-      });
+    return controller.create(this.className, params);
   }
 
   /**
    * Update a Schema on Parse
    *
-   * @param {Object} options
-   * Valid options are:<ul>
-   *   <li>useMasterKey: In Cloud Code and Node only, causes the Master Key to
-   *     be used for this request.
-   *   <li>sessionToken: A valid session token, used for making a request on
-   *       behalf of a specific user.
-   * </ul>
-   *
    * @return {Promise} A promise that is resolved with the result when
    * the query completes.
    */
-  update(options: FullOptions) {
+  update() {
     this.assertClassName();
 
-    options = options || {};
     const controller = CoreManager.getSchemaController();
     const params = {
       className: this.className,
@@ -163,37 +121,21 @@ class ParseSchema {
     this._fields = {};
     this._indexes = {};
 
-    return controller.update(this.className, params, options)
-      .then((response) => {
-        return response;
-      });
+    return controller.update(this.className, params);
   }
 
   /**
    * Removing a Schema from Parse
    * Can only be used on Schema without objects
    *
-   * @param {Object} options
-   * Valid options are:<ul>
-   *   <li>useMasterKey: In Cloud Code and Node only, causes the Master Key to
-   *     be used for this request.
-   *   <li>sessionToken: A valid session token, used for making a request on
-   *       behalf of a specific user.
-   * </ul>
-   *
    * @return {Promise} A promise that is resolved with the result when
    * the query completes.
    */
-  delete(options: FullOptions) {
+  delete() {
     this.assertClassName();
 
-    options = options || {};
     const controller = CoreManager.getSchemaController();
-
-    return controller.delete(this.className, options)
-      .then((response) => {
-        return response;
-      });
+    return controller.delete(this.className);
   }
 
   /**
@@ -206,11 +148,7 @@ class ParseSchema {
     this.assertClassName();
 
     const controller = CoreManager.getSchemaController();
-
-    return controller.purge(this.className)
-      .then((response) => {
-        return response;
-      });
+    return controller.purge(this.className);
   }
 
   /**
@@ -425,34 +363,30 @@ class ParseSchema {
 }
 
 const DefaultController = {
-  send(className: string, method: string, params: any, options: RequestOptions): Promise {
+  send(className: string, method: string, params: any): Promise {
     const RESTController = CoreManager.getRESTController();
-    const requestOptions = { useMasterKey: true };
-    if (options.hasOwnProperty('sessionToken')) {
-      requestOptions.sessionToken = options.sessionToken;
-    }
     return RESTController.request(
       method,
       `schemas/${className}`,
       params,
-      requestOptions
+      { useMasterKey: true }
     );
   },
 
-  get(className: string, options: RequestOptions): Promise {
-    return this.send(className, 'GET', {}, options);
+  get(className: string): Promise {
+    return this.send(className, 'GET', {});
   },
 
-  create(className: string, params: any, options: RequestOptions): Promise {
-    return this.send(className, 'POST', params, options);
+  create(className: string, params: any): Promise {
+    return this.send(className, 'POST', params);
   },
 
-  update(className: string, params: any, options: RequestOptions): Promise {
-    return this.send(className, 'PUT', params, options);
+  update(className: string, params: any): Promise {
+    return this.send(className, 'PUT', params);
   },
 
-  delete(className: string, options: RequestOptions): Promise {
-    return this.send(className, 'DELETE', {}, options);
+  delete(className: string): Promise {
+    return this.send(className, 'DELETE', {});
   },
 
   purge(className: string): Promise {

--- a/src/ParseSchema.js
+++ b/src/ParseSchema.js
@@ -363,7 +363,7 @@ class ParseSchema {
 }
 
 const DefaultController = {
-  send(className: string, method: string, params: any): Promise {
+  send(className: string, method: string, params: any = {}): Promise {
     const RESTController = CoreManager.getRESTController();
     return RESTController.request(
       method,
@@ -374,7 +374,7 @@ const DefaultController = {
   },
 
   get(className: string): Promise {
-    return this.send(className, 'GET', {});
+    return this.send(className, 'GET');
   },
 
   create(className: string, params: any): Promise {
@@ -386,7 +386,7 @@ const DefaultController = {
   },
 
   delete(className: string): Promise {
-    return this.send(className, 'DELETE', {});
+    return this.send(className, 'DELETE');
   },
 
   purge(className: string): Promise {

--- a/src/__tests__/ParseSchema-test.js
+++ b/src/__tests__/ParseSchema-test.js
@@ -170,14 +170,13 @@ describe('ParseSchema', () => {
       update() {},
       delete() {},
       purge() {},
-      create(className, params, options) {
+      create(className, params) {
         expect(className).toBe('SchemaTest');
         expect(params).toEqual({
           className: 'SchemaTest',
           fields: { name: { type: 'String'} },
           indexes: { testIndex: { name: 1 } }
         });
-        expect(options).toEqual({});
         return Promise.resolve([]);
       },
     });
@@ -198,14 +197,13 @@ describe('ParseSchema', () => {
       create() {},
       delete() {},
       purge() {},
-      update(className, params, options) {
+      update(className, params) {
         expect(className).toBe('SchemaTest');
         expect(params).toEqual({
           className: 'SchemaTest',
           fields: { name: { type: 'String'} },
           indexes: { testIndex: { name: 1 } }
         });
-        expect(options).toEqual({});
         return Promise.resolve([]);
       },
     });
@@ -226,9 +224,8 @@ describe('ParseSchema', () => {
       update() {},
       get() {},
       purge() {},
-      delete(className, options) {
+      delete(className) {
         expect(className).toBe('SchemaTest');
-        expect(options).toEqual({});
         return Promise.resolve([]);
       },
     });
@@ -267,36 +264,14 @@ describe('ParseSchema', () => {
       update() {},
       delete() {},
       purge() {},
-      get(className, options) {
+      get(className) {
         expect(className).toBe('SchemaTest');
-        expect(options).toEqual({});
         return Promise.resolve([]);
       },
     });
 
     const schema = new ParseSchema('SchemaTest');
     schema.get().then((results) => {
-      expect(results).toEqual([]);
-      done();
-    });
-  });
-
-  it('can get schema with options', (done) => {
-    CoreManager.setSchemaController({
-      send() {},
-      create() {},
-      update() {},
-      delete() {},
-      purge() {},
-      get(className, options) {
-        expect(className).toBe('SchemaTest');
-        expect(options).toEqual({ sessionToken: 1234 });
-        return Promise.resolve([]);
-      },
-    });
-
-    const schema = new ParseSchema('SchemaTest');
-    schema.get({ sessionToken: 1234 }).then((results) => {
       expect(results).toEqual([]);
       done();
     });
@@ -309,9 +284,8 @@ describe('ParseSchema', () => {
       update() {},
       delete() {},
       purge() {},
-      get(className, options) {
+      get(className) {
         expect(className).toBe('SchemaTest');
-        expect(options).toEqual({});
         return Promise.resolve(null);
       },
     });
@@ -334,9 +308,8 @@ describe('ParseSchema', () => {
       update() {},
       delete() {},
       purge() {},
-      get(className, options) {
+      get(className) {
         expect(className).toBe('');
-        expect(options).toEqual({});
         return Promise.resolve({
           results: ['all']
         });
@@ -349,28 +322,6 @@ describe('ParseSchema', () => {
     });
   });
 
-  it('can get all schema with options', (done) => {
-    CoreManager.setSchemaController({
-      send() {},
-      create() {},
-      update() {},
-      delete() {},
-      purge() {},
-      get(className, options) {
-        expect(className).toBe('');
-        expect(options).toEqual({ sessionToken: 1234 });
-        return Promise.resolve({
-          results: ['all']
-        });
-      },
-    });
-
-    ParseSchema.all({ sessionToken: 1234 }).then((results) => {
-      expect(results[0]).toEqual('all');
-      done();
-    });
-  });
-
   it('cannot get all schema when empty', (done) => {
     CoreManager.setSchemaController({
       send() {},
@@ -378,9 +329,8 @@ describe('ParseSchema', () => {
       update() {},
       delete() {},
       purge() {},
-      get(className, options) {
+      get(className) {
         expect(className).toBe('');
-        expect(options).toEqual({});
         return Promise.resolve({
           results: []
         });
@@ -408,14 +358,6 @@ describe('SchemaController', () => {
       return Promise.resolve([]);
     };
     CoreManager.setRESTController({ request: request, ajax: ajax });
-  });
-
-  it('save schema with sessionToken', (done) => {
-    const schema = new ParseSchema('SchemaTest');
-    schema.save({ sessionToken: 1234 }).then((results) => {
-      expect(results).toEqual([]);
-      done();
-    });
   });
 
   it('get schema', (done) => {

--- a/src/__tests__/ParseSchema-test.js
+++ b/src/__tests__/ParseSchema-test.js
@@ -360,6 +360,14 @@ describe('SchemaController', () => {
     CoreManager.setRESTController({ request: request, ajax: ajax });
   });
 
+  it('save schema', (done) => {
+    const schema = new ParseSchema('SchemaTest');
+    schema.save().then((results) => {
+      expect(results).toEqual([]);
+      done();
+    });
+  });
+
   it('get schema', (done) => {
     const schema = new ParseSchema('SchemaTest');
     schema.get().then((results) => {


### PR DESCRIPTION
Closes: https://github.com/parse-community/Parse-SDK-JS/issues/941

Fixes Documentation.

`useMasterKey: true` is sent with every Parse.Schema request so passing it and sessionToken as a parameter is redundant.

https://github.com/parse-community/parse-server/blob/master/src/Routers/SchemasRouter.js#L124