### PR TITLE
Set Class Level Permission via Parse.Schema

### DIFF
--- a/integration/test/ParseSchemaTest.js
+++ b/integration/test/ParseSchemaTest.js
@@ -2,6 +2,28 @@ const assert = require('assert');
 const clear = require('./clear');
 const Parse = require('../../node');
 
+const emptyCLPS = {
+  find: {},
+  count: {},
+  get: {},
+  create: {},
+  update: {},
+  delete: {},
+  addField: {},
+  protectedFields: {},
+};
+
+const defaultCLPS = {
+  find: { '*': true },
+  count: { '*': true },
+  get: { '*': true },
+  create: { '*': true },
+  update: { '*': true },
+  delete: { '*': true },
+  addField: { '*': true },
+  protectedFields: { '*': [] },
+};
+
 describe('Schema', () => {
   beforeAll(() => {
     Parse.initialize('integration');
@@ -80,6 +102,47 @@ describe('Schema', () => {
       assert.equal(results.length, 1);
       done();
     });
+  });
+
+  it('save class level permissions', async () => {
+    const clp = {
+      get: { requiresAuthentication: true },
+      find: {},
+      count: {},
+      create: { '*': true },
+      update: { requiresAuthentication: true },
+      delete: {},
+      addField: {},
+      protectedFields: {}
+    };
+    const testSchema = new Parse.Schema('SchemaTest');
+    testSchema.setCLP(clp);
+    const schema = await testSchema.save();
+    assert.deepEqual(schema.classLevelPermissions, clp);
+  });
+
+  it('update class level permissions', async () => {
+    const clp = {
+      get: { requiresAuthentication: true },
+      find: {},
+      count: {},
+      create: { '*': true },
+      update: { requiresAuthentication: true },
+      delete: {},
+      addField: {},
+      protectedFields: {}
+    };
+    const testSchema = new Parse.Schema('SchemaTest');
+    let schema = await testSchema.save();
+    assert.deepEqual(schema.classLevelPermissions, defaultCLPS);
+
+    testSchema.setCLP(clp);
+    schema = await testSchema.update();
+    assert.deepEqual(schema.classLevelPermissions, clp);
+
+    testSchema.setCLP({});
+    schema = await testSchema.update();
+    assert.deepEqual(schema.classLevelPermissions, emptyCLPS);
   });
 
   it('update', (done) => {

--- a/integration/test/ParseSchemaTest.js
+++ b/integration/test/ParseSchemaTest.js
@@ -136,6 +136,10 @@ describe('Schema', () => {
     let schema = await testSchema.save();
     assert.deepEqual(schema.classLevelPermissions, defaultCLPS);
 
+    testSchema.setCLP(1234);
+    schema = await testSchema.update();
+    assert.deepEqual(schema.classLevelPermissions, emptyCLPS);
+
     testSchema.setCLP(clp);
     schema = await testSchema.update();
     assert.deepEqual(schema.classLevelPermissions, clp);

--- a/integration/test/ParseSchemaTest.js
+++ b/integration/test/ParseSchemaTest.js
@@ -149,6 +149,29 @@ describe('Schema', () => {
     assert.deepEqual(schema.classLevelPermissions, emptyCLPS);
   });
 
+  it('update class level permissions multiple', async () => {
+    const clp = {
+      get: { requiresAuthentication: true },
+      find: {},
+      count: {},
+      create: { '*': true },
+      update: { requiresAuthentication: true },
+      delete: {},
+      addField: {},
+      protectedFields: {}
+    };
+    const testSchema = new Parse.Schema('SchemaTest');
+    testSchema.setCLP(clp);
+    let schema = await testSchema.save();
+    assert.deepEqual(schema.classLevelPermissions, clp);
+
+    schema = await testSchema.update();
+    assert.deepEqual(schema.classLevelPermissions, clp);
+
+    schema = await testSchema.update();
+    assert.deepEqual(schema.classLevelPermissions, clp);
+  });
+
   it('update', (done) => {
     const testSchema = new Parse.Schema('SchemaTest');
     testSchema.addString('name');

--- a/src/ParseSchema.js
+++ b/src/ParseSchema.js
@@ -173,9 +173,6 @@ class ParseSchema {
    * @return {Parse.Schema} Returns the schema, so you can chain this call.
    */
   setCLP(clp: { [key: string]: mixed }) {
-    if (!clp) {
-      return;
-    }
     this._clp = clp;
     return this;
   }

--- a/src/ParseSchema.js
+++ b/src/ParseSchema.js
@@ -123,7 +123,6 @@ class ParseSchema {
 
     this._fields = {};
     this._indexes = {};
-    this._clp = null;
 
     return controller.update(this.className, params);
   }

--- a/src/ParseSchema.js
+++ b/src/ParseSchema.js
@@ -30,6 +30,7 @@ class ParseSchema {
   className: string;
   _fields: { [key: string]: mixed };
   _indexes: { [key: string]: mixed };
+  _clp: { [key: string]: mixed };
 
   /**
    * @param {String} className Parse Class string.
@@ -97,6 +98,7 @@ class ParseSchema {
       className: this.className,
       fields: this._fields,
       indexes: this._indexes,
+      classLevelPermissions: this._clp,
     };
 
     return controller.create(this.className, params);
@@ -116,10 +118,12 @@ class ParseSchema {
       className: this.className,
       fields: this._fields,
       indexes: this._indexes,
+      classLevelPermissions: this._clp,
     };
 
     this._fields = {};
     this._indexes = {};
+    this._clp = null;
 
     return controller.update(this.className, params);
   }
@@ -159,6 +163,21 @@ class ParseSchema {
     if (!this.className) {
       throw new Error('You must set a Class Name before making any request.');
     }
+  }
+
+  /**
+   * Sets Class Level Permissions when creating / updating a Schema.
+   * EXERCISE CAUTION, running this may override CLP for this schema and cannot be reversed
+   *
+   * @param {Object} clp Class Level Permissions
+   * @return {Parse.Schema} Returns the schema, so you can chain this call.
+   */
+  setCLP(clp: { [key: string]: mixed }) {
+    if (!clp) {
+      return;
+    }
+    this._clp = clp;
+    return this;
   }
 
   /**

--- a/src/__tests__/ParseSchema-test.js
+++ b/src/__tests__/ParseSchema-test.js
@@ -77,6 +77,28 @@ describe('ParseSchema', () => {
     done();
   });
 
+  it('can set schema class level permissions', (done) => {
+    const schema = new ParseSchema('SchemaTest');
+    expect(schema._clp).toBeUndefined();
+    schema.setCLP(undefined);
+    expect(schema._clp).toBeUndefined();
+    schema.setCLP({});
+    expect(schema._clp).toEqual({});
+    const clp = {
+      get: { requiresAuthentication: true },
+      find: {},
+      count: {},
+      create: { '*': true },
+      update: { requiresAuthentication: true },
+      delete: {},
+      addField: {},
+      protectedFields: {}
+    };
+    schema.setCLP(clp);
+    expect(schema._clp).toEqual(clp);
+    done();
+  });
+
   it('cannot add field with null name', (done) => {
     try {
       const schema = new ParseSchema('SchemaTest');


### PR DESCRIPTION
Closes: https://github.com/parse-community/Parse-SDK-JS/issues/583

Let me know if there are any other tests needed.
I rarely use CLPs so I may miss something.