### PR TITLE
Parse.Schema required fields and defaultValues

### DIFF
--- a/integration/test/ParseSchemaTest.js
+++ b/integration/test/ParseSchemaTest.js
@@ -143,8 +143,8 @@ describe('Schema', () => {
       .addString('stringField', { required: true, defaultValue: 'world' })
       .addNumber('numberField', { required: true, defaultValue: 10 })
       .addBoolean('booleanField', { required: true, defaultValue: false })
-      .addDate('dateField', { required: true, defaultValue: new Date('January 1, 2000 00:00:00') })
-      .addDate('dateStringField', { required: true, defaultValue:  '2000-01-01T00:00:00.000Z' })
+      .addDate('dateField', { required: true, defaultValue: new Date('2000-01-01T00:00:00.000Z') })
+      .addDate('dateStringField', { required: true, defaultValue: '2000-01-01T00:00:00.000Z' })
       .addFile('fileField', { required: true, defaultValue: file })
       .addGeoPoint('geoPointField', { required: true, defaultValue: point })
       .addPolygon('polygonField', { required: true, defaultValue: polygon })
@@ -152,8 +152,6 @@ describe('Schema', () => {
       .addObject('objectField', { required: true, defaultValue: { foo: 'bar' } })
 
     const schema = await testSchema.save();
-    console.log(schema.fields);
-    console.log(schema.fields.polygonField.defaultValue);
     assert.deepEqual(schema.fields, {
       objectId: { type: 'String' },
       updatedAt: { type: 'Date' },
@@ -162,7 +160,7 @@ describe('Schema', () => {
       stringField: { type: 'String', required: true, defaultValue: 'world' },
       numberField: { type: 'Number', required: true, defaultValue: 10 },
       booleanField: { type: 'Boolean', required: true, defaultValue: false },
-      dateField: { type: 'Date', required: true, defaultValue: { __type: 'Date', iso: '2000-01-01T06:00:00.000Z' } },
+      dateField: { type: 'Date', required: true, defaultValue: { __type: 'Date', iso: '2000-01-01T00:00:00.000Z' } },
       dateStringField: { type: 'Date', required: true, defaultValue: { __type: 'Date', iso: '2000-01-01T00:00:00.000Z' } },
       fileField: { type: 'File', required: true, defaultValue: file.toJSON() },
       geoPointField: { type: 'GeoPoint', required: true, defaultValue: point.toJSON() },
@@ -183,7 +181,7 @@ describe('Schema', () => {
       stringField: 'world',
       numberField: 10,
       booleanField: false,
-      dateField: { __type: 'Date', iso: '2000-01-01T06:00:00.000Z' },
+      dateField: { __type: 'Date', iso: '2000-01-01T00:00:00.000Z' },
       dateStringField: { __type: 'Date', iso: '2000-01-01T00:00:00.000Z' },
       fileField: file.toJSON(),
       geoPointField: point.toJSON(),

--- a/integration/test/ParseSchemaTest.js
+++ b/integration/test/ParseSchemaTest.js
@@ -118,9 +118,20 @@ describe('Schema', () => {
     assert.equal(object.get('fieldString'), 'Hello World');
   });
 
-  it('set multiple required and default values', async () => {
+  it('save required and default pointer values', async () => {
     const pointer = new TestObject();
     await pointer.save();
+    const testSchema = new Parse.Schema('SchemaTest');
+    testSchema
+      .addPointer('pointerField', 'TestObject', { required: true, defaultValue: pointer })
+      .addPointer('pointerJSONField', 'TestObject', { required: true, defaultValue: pointer.toPointer() })
+    const schema = await testSchema.save();
+    assert.deepEqual(schema.fields.pointerField, schema.fields.pointerJSONField);
+    assert.deepEqual(schema.fields.pointerField.defaultValue, pointer.toPointer());
+    assert.equal(schema.fields.pointerField.required, true);
+  });
+
+  it('set multiple required and default values', async () => {
     const point = new Parse.GeoPoint(44.0, -11.0);
     const polygon = new Parse.Polygon([[0,0], [0,1], [1,1], [1,0]]);
     const file = new Parse.File('parse-server-logo', { base64: 'ParseA==' });
@@ -132,13 +143,13 @@ describe('Schema', () => {
       .addString('stringField', { required: true, defaultValue: 'world' })
       .addNumber('numberField', { required: true, defaultValue: 10 })
       .addBoolean('booleanField', { required: true, defaultValue: false })
-      // .addDate('dateField', { required: true, defaultValue: new Date('January 1, 2000 00:00:00') })
+      .addDate('dateField', { required: true, defaultValue: new Date('January 1, 2000 00:00:00') })
+      .addDate('dateStringField', { required: true, defaultValue:  '2000-01-01T00:00:00.000Z' })
       .addFile('fileField', { required: true, defaultValue: file })
       .addGeoPoint('geoPointField', { required: true, defaultValue: point })
       .addPolygon('polygonField', { required: true, defaultValue: polygon })
       .addArray('arrayField', { required: true, defaultValue: [1, 2, 3] })
       .addObject('objectField', { required: true, defaultValue: { foo: 'bar' } })
-      // .addPointer('pointerField', 'TestObject', { required: true, defaultValue: pointer })
 
     const schema = await testSchema.save();
     assert.deepEqual(schema.fields, {
@@ -149,6 +160,8 @@ describe('Schema', () => {
       stringField: { type: 'String', required: true, defaultValue: 'world' },
       numberField: { type: 'Number', required: true, defaultValue: 10 },
       booleanField: { type: 'Boolean', required: true, defaultValue: false },
+      dateField: { type: 'Date', required: true, defaultValue: { __type: 'Date', iso: '2000-01-01T06:00:00.000Z' } },
+      dateStringField: { type: 'Date', required: true, defaultValue: { __type: 'Date', iso: '2000-01-01T00:00:00.000Z' } },
       fileField: { type: 'File', required: true, defaultValue: file.toJSON() },
       geoPointField: { type: 'GeoPoint', required: true, defaultValue: point.toJSON() },
       polygonField: { type: 'Polygon', required: true, defaultValue: polygon.toJSON() },
@@ -168,6 +181,8 @@ describe('Schema', () => {
       stringField: 'world',
       numberField: 10,
       booleanField: false,
+      dateField: { __type: 'Date', iso: '2000-01-01T06:00:00.000Z' },
+      dateStringField: { __type: 'Date', iso: '2000-01-01T00:00:00.000Z' },
       fileField: file.toJSON(),
       geoPointField: point.toJSON(),
       polygonField: {

--- a/integration/test/ParseSchemaTest.js
+++ b/integration/test/ParseSchemaTest.js
@@ -152,6 +152,8 @@ describe('Schema', () => {
       .addObject('objectField', { required: true, defaultValue: { foo: 'bar' } })
 
     const schema = await testSchema.save();
+    console.log(schema.fields);
+    console.log(schema.fields.polygonField.defaultValue);
     assert.deepEqual(schema.fields, {
       objectId: { type: 'String' },
       updatedAt: { type: 'Date' },

--- a/package-lock.json
+++ b/package-lock.json
@@ -48,78 +48,18 @@
         "resolve": "^1.3.2",
         "semver": "^5.4.1",
         "source-map": "^0.5.0"
-      },
-      "dependencies": {
-        "@babel/generator": {
-          "version": "7.6.4",
-          "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.6.4.tgz",
-          "integrity": "sha512-jsBuXkFoZxk0yWLyGI9llT9oiQ2FeTASmRFE32U+aaDTfoE92t78eroO7PTpU/OrYq38hlcDM6vbfLDaOLy+7w==",
-          "dev": true,
-          "requires": {
-            "@babel/types": "^7.6.3",
-            "jsesc": "^2.5.1",
-            "lodash": "^4.17.13",
-            "source-map": "^0.5.0"
-          }
-        },
-        "@babel/parser": {
-          "version": "7.6.4",
-          "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.6.4.tgz",
-          "integrity": "sha512-D8RHPW5qd0Vbyo3qb+YjO5nvUVRTXFLQ/FsDxJU2Nqz4uB5EnUN0ZQSEYpvTIbRuttig1XbHWU5oMeQwQSAA+A==",
-          "dev": true
-        },
-        "@babel/template": {
-          "version": "7.6.0",
-          "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.6.0.tgz",
-          "integrity": "sha512-5AEH2EXD8euCk446b7edmgFdub/qfH1SN6Nii3+fyXP807QRx9Q73A2N5hNwRRslC2H9sNzaFhsPubkS4L8oNQ==",
-          "dev": true,
-          "requires": {
-            "@babel/code-frame": "^7.0.0",
-            "@babel/parser": "^7.6.0",
-            "@babel/types": "^7.6.0"
-          }
-        },
-        "@babel/traverse": {
-          "version": "7.6.3",
-          "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.6.3.tgz",
-          "integrity": "sha512-unn7P4LGsijIxaAJo/wpoU11zN+2IaClkQAxcJWBNCMS6cmVh802IyLHNkAjQ0iYnRS3nnxk5O3fuXW28IMxTw==",
-          "dev": true,
-          "requires": {
-            "@babel/code-frame": "^7.5.5",
-            "@babel/generator": "^7.6.3",
-            "@babel/helper-function-name": "^7.1.0",
-            "@babel/helper-split-export-declaration": "^7.4.4",
-            "@babel/parser": "^7.6.3",
-            "@babel/types": "^7.6.3",
-            "debug": "^4.1.0",
-            "globals": "^11.1.0",
-            "lodash": "^4.17.13"
-          }
-        },
-        "@babel/types": {
-          "version": "7.6.3",
-          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.6.3.tgz",
-          "integrity": "sha512-CqbcpTxMcpuQTMhjI37ZHVgjBkysg5icREQIEZ0eG1yCNwg3oy+5AaLiOKmjsCj6nqOsa6Hf0ObjRVwokb7srA==",
-          "dev": true,
-          "requires": {
-            "esutils": "^2.0.2",
-            "lodash": "^4.17.13",
-            "to-fast-properties": "^2.0.0"
-          }
-        }
       }
     },
     "@babel/generator": {
-      "version": "7.5.5",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.5.5.tgz",
-      "integrity": "sha512-ETI/4vyTSxTzGnU2c49XHv2zhExkv9JHLTwDAFz85kmcwuShvYG2H08FwgIguQf4JC75CBnXAUM5PqeF4fj0nQ==",
+      "version": "7.6.4",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.6.4.tgz",
+      "integrity": "sha512-jsBuXkFoZxk0yWLyGI9llT9oiQ2FeTASmRFE32U+aaDTfoE92t78eroO7PTpU/OrYq38hlcDM6vbfLDaOLy+7w==",
       "dev": true,
       "requires": {
-        "@babel/types": "^7.5.5",
+        "@babel/types": "^7.6.3",
         "jsesc": "^2.5.1",
         "lodash": "^4.17.13",
-        "source-map": "^0.5.0",
-        "trim-right": "^1.0.1"
+        "source-map": "^0.5.0"
       }
     },
     "@babel/helper-annotate-as-pure": {
@@ -163,9 +103,9 @@
       }
     },
     "@babel/helper-create-class-features-plugin": {
-      "version": "7.5.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.5.5.tgz",
-      "integrity": "sha512-ZsxkyYiRA7Bg+ZTRpPvB6AbOFKTFFK4LrvTet8lInm0V468MWCaSYJE+I7v2z2r8KNLtYiV+K5kTCnR7dvyZjg==",
+      "version": "7.6.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.6.0.tgz",
+      "integrity": "sha512-O1QWBko4fzGju6VoVvrZg0RROCVifcLxiApnGP3OWfWzvxRZFCoBD81K5ur5e3bVY2Vf/5rIJm8cqPKn8HUJng==",
       "dev": true,
       "requires": {
         "@babel/helper-function-name": "^7.1.0",
@@ -347,65 +287,6 @@
         "@babel/template": "^7.6.0",
         "@babel/traverse": "^7.6.2",
         "@babel/types": "^7.6.0"
-      },
-      "dependencies": {
-        "@babel/generator": {
-          "version": "7.6.4",
-          "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.6.4.tgz",
-          "integrity": "sha512-jsBuXkFoZxk0yWLyGI9llT9oiQ2FeTASmRFE32U+aaDTfoE92t78eroO7PTpU/OrYq38hlcDM6vbfLDaOLy+7w==",
-          "dev": true,
-          "requires": {
-            "@babel/types": "^7.6.3",
-            "jsesc": "^2.5.1",
-            "lodash": "^4.17.13",
-            "source-map": "^0.5.0"
-          }
-        },
-        "@babel/parser": {
-          "version": "7.6.4",
-          "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.6.4.tgz",
-          "integrity": "sha512-D8RHPW5qd0Vbyo3qb+YjO5nvUVRTXFLQ/FsDxJU2Nqz4uB5EnUN0ZQSEYpvTIbRuttig1XbHWU5oMeQwQSAA+A==",
-          "dev": true
-        },
-        "@babel/template": {
-          "version": "7.6.0",
-          "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.6.0.tgz",
-          "integrity": "sha512-5AEH2EXD8euCk446b7edmgFdub/qfH1SN6Nii3+fyXP807QRx9Q73A2N5hNwRRslC2H9sNzaFhsPubkS4L8oNQ==",
-          "dev": true,
-          "requires": {
-            "@babel/code-frame": "^7.0.0",
-            "@babel/parser": "^7.6.0",
-            "@babel/types": "^7.6.0"
-          }
-        },
-        "@babel/traverse": {
-          "version": "7.6.3",
-          "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.6.3.tgz",
-          "integrity": "sha512-unn7P4LGsijIxaAJo/wpoU11zN+2IaClkQAxcJWBNCMS6cmVh802IyLHNkAjQ0iYnRS3nnxk5O3fuXW28IMxTw==",
-          "dev": true,
-          "requires": {
-            "@babel/code-frame": "^7.5.5",
-            "@babel/generator": "^7.6.3",
-            "@babel/helper-function-name": "^7.1.0",
-            "@babel/helper-split-export-declaration": "^7.4.4",
-            "@babel/parser": "^7.6.3",
-            "@babel/types": "^7.6.3",
-            "debug": "^4.1.0",
-            "globals": "^11.1.0",
-            "lodash": "^4.17.13"
-          }
-        },
-        "@babel/types": {
-          "version": "7.6.3",
-          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.6.3.tgz",
-          "integrity": "sha512-CqbcpTxMcpuQTMhjI37ZHVgjBkysg5icREQIEZ0eG1yCNwg3oy+5AaLiOKmjsCj6nqOsa6Hf0ObjRVwokb7srA==",
-          "dev": true,
-          "requires": {
-            "esutils": "^2.0.2",
-            "lodash": "^4.17.13",
-            "to-fast-properties": "^2.0.0"
-          }
-        }
       }
     },
     "@babel/highlight": {
@@ -420,9 +301,9 @@
       }
     },
     "@babel/parser": {
-      "version": "7.5.5",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.5.5.tgz",
-      "integrity": "sha512-E5BN68cqR7dhKan1SfqgPGhQ178bkVKpXTPEXnFJBrEt8/DKRZlybmy+IgYLTeN7tp1R5Ccmbm2rBk17sHYU3g==",
+      "version": "7.6.4",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.6.4.tgz",
+      "integrity": "sha512-D8RHPW5qd0Vbyo3qb+YjO5nvUVRTXFLQ/FsDxJU2Nqz4uB5EnUN0ZQSEYpvTIbRuttig1XbHWU5oMeQwQSAA+A==",
       "dev": true
     },
     "@babel/plugin-proposal-async-generator-functions": {
@@ -672,37 +553,6 @@
         "@babel/generator": "^7.6.3",
         "@babel/helper-plugin-utils": "^7.0.0",
         "@babel/plugin-syntax-flow": "^7.2.0"
-      },
-      "dependencies": {
-        "@babel/generator": {
-          "version": "7.6.3",
-          "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.6.3.tgz",
-          "integrity": "sha512-hLhYbAb3pHwxjlijC4AQ7mqZdcoujiNaW7izCT04CIowHK8psN0IN8QjDv0iyFtycF5FowUOTwDloIheI25aMw==",
-          "dev": true,
-          "requires": {
-            "@babel/types": "^7.6.3",
-            "jsesc": "^2.5.1",
-            "lodash": "^4.17.13",
-            "source-map": "^0.6.1"
-          }
-        },
-        "@babel/types": {
-          "version": "7.6.3",
-          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.6.3.tgz",
-          "integrity": "sha512-CqbcpTxMcpuQTMhjI37ZHVgjBkysg5icREQIEZ0eG1yCNwg3oy+5AaLiOKmjsCj6nqOsa6Hf0ObjRVwokb7srA==",
-          "dev": true,
-          "requires": {
-            "esutils": "^2.0.2",
-            "lodash": "^4.17.13",
-            "to-fast-properties": "^2.0.0"
-          }
-        },
-        "source-map": {
-          "version": "0.6.1",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-          "dev": true
-        }
       }
     },
     "@babel/plugin-transform-flow-strip-types": {
@@ -1028,19 +878,6 @@
         "invariant": "^2.2.2",
         "js-levenshtein": "^1.1.3",
         "semver": "^5.5.0"
-      },
-      "dependencies": {
-        "@babel/types": {
-          "version": "7.6.3",
-          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.6.3.tgz",
-          "integrity": "sha512-CqbcpTxMcpuQTMhjI37ZHVgjBkysg5icREQIEZ0eG1yCNwg3oy+5AaLiOKmjsCj6nqOsa6Hf0ObjRVwokb7srA==",
-          "dev": true,
-          "requires": {
-            "esutils": "^2.0.2",
-            "lodash": "^4.17.13",
-            "to-fast-properties": "^2.0.0"
-          }
-        }
       }
     },
     "@babel/preset-react": {
@@ -1088,37 +925,37 @@
       }
     },
     "@babel/template": {
-      "version": "7.4.4",
-      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.4.4.tgz",
-      "integrity": "sha512-CiGzLN9KgAvgZsnivND7rkA+AeJ9JB0ciPOD4U59GKbQP2iQl+olF1l76kJOupqidozfZ32ghwBEJDhnk9MEcw==",
+      "version": "7.6.0",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.6.0.tgz",
+      "integrity": "sha512-5AEH2EXD8euCk446b7edmgFdub/qfH1SN6Nii3+fyXP807QRx9Q73A2N5hNwRRslC2H9sNzaFhsPubkS4L8oNQ==",
       "dev": true,
       "requires": {
         "@babel/code-frame": "^7.0.0",
-        "@babel/parser": "^7.4.4",
-        "@babel/types": "^7.4.4"
+        "@babel/parser": "^7.6.0",
+        "@babel/types": "^7.6.0"
       }
     },
     "@babel/traverse": {
-      "version": "7.5.5",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.5.5.tgz",
-      "integrity": "sha512-MqB0782whsfffYfSjH4TM+LMjrJnhCNEDMDIjeTpl+ASaUvxcjoiVCo/sM1GhS1pHOXYfWVCYneLjMckuUxDaQ==",
+      "version": "7.6.3",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.6.3.tgz",
+      "integrity": "sha512-unn7P4LGsijIxaAJo/wpoU11zN+2IaClkQAxcJWBNCMS6cmVh802IyLHNkAjQ0iYnRS3nnxk5O3fuXW28IMxTw==",
       "dev": true,
       "requires": {
         "@babel/code-frame": "^7.5.5",
-        "@babel/generator": "^7.5.5",
+        "@babel/generator": "^7.6.3",
         "@babel/helper-function-name": "^7.1.0",
         "@babel/helper-split-export-declaration": "^7.4.4",
-        "@babel/parser": "^7.5.5",
-        "@babel/types": "^7.5.5",
+        "@babel/parser": "^7.6.3",
+        "@babel/types": "^7.6.3",
         "debug": "^4.1.0",
         "globals": "^11.1.0",
         "lodash": "^4.17.13"
       }
     },
     "@babel/types": {
-      "version": "7.5.5",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.5.5.tgz",
-      "integrity": "sha512-s63F9nJioLqOlW3UkyMd+BYhXt44YuaFm/VV0VwuteqjYwRrObkU7ra9pY4wAJR3oXi8hJrMcrcJdO/HH33vtw==",
+      "version": "7.6.3",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.6.3.tgz",
+      "integrity": "sha512-CqbcpTxMcpuQTMhjI37ZHVgjBkysg5icREQIEZ0eG1yCNwg3oy+5AaLiOKmjsCj6nqOsa6Hf0ObjRVwokb7srA==",
       "dev": true,
       "requires": {
         "esutils": "^2.0.2",
@@ -1341,9 +1178,9 @@
       "dev": true
     },
     "@parse/node-apn": {
-      "version": "3.0.6",
-      "resolved": "https://registry.npmjs.org/@parse/node-apn/-/node-apn-3.0.6.tgz",
-      "integrity": "sha512-zM85e7t4xnfto3uxlMXGPzINbPJ8XwwCPaFTOnT0iatDOlVcuX/j5EgmtCtO7j+1TXdPRKC6JDEa5HvxTlOXiA==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@parse/node-apn/-/node-apn-3.1.0.tgz",
+      "integrity": "sha512-uEf6hL2WOFle5e9JUpbVwYUWYupqeiVS6StibkiYY4Bw3GmjYoZvHZu7DbGxQedJ85EjxuCYXFfopudiUElRpQ==",
       "dev": true,
       "requires": {
         "coveralls": "^3.0.6",
@@ -1387,45 +1224,21 @@
       }
     },
     "@parse/push-adapter": {
-      "version": "3.0.10",
-      "resolved": "https://registry.npmjs.org/@parse/push-adapter/-/push-adapter-3.0.10.tgz",
-      "integrity": "sha512-Bs+F5BaDYSJ50+SGd693la+YmyhfnDSqAgOGfpk6FT/i+0RE/T3t88biyANcxNXd6DBSlCavKZHoWxWFFvjc3Q==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@parse/push-adapter/-/push-adapter-3.1.0.tgz",
+      "integrity": "sha512-SvLXKtAtlVMvlwl0Dw3smpy8ZgGicZDIxkUokV5HrZIFaQxHCEIj+9aj4y9IYOo6+7jE97vVwDmvh+n4geyZRg==",
       "dev": true,
       "requires": {
-        "@parse/node-apn": "^3.0.6",
+        "@parse/node-apn": "^3.1.0",
         "@parse/node-gcm": "^1.0.0",
         "npmlog": "^4.0.2",
-        "parse": "^1.11.1"
-      },
-      "dependencies": {
-        "parse": {
-          "version": "1.11.1",
-          "resolved": "https://registry.npmjs.org/parse/-/parse-1.11.1.tgz",
-          "integrity": "sha1-VY5TnULZ+4khDggiCdbzsD1frtU=",
-          "dev": true,
-          "requires": {
-            "babel-runtime": "^6.11.6",
-            "ws": "^3.3.1",
-            "xmlhttprequest": "^1.7.0"
-          }
-        },
-        "ws": {
-          "version": "3.3.3",
-          "resolved": "https://registry.npmjs.org/ws/-/ws-3.3.3.tgz",
-          "integrity": "sha512-nnWLa/NwZSt4KQJu51MYlCcSQ5g7INpOrOMt4XV8j4dqTXdmlUmSHQ8/oLC069ckre0fRsgfvsKwbTdtKLCDkA==",
-          "dev": true,
-          "requires": {
-            "async-limiter": "~1.0.0",
-            "safe-buffer": "~5.1.0",
-            "ultron": "~1.1.0"
-          }
-        }
+        "parse": "^2.7.1"
       }
     },
     "@parse/s3-files-adapter": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/@parse/s3-files-adapter/-/s3-files-adapter-1.2.3.tgz",
-      "integrity": "sha512-fmCf2X1akoCSpY3x4TOC7wj1jWI1qM0u6thUwwOXyREebw+YvEclufXGorpbIEhLeZj+foyg2s7nxDaxKqmAQg==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@parse/s3-files-adapter/-/s3-files-adapter-1.3.0.tgz",
+      "integrity": "sha512-Sw5P2qLt5wxFv/j8auChfOomZFIZ4jhP5f85qpgOk1OCITFwvd7FWF6Qo3N72Hqn/9MCr76tblb/JBNEU+Qgjw==",
       "dev": true,
       "requires": {
         "aws-sdk": "^2.59.0"
@@ -1527,9 +1340,9 @@
       }
     },
     "@types/babel__generator": {
-      "version": "7.0.2",
-      "resolved": "https://registry.npmjs.org/@types/babel__generator/-/babel__generator-7.0.2.tgz",
-      "integrity": "sha512-NHcOfab3Zw4q5sEE2COkpfXjoE7o+PmqD9DQW4koUT3roNxwziUdXGnRndMat/LJNUtePwn1TlP4do3uoe3KZQ==",
+      "version": "7.6.0",
+      "resolved": "https://registry.npmjs.org/@types/babel__generator/-/babel__generator-7.6.0.tgz",
+      "integrity": "sha512-c1mZUu4up5cp9KROs/QAw0gTeHrw/x7m52LcnvMxxOZ03DmLwPV0MlGmlgzV3cnSdjhJOZsj7E7FHeioai+egw==",
       "dev": true,
       "requires": {
         "@babel/types": "^7.0.0"
@@ -1574,9 +1387,9 @@
       }
     },
     "@types/cookies": {
-      "version": "0.7.2",
-      "resolved": "https://registry.npmjs.org/@types/cookies/-/cookies-0.7.2.tgz",
-      "integrity": "sha512-jnihWgshWystcJKrz8C9hV+Ot9lqOUyAh2RF+o3BEo6K6AS2l4zYCb9GYaBuZ3C6Il59uIGqpE3HvCun4KKeJA==",
+      "version": "0.7.4",
+      "resolved": "https://registry.npmjs.org/@types/cookies/-/cookies-0.7.4.tgz",
+      "integrity": "sha512-oTGtMzZZAVuEjTwCjIh8T8FrC8n/uwy+PG0yTvQcdZ7etoel7C7/3MSd7qrukENTgQtotG7gvBlBojuVs7X5rw==",
       "dev": true,
       "requires": {
         "@types/connect": "*",
@@ -1606,9 +1419,9 @@
       }
     },
     "@types/express-serve-static-core": {
-      "version": "4.16.9",
-      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.16.9.tgz",
-      "integrity": "sha512-GqpaVWR0DM8FnRUJYKlWgyARoBUAVfRIeVDZQKOttLFp5SmhhF9YFIYeTPwMd/AXfxlP7xVO2dj1fGu0Q+krKQ==",
+      "version": "4.16.10",
+      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.16.10.tgz",
+      "integrity": "sha512-gM6evDj0OvTILTRKilh9T5dTaGpv1oYiFcJAfgSejuMJgGJUsD9hKEU2lB4aiTNy4WwChxRnjfYFuBQsULzsJw==",
       "dev": true,
       "requires": {
         "@types/node": "*",
@@ -1674,9 +1487,9 @@
       "dev": true
     },
     "@types/koa": {
-      "version": "2.0.49",
-      "resolved": "https://registry.npmjs.org/@types/koa/-/koa-2.0.49.tgz",
-      "integrity": "sha512-WQWpCH8O4Dslk8IcXfazff40aM1jXX7BQRbADIj/fKozVPu76P/wQE4sRe2SCWMn8yNkOcare2MkDrnZqLMkPQ==",
+      "version": "2.0.50",
+      "resolved": "https://registry.npmjs.org/@types/koa/-/koa-2.0.50.tgz",
+      "integrity": "sha512-TcgOD2lh0EISSadAk1DOBYw7kNoY9XdeB3vEMOKiDDaTMYm+V54nyPsU7Ulb/htb5OBIR79RgTeCWntCcophLw==",
       "dev": true,
       "requires": {
         "@types/accepts": "*",
@@ -1709,9 +1522,9 @@
       "dev": true
     },
     "@types/node": {
-      "version": "8.10.53",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-8.10.53.tgz",
-      "integrity": "sha512-aOmXdv1a1/vYUn1OT1CED8ftbkmmYbKhKGSyMDeJiidLvKRKvZUQOdXwG/wcNY7T1Qb0XTlVdiYjIq00U7pLrQ==",
+      "version": "12.11.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-12.11.1.tgz",
+      "integrity": "sha512-TJtwsqZ39pqcljJpajeoofYRfeZ7/I/OMUQ5pR4q5wOKf2ocrUvBAZUMhWsOvKx3dVc/aaV5GluBivt0sWqA5A==",
       "dev": true
     },
     "@types/range-parser": {
@@ -1746,9 +1559,9 @@
       }
     },
     "@types/yargs": {
-      "version": "13.0.2",
-      "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-13.0.2.tgz",
-      "integrity": "sha512-lwwgizwk/bIIU+3ELORkyuOgDjCh7zuWDFqRtPPhhVgq9N1F7CvLNKg1TX4f2duwtKQ0p044Au9r1PLIXHrIzQ==",
+      "version": "13.0.3",
+      "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-13.0.3.tgz",
+      "integrity": "sha512-K8/LfZq2duW33XW/tFwEAfnZlqIfVsoyRB3kfXdPXYhl0nfM8mmh7GS0jg7WrX2Dgq/0Ha/pR1PaR+BvmWwjiQ==",
       "dev": true,
       "requires": {
         "@types/yargs-parser": "*"
@@ -1780,9 +1593,9 @@
       }
     },
     "abab": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/abab/-/abab-2.0.1.tgz",
-      "integrity": "sha512-1zSbbCuoIjafKZ3mblY5ikvAb0ODUbqBnFuUb7f6uLeQhhGJ0vEV4ntmtxKLT2WgXCO94E07BjunsIw1jOMPZw==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/abab/-/abab-2.0.2.tgz",
+      "integrity": "sha512-2scffjvioEmNz0OyDSLGWDfKCVwaKc6l9Pm9kOIREU13ClXZvHpg/nRL5xyjSSSLhOnXqft2HpsAzNEEA8cFFg==",
       "dev": true
     },
     "abbrev": {
@@ -1803,15 +1616,15 @@
       }
     },
     "acorn": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.0.0.tgz",
-      "integrity": "sha512-PaF/MduxijYYt7unVGRuds1vBC9bFxbNf+VWqhOClfdgy7RlVkQqt610ig1/yxTgsDIfW1cWDel5EBbOy3jdtQ==",
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.1.0.tgz",
+      "integrity": "sha512-kL5CuoXA/dgxlBbVrflsflzQ3PAas7RYZB52NOm/6839iVYJgKMJ3cQJD+t2i5+qFa8h3MDpEOJiS64E8JLnSQ==",
       "dev": true
     },
     "acorn-globals": {
-      "version": "4.3.3",
-      "resolved": "https://registry.npmjs.org/acorn-globals/-/acorn-globals-4.3.3.tgz",
-      "integrity": "sha512-vkR40VwS2SYO98AIeFvzWWh+xyc2qi9s7OoXSFEGIP/rOJKzjnhykaZJNnHdoq4BL2gGxI5EZOU16z896EYnOQ==",
+      "version": "4.3.4",
+      "resolved": "https://registry.npmjs.org/acorn-globals/-/acorn-globals-4.3.4.tgz",
+      "integrity": "sha512-clfQEh21R+D0leSbUdWf3OcfqyaCSAQ8Ryq00bofSekfr9W8u1jyYZo6ir0xu9Gtcf7BjcHJpnbZH7JOCpP60A==",
       "dev": true,
       "requires": {
         "acorn": "^6.0.1",
@@ -1833,9 +1646,9 @@
       }
     },
     "acorn-jsx": {
-      "version": "5.0.2",
-      "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.0.2.tgz",
-      "integrity": "sha512-tiNTrP1MP0QrChmD2DdupCr6HWSFeKVw5d/dHTu4Y7rkAkRhU/Dt7dphAfIUyxtHpl/eBVip5uTNSpQJHylpAw==",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.1.0.tgz",
+      "integrity": "sha512-tMUqwBWfLFbJbizRmEcWSLw6HnFzfdJs2sOJEOwwtVPMoH/0Ay+E703oZz78VSXZiiDcZrQ5XKjPIUQixhmgVw==",
       "dev": true
     },
     "acorn-node": {
@@ -1932,13 +1745,13 @@
       }
     },
     "apollo-cache-control": {
-      "version": "0.8.4",
-      "resolved": "https://registry.npmjs.org/apollo-cache-control/-/apollo-cache-control-0.8.4.tgz",
-      "integrity": "sha512-IZ1d3AXZtkZhLYo0kWqTbZ6nqLFaeUvLdMESs+9orMadBZ7mvzcAfBwrhKyCWPGeAAZ/jKv8FtYHybpchHgFAg==",
+      "version": "0.8.5",
+      "resolved": "https://registry.npmjs.org/apollo-cache-control/-/apollo-cache-control-0.8.5.tgz",
+      "integrity": "sha512-2yQ1vKgJQ54SGkoQS/ZLZrDX3La6cluAYYdruFYJMJtL4zQrSdeOCy11CQliCMYEd6eKNyE70Rpln51QswW2Og==",
       "dev": true,
       "requires": {
         "apollo-server-env": "^2.4.3",
-        "graphql-extensions": "^0.10.3"
+        "graphql-extensions": "^0.10.4"
       }
     },
     "apollo-datasource": {
@@ -1952,24 +1765,24 @@
       }
     },
     "apollo-engine-reporting": {
-      "version": "1.4.6",
-      "resolved": "https://registry.npmjs.org/apollo-engine-reporting/-/apollo-engine-reporting-1.4.6.tgz",
-      "integrity": "sha512-acfb7oFnru/8YQdY4x6+7WJbZfzdVETI8Cl+9ImgUrvUnE8P+f2SsGTKXTC1RuUvve4c56PAvaPgE+z8X1a1Mw==",
+      "version": "1.4.7",
+      "resolved": "https://registry.npmjs.org/apollo-engine-reporting/-/apollo-engine-reporting-1.4.7.tgz",
+      "integrity": "sha512-qsKDz9VkoctFhojM3Nj3nvRBO98t8TS2uTgtiIjUGs3Hln2poKMP6fIQ37Nm2Q2B3JJst76HQtpPwXmRJd1ZUg==",
       "dev": true,
       "requires": {
-        "apollo-engine-reporting-protobuf": "^0.4.0",
-        "apollo-graphql": "^0.3.3",
+        "apollo-engine-reporting-protobuf": "^0.4.1",
+        "apollo-graphql": "^0.3.4",
         "apollo-server-caching": "^0.5.0",
         "apollo-server-env": "^2.4.3",
-        "apollo-server-types": "^0.2.4",
+        "apollo-server-types": "^0.2.5",
         "async-retry": "^1.2.1",
-        "graphql-extensions": "^0.10.3"
+        "graphql-extensions": "^0.10.4"
       }
     },
     "apollo-engine-reporting-protobuf": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/apollo-engine-reporting-protobuf/-/apollo-engine-reporting-protobuf-0.4.0.tgz",
-      "integrity": "sha512-cXHZSienkis8v4RhqB3YG3DkaksqLpcxApRLTpRMs7IXNozgV7CUPYGFyFBEra1ZFgUyHXx4G9MpelV+n2cCfA==",
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/apollo-engine-reporting-protobuf/-/apollo-engine-reporting-protobuf-0.4.1.tgz",
+      "integrity": "sha512-d7vFFZ2oUrvGaN0Hpet8joe2ZG0X0lIGilN+SwgVP38dJnOuadjsaYMyrD9JudGQJg0bJA5wVQfYzcCVy0slrw==",
       "dev": true,
       "requires": {
         "protobufjs": "^6.8.6"
@@ -1987,25 +1800,25 @@
       }
     },
     "apollo-graphql": {
-      "version": "0.3.3",
-      "resolved": "https://registry.npmjs.org/apollo-graphql/-/apollo-graphql-0.3.3.tgz",
-      "integrity": "sha512-t3CO/xIDVsCG2qOvx2MEbuu4b/6LzQjcBBwiVnxclmmFyAxYCIe7rpPlnLHSq7HyOMlCWDMozjoeWfdqYSaLqQ==",
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/apollo-graphql/-/apollo-graphql-0.3.4.tgz",
+      "integrity": "sha512-w+Az1qxePH4oQ8jvbhQBl5iEVvqcqynmU++x/M7MM5xqN1C7m1kyIzpN17gybXlTJXY4Oxej2WNURC2/hwpfYw==",
       "dev": true,
       "requires": {
-        "apollo-env": "0.5.1",
+        "apollo-env": "^0.5.1",
         "lodash.sortby": "^4.7.0"
       }
     },
     "apollo-link": {
-      "version": "1.2.12",
-      "resolved": "https://registry.npmjs.org/apollo-link/-/apollo-link-1.2.12.tgz",
-      "integrity": "sha512-fsgIAXPKThyMVEMWQsUN22AoQI+J/pVXcjRGAShtk97h7D8O+SPskFinCGEkxPeQpE83uKaqafB2IyWdjN+J3Q==",
+      "version": "1.2.13",
+      "resolved": "https://registry.npmjs.org/apollo-link/-/apollo-link-1.2.13.tgz",
+      "integrity": "sha512-+iBMcYeevMm1JpYgwDEIDt/y0BB7VWyvlm/7x+TIPNLHCTCMgcEgDuW5kH86iQZWo0I7mNwQiTOz+/3ShPFmBw==",
       "dev": true,
       "requires": {
         "apollo-utilities": "^1.3.0",
         "ts-invariant": "^0.4.0",
         "tslib": "^1.9.3",
-        "zen-observable-ts": "^0.8.19"
+        "zen-observable-ts": "^0.8.20"
       }
     },
     "apollo-server-caching": {
@@ -2018,26 +1831,26 @@
       }
     },
     "apollo-server-core": {
-      "version": "2.9.3",
-      "resolved": "https://registry.npmjs.org/apollo-server-core/-/apollo-server-core-2.9.3.tgz",
-      "integrity": "sha512-KQpOM3nAXdMqKVE0HHcOkH/EVhyDqFEKLNFlsyGHGOn9ujpI6RsltX+YpXRyAdbfQHpTk11v/IAo6XksWN+g1Q==",
+      "version": "2.9.6",
+      "resolved": "https://registry.npmjs.org/apollo-server-core/-/apollo-server-core-2.9.6.tgz",
+      "integrity": "sha512-2tHAWQxP7HrETI/BZvg2fem6YlahF9HUp4Y6SSL95WP3uNMOJBlN12yM1y+O2u5K5e4jwdPNaLjoL2A/26XrLw==",
       "dev": true,
       "requires": {
         "@apollographql/apollo-tools": "^0.4.0",
         "@apollographql/graphql-playground-html": "1.6.24",
         "@types/graphql-upload": "^8.0.0",
         "@types/ws": "^6.0.0",
-        "apollo-cache-control": "^0.8.4",
+        "apollo-cache-control": "^0.8.5",
         "apollo-datasource": "^0.6.3",
-        "apollo-engine-reporting": "^1.4.6",
+        "apollo-engine-reporting": "^1.4.7",
         "apollo-server-caching": "^0.5.0",
         "apollo-server-env": "^2.4.3",
         "apollo-server-errors": "^2.3.3",
-        "apollo-server-plugin-base": "^0.6.4",
-        "apollo-server-types": "^0.2.4",
-        "apollo-tracing": "^0.8.4",
+        "apollo-server-plugin-base": "^0.6.5",
+        "apollo-server-types": "^0.2.5",
+        "apollo-tracing": "^0.8.5",
         "fast-json-stable-stringify": "^2.0.0",
-        "graphql-extensions": "^0.10.3",
+        "graphql-extensions": "^0.10.4",
         "graphql-tag": "^2.9.2",
         "graphql-tools": "^4.0.0",
         "graphql-upload": "^8.0.2",
@@ -2074,9 +1887,9 @@
       "dev": true
     },
     "apollo-server-express": {
-      "version": "2.9.3",
-      "resolved": "https://registry.npmjs.org/apollo-server-express/-/apollo-server-express-2.9.3.tgz",
-      "integrity": "sha512-Hkfs+ce6GqaoSzDOJs8Pj7W3YUjH0BzGglo5HMsOXOnjPZ0pJE9v8fmK76rlkITLw7GjvIq5GKlafymC31FMBw==",
+      "version": "2.9.6",
+      "resolved": "https://registry.npmjs.org/apollo-server-express/-/apollo-server-express-2.9.6.tgz",
+      "integrity": "sha512-j80azBeXvLvyZsbqCnus7GH+w8vk+2IOnYzROZu/f0D2roDZtsu1XZkn+aplDJZXMcEXtqB6t4qNpyvV4zY0XQ==",
       "dev": true,
       "requires": {
         "@apollographql/graphql-playground-html": "1.6.24",
@@ -2085,8 +1898,8 @@
         "@types/cors": "^2.8.4",
         "@types/express": "4.17.1",
         "accepts": "^1.3.5",
-        "apollo-server-core": "^2.9.3",
-        "apollo-server-types": "^0.2.4",
+        "apollo-server-core": "^2.9.6",
+        "apollo-server-types": "^0.2.5",
         "body-parser": "^1.18.3",
         "cors": "^2.8.4",
         "express": "^4.17.1",
@@ -2098,33 +1911,33 @@
       }
     },
     "apollo-server-plugin-base": {
-      "version": "0.6.4",
-      "resolved": "https://registry.npmjs.org/apollo-server-plugin-base/-/apollo-server-plugin-base-0.6.4.tgz",
-      "integrity": "sha512-4rY+cBAIpQomGWYBtk8hHkLQWHrh5hgIBPQqmhXh00YFdcY+Ob1/cU2/2iqTcIzhtcaezsc8OZ63au6ahSBQqg==",
+      "version": "0.6.5",
+      "resolved": "https://registry.npmjs.org/apollo-server-plugin-base/-/apollo-server-plugin-base-0.6.5.tgz",
+      "integrity": "sha512-z2ve7HEPWmZI3EzL0iiY9qyt1i0hitT+afN5PzssCw594LB6DfUQWsI14UW+W+gcw8hvl8VQUpXByfUntAx5vw==",
       "dev": true,
       "requires": {
-        "apollo-server-types": "^0.2.4"
+        "apollo-server-types": "^0.2.5"
       }
     },
     "apollo-server-types": {
-      "version": "0.2.4",
-      "resolved": "https://registry.npmjs.org/apollo-server-types/-/apollo-server-types-0.2.4.tgz",
-      "integrity": "sha512-G4FvBVgGQcTW6ZBS2+hvcDQkSfdOIKV+cHADduXA275v+5zl42g+bCaGd/hCCKTDRjmQvObLiMxH/BJ6pDMQgA==",
+      "version": "0.2.5",
+      "resolved": "https://registry.npmjs.org/apollo-server-types/-/apollo-server-types-0.2.5.tgz",
+      "integrity": "sha512-6iJQsPh59FWu4K7ABrVmpnQVgeK8Ockx8BcawBh+saFYWTlVczwcLyGSZPeV1tPSKwFwKZutyEslrYSafcarXQ==",
       "dev": true,
       "requires": {
-        "apollo-engine-reporting-protobuf": "^0.4.0",
+        "apollo-engine-reporting-protobuf": "^0.4.1",
         "apollo-server-caching": "^0.5.0",
         "apollo-server-env": "^2.4.3"
       }
     },
     "apollo-tracing": {
-      "version": "0.8.4",
-      "resolved": "https://registry.npmjs.org/apollo-tracing/-/apollo-tracing-0.8.4.tgz",
-      "integrity": "sha512-DjbFW0IvHicSlTVG+vK+1WINfBMRCdPPHJSW/j65JMir9Oe56WGeqL8qz8hptdUUmLYEb+azvcyyGsJsiR3zpQ==",
+      "version": "0.8.5",
+      "resolved": "https://registry.npmjs.org/apollo-tracing/-/apollo-tracing-0.8.5.tgz",
+      "integrity": "sha512-lZn10/GRBZUlMxVYLghLMFsGcLN0jTYDd98qZfBtxw+wEWUx+PKkZdljDT+XNoOm/kDvEutFGmi5tSLhArIzWQ==",
       "dev": true,
       "requires": {
         "apollo-server-env": "^2.4.3",
-        "graphql-extensions": "^0.10.3"
+        "graphql-extensions": "^0.10.4"
       }
     },
     "apollo-utilities": {
@@ -2457,14 +2270,14 @@
       "dev": true
     },
     "aws-sdk": {
-      "version": "2.524.0",
-      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.524.0.tgz",
-      "integrity": "sha512-nCnKEExs1OqwNG6sIrRy+Lj8Zt2M6BTa6YlEMQ1gIpdwznaAN9XyTnm+MDc3iYsSl58MOBwiKpY8d6CONuxuDw==",
+      "version": "2.550.0",
+      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.550.0.tgz",
+      "integrity": "sha512-eZQYY7O6VJeVQvBWnctOOTOO/+aTXhy23+T7QU1FcHfuvWV7K+7+7Uats9rgMS42SQ4R8q1cIZZ1InWnmmfrEw==",
       "dev": true,
       "requires": {
         "buffer": "4.9.1",
         "events": "1.1.1",
-        "ieee754": "1.1.8",
+        "ieee754": "1.1.13",
         "jmespath": "0.15.0",
         "querystring": "0.2.0",
         "sax": "1.2.1",
@@ -2488,12 +2301,6 @@
           "version": "1.1.1",
           "resolved": "https://registry.npmjs.org/events/-/events-1.1.1.tgz",
           "integrity": "sha1-nr23Y1rQmccNzEwqH1AEKI6L2SQ=",
-          "dev": true
-        },
-        "ieee754": {
-          "version": "1.1.8",
-          "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.8.tgz",
-          "integrity": "sha1-vjPUCsEO8ZJnAfbwii2G+/0a0+Q=",
           "dev": true
         },
         "punycode": {
@@ -2649,30 +2456,6 @@
         "babel-plugin-jest-hoist": "^24.9.0"
       }
     },
-    "babel-runtime": {
-      "version": "6.26.0",
-      "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
-      "integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
-      "dev": true,
-      "requires": {
-        "core-js": "^2.4.0",
-        "regenerator-runtime": "^0.11.0"
-      },
-      "dependencies": {
-        "core-js": {
-          "version": "2.6.9",
-          "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.9.tgz",
-          "integrity": "sha512-HOpZf6eXmnl7la+cUdMnLvUxKNqLUzJvgIziQ0DiF3JwSImNphIqdGqzj6hIKyX04MmV0poclQ7+wjWvxQyR2A==",
-          "dev": true
-        },
-        "regenerator-runtime": {
-          "version": "0.11.1",
-          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz",
-          "integrity": "sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg==",
-          "dev": true
-        }
-      }
-    },
     "bach": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/bach/-/bach-1.2.0.tgz",
@@ -2811,9 +2594,9 @@
       "dev": true
     },
     "bluebird": {
-      "version": "3.5.5",
-      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.5.tgz",
-      "integrity": "sha512-5am6HnnfN+urzt4yfg7IgTbotDjIT/u8AJpEt0sIU9FtXfVeezXAPKswrG+xKUCOYAINpSdgZVDU6QFh+cuH3w==",
+      "version": "3.7.1",
+      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.7.1.tgz",
+      "integrity": "sha512-DdmyoGCleJnkbp3nkbxTLJ18rjDsE4yCggEwKNXkeV123sPNfOCYeDoeuOY+F2FrSjO1YXcTU+dsy96KMy+gcg==",
       "dev": true
     },
     "bn.js": {
@@ -3093,9 +2876,9 @@
       "dev": true
     },
     "buffer": {
-      "version": "5.4.2",
-      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.4.2.tgz",
-      "integrity": "sha512-iy9koArjAFCzGnx3ZvNA6Z0clIbbFgbdWQ0mKD3hO0krOrZh8UgA6qMKcZvwLJxS+D6iVR76+5/pV56yMNYTag==",
+      "version": "5.4.3",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.4.3.tgz",
+      "integrity": "sha512-zvj65TkFeIt3i6aj5bIvJDzjjQQGs4o/sNoezg1F1kYap9Nu2jcUdpwzRSJTHMMzG0H7bZkn4rNQpImhuxWX2A==",
       "dev": true,
       "requires": {
         "base64-js": "^1.0.2",
@@ -3294,9 +3077,9 @@
       }
     },
     "chownr": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.2.tgz",
-      "integrity": "sha512-GkfeAQh+QNy3wquu9oIZr6SS5x7wGdSgNQvD10X3r+AZr1Oys22HW8kAmDMvNg2+Dm0TeGaEuO8gFwdBXxwO8A==",
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.3.tgz",
+      "integrity": "sha512-i70fVHhmV3DtTl6nqvZOnIjbY0Pe4kAUjwHj8z0zAdgBtYrJyYwLKCCuRBQ5ppkyL0AkN7HKRnETdmdp1zqNXw==",
       "dev": true,
       "optional": true
     },
@@ -3525,9 +3308,9 @@
       "dev": true
     },
     "colors": {
-      "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/colors/-/colors-1.3.3.tgz",
-      "integrity": "sha512-mmGt/1pZqYRjMxB1axhTo16/snVZ5krrKkcmMeVKxzECMMXoCgnvTPp10QgHfcbQZw8Dq2jMNG6je4JlWU0gWg==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/colors/-/colors-1.4.0.tgz",
+      "integrity": "sha512-a+UqTh4kgZg/SlGvfbzDHpgRu7AAQOmmqRHJnxhRZICKFUT91brVhNNt58CMWU9PsBbv3PDCZUHbVxuDiH2mtA==",
       "dev": true
     },
     "colorspace": {
@@ -3679,12 +3462,12 @@
       "dev": true
     },
     "core-js-compat": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.2.1.tgz",
-      "integrity": "sha512-MwPZle5CF9dEaMYdDeWm73ao/IflDH+FjeJCWEADcEgFSE9TLimFKwJsfmkwzI8eC0Aj0mgvMDjeQjrElkz4/A==",
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.3.2.tgz",
+      "integrity": "sha512-gfiK4QnNXhnnHVOIZst2XHdFfdMTPxtR0EGs0TdILMlGIft+087oH6/Sw2xTTIjpWXC9vEwsJA8VG3XTGcmO5g==",
       "dev": true,
       "requires": {
-        "browserslist": "^4.6.6",
+        "browserslist": "^4.7.0",
         "semver": "^6.3.0"
       },
       "dependencies": {
@@ -3697,9 +3480,9 @@
       }
     },
     "core-js-pure": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.2.1.tgz",
-      "integrity": "sha512-+qpvnYrsi/JDeQTArB7NnNc2VoMYLE1YSkziCDHgjexC2KH7OFiGhLUd3urxfyWmNjSwSW7NYXPWHMhuIJx9Ow=="
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.3.2.tgz",
+      "integrity": "sha512-sw695hB0UxFXrSkUthEby5tMdjOYN3hVC8IGQePF1m3JYb9e/KjT0TOFWzaSzlKwGNglKCgLYUjiJ7uZvactiw=="
     },
     "core-util-is": {
       "version": "1.0.2",
@@ -3718,9 +3501,9 @@
       }
     },
     "coveralls": {
-      "version": "3.0.6",
-      "resolved": "https://registry.npmjs.org/coveralls/-/coveralls-3.0.6.tgz",
-      "integrity": "sha512-Pgh4v3gCI4T/9VijVrm8Ym5v0OgjvGLKj3zTUwkvsCiwqae/p6VLzpsFNjQS2i6ewV7ef+DjFJ5TSKxYt/mCrA==",
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/coveralls/-/coveralls-3.0.7.tgz",
+      "integrity": "sha512-mUuH2MFOYB2oBaA4D4Ykqi9LaEYpMMlsiOMJOrv358yAjP6enPIk55fod2fNJ8AvwoYXStWQls37rA+s5e7boA==",
       "dev": true,
       "requires": {
         "growl": "~> 1.10.0",
@@ -3778,14 +3561,14 @@
       },
       "dependencies": {
         "cross-spawn": {
-          "version": "7.0.0",
-          "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.0.tgz",
-          "integrity": "sha512-6U/8SMK2FBNnB21oQ4+6Nsodxanw1gTkntYA2zBdkFYFu3ZDx65P2ONEXGSvob/QS6REjVHQ9zxzdOafwFdstw==",
+          "version": "7.0.1",
+          "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.1.tgz",
+          "integrity": "sha512-u7v4o84SwFpD32Z8IIcPZ6z1/ie24O6RU3RbtL5Y316l3KuHVPx9ItBgWQ6VlfAFnRnTtMUrsQ9MUUTuEZjogg==",
           "dev": true,
           "requires": {
             "path-key": "^3.1.0",
-            "shebang-command": "^1.2.0",
-            "which": "^1.2.9"
+            "shebang-command": "^2.0.0",
+            "which": "^2.0.1"
           }
         },
         "path-key": {
@@ -3793,6 +3576,30 @@
           "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.0.tgz",
           "integrity": "sha512-8cChqz0RP6SHJkMt48FW0A7+qUOn+OsnOsVtzI59tZ8m+5bCSk7hzwET0pulwOM2YMn9J1efb07KB9l9f30SGg==",
           "dev": true
+        },
+        "shebang-command": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+          "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+          "dev": true,
+          "requires": {
+            "shebang-regex": "^3.0.0"
+          }
+        },
+        "shebang-regex": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+          "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+          "dev": true
+        },
+        "which": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/which/-/which-2.0.1.tgz",
+          "integrity": "sha512-N7GBZOTswtB9lkQBZA4+zAXrjEIWAUOB93AvzUiudRzRxhUdLURQ7D/gAIMY1gatT/LTbmbcv8SiYazy3eYB7w==",
+          "dev": true,
+          "requires": {
+            "isexe": "^2.0.0"
+          }
         }
       }
     },
@@ -3875,13 +3682,10 @@
       }
     },
     "data-uri-to-buffer": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-2.0.1.tgz",
-      "integrity": "sha512-OkVVLrerfAKZlW2ZZ3Ve2y65jgiWqBKsTfUIAFbn8nVbPcCZg6l6gikKlEYv0kXcmzqGm6mFq/Jf2vriuEkv8A==",
-      "dev": true,
-      "requires": {
-        "@types/node": "^8.0.7"
-      }
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-1.2.0.tgz",
+      "integrity": "sha512-vKQ9DTQPN1FLYiiEEOQ6IBGFqvjCa5rSK3cWMy/Nespm5d/x3dGFT9UBZnkLxCwua/IXBi2TYnwTEpsOvhC4UQ==",
+      "dev": true
     },
     "data-urls": {
       "version": "1.1.0",
@@ -4446,9 +4250,9 @@
       "dev": true
     },
     "electron-to-chromium": {
-      "version": "1.3.277",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.277.tgz",
-      "integrity": "sha512-Czmsrgng89DOgJlIknnw9bn5431QdtnUwGp5YYiPwU1DbZQUxCLF+rc1ZC09VNAdalOPcvH6AE8BaA0H5HjI/w==",
+      "version": "1.3.282",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.282.tgz",
+      "integrity": "sha512-irSaDeCGgfMu1OA30bhqIBr+dx+pDJjRbwCpob7YWqVZbzXblybNzPGklVnWqv4EXxbkEAzQYqiNCqNTgu00lQ==",
       "dev": true
     },
     "elliptic": {
@@ -4488,9 +4292,9 @@
       "dev": true
     },
     "end-of-stream": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.1.tgz",
-      "integrity": "sha512-1MkrZNvWTKCaigbn+W15elq2BB/L22nqrSY5DKlo3X6+vclJm8Bb5djXJBmEX6fS3+zCh/F4VBK5Z2KxJt4s2Q==",
+      "version": "1.4.4",
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.4.tgz",
+      "integrity": "sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==",
       "dev": true,
       "requires": {
         "once": "^1.4.0"
@@ -4518,9 +4322,9 @@
       }
     },
     "es-abstract": {
-      "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.14.1.tgz",
-      "integrity": "sha512-cp/Tb1oA/rh2X7vqeSOvM+TSo3UkJLX70eNihgVEvnzwAgikjkTFr/QVgRCaxjm0knCNQzNoxxxcw2zO2LJdZA==",
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.15.0.tgz",
+      "integrity": "sha512-bhkEqWJ2t2lMeaJDuk7okMkJWI/yqgH/EoGwpcvv0XW9RWQsRspI4wt6xuyuvMvvQE3gg/D9HXppgk21w78GyQ==",
       "dev": true,
       "requires": {
         "es-to-primitive": "^1.2.0",
@@ -4531,8 +4335,8 @@
         "is-regex": "^1.0.4",
         "object-inspect": "^1.6.0",
         "object-keys": "^1.1.1",
-        "string.prototype.trimleft": "^2.0.0",
-        "string.prototype.trimright": "^2.0.0"
+        "string.prototype.trimleft": "^2.1.0",
+        "string.prototype.trimright": "^2.1.0"
       }
     },
     "es-to-primitive": {
@@ -5214,9 +5018,9 @@
       "dev": true
     },
     "fast-safe-stringify": {
-      "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-2.0.6.tgz",
-      "integrity": "sha512-q8BZ89jjc+mz08rSxROs8VsrBBcn1SIw1kq9NjolL509tkABRk9io01RAjSaEv1Xb2uFLt8VtRiZbGp5H8iDtg==",
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-2.0.7.tgz",
+      "integrity": "sha512-Utm6CdzT+6xsDk2m8S6uL8VHxNwI6Jub+e9NYTcAms28T84pTa25GJQV9j0CY0N1rM8hK4x6grpF2BQf+2qwVA==",
       "dev": true
     },
     "fb-watchman": {
@@ -5405,9 +5209,9 @@
       }
     },
     "follow-redirects": {
-      "version": "1.8.1",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.8.1.tgz",
-      "integrity": "sha512-micCIbldHioIegeKs41DoH0KS3AXfFzgS30qVkM6z/XOE/GJgvmsoc839NUqa1B9udYe9dQxgv7KFwng6+p/dw==",
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.9.0.tgz",
+      "integrity": "sha512-CRcPzsSIbXyVDl0QI01muNDu69S8trU4jArW9LpOt2WtC6LyUJetcIrmfHsRBx7/Jb6GHJUiuqyYxPooFfNt6A==",
       "dev": true,
       "requires": {
         "debug": "^3.0.0"
@@ -5484,13 +5288,13 @@
       "dev": true
     },
     "fs-minipass": {
-      "version": "1.2.6",
-      "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-1.2.6.tgz",
-      "integrity": "sha512-crhvyXcMejjv3Z5d2Fa9sf5xLYVCF5O1c71QxbVnbLsmYMBEvDAftewesN/HhY03YRoA7zOMxjNGrF5svGaaeQ==",
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-1.2.7.tgz",
+      "integrity": "sha512-GWSSJGFy4e9GUeCcbIkED+bgAoFyj7XF1mV8rma3QW4NIqX9Kyx79N/PF61H5udOV3aY1IaMLs6pGbH71nlCTA==",
       "dev": true,
       "optional": true,
       "requires": {
-        "minipass": "^2.2.1"
+        "minipass": "^2.6.0"
       }
     },
     "fs-mkdirp-stream": {
@@ -6180,29 +5984,33 @@
       }
     },
     "get-uri": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/get-uri/-/get-uri-2.0.3.tgz",
-      "integrity": "sha512-x5j6Ks7FOgLD/GlvjKwgu7wdmMR55iuRHhn8hj/+gA+eSbxQvZ+AEomq+3MgVEZj1vpi738QahGbCCSIDtXtkw==",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/get-uri/-/get-uri-2.0.4.tgz",
+      "integrity": "sha512-v7LT/s8kVjs+Tx0ykk1I+H/rbpzkHvuIq87LmeXptcf5sNWm9uQiwjNAt94SJPA1zOlCntmnOlJvVWKmzsxG8Q==",
       "dev": true,
       "requires": {
-        "data-uri-to-buffer": "2",
-        "debug": "4",
+        "data-uri-to-buffer": "1",
+        "debug": "2",
         "extend": "~3.0.2",
         "file-uri-to-path": "1",
         "ftp": "~0.3.10",
-        "readable-stream": "3"
+        "readable-stream": "2"
       },
       "dependencies": {
-        "readable-stream": {
-          "version": "3.4.0",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.4.0.tgz",
-          "integrity": "sha512-jItXPLmrSR8jmTRmRWJXCnGJsfy85mB3Wd/uINMXA65yrnFo0cPClFIUWzo2najVNSl+mx7/4W8ttlLWJe99pQ==",
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
           "dev": true,
           "requires": {
-            "inherits": "^2.0.3",
-            "string_decoder": "^1.1.1",
-            "util-deprecate": "^1.0.1"
+            "ms": "2.0.0"
           }
+        },
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+          "dev": true
         }
       }
     },
@@ -6379,23 +6187,23 @@
       "dev": true
     },
     "graphql": {
-      "version": "14.5.4",
-      "resolved": "https://registry.npmjs.org/graphql/-/graphql-14.5.4.tgz",
-      "integrity": "sha512-dPLvHoxy5m9FrkqWczPPRnH0X80CyvRE6e7Fa5AWEqEAzg9LpxHvKh24po/482E6VWHigOkAmb4xCp6P9yT9gw==",
+      "version": "14.5.8",
+      "resolved": "https://registry.npmjs.org/graphql/-/graphql-14.5.8.tgz",
+      "integrity": "sha512-MMwmi0zlVLQKLdGiMfWkgQD7dY/TUKt4L+zgJ/aR0Howebod3aNgP5JkgvAULiR2HPVZaP2VEElqtdidHweLkg==",
       "dev": true,
       "requires": {
         "iterall": "^1.2.2"
       }
     },
     "graphql-extensions": {
-      "version": "0.10.3",
-      "resolved": "https://registry.npmjs.org/graphql-extensions/-/graphql-extensions-0.10.3.tgz",
-      "integrity": "sha512-kwU0gUe+Qdfr8iZYT91qrPSwQNgPhB/ClF1m1LEPdxlptk5FhFmjpxAcbMZ8q7j0kjfnbp2IeV1OhRDCEPqz2w==",
+      "version": "0.10.4",
+      "resolved": "https://registry.npmjs.org/graphql-extensions/-/graphql-extensions-0.10.4.tgz",
+      "integrity": "sha512-lE6MroluEYocbR/ICwccv39w+Pz4cBPadJ11z1rJkbZv5wstISEganbDOwl9qN21rcZGiWzh7QUNxUiFUXXEDw==",
       "dev": true,
       "requires": {
         "@apollographql/apollo-tools": "^0.4.0",
         "apollo-server-env": "^2.4.3",
-        "apollo-server-types": "^0.2.4"
+        "apollo-server-types": "^0.2.5"
       }
     },
     "graphql-list-fields": {
@@ -6433,15 +6241,30 @@
       }
     },
     "graphql-upload": {
-      "version": "8.0.7",
-      "resolved": "https://registry.npmjs.org/graphql-upload/-/graphql-upload-8.0.7.tgz",
-      "integrity": "sha512-gi2yygbDPXbHPC7H0PNPqP++VKSoNoJO4UrXWq4T0Bi4IhyUd3Ycop/FSxhx2svWIK3jdXR/i0vi91yR1aAF0g==",
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/graphql-upload/-/graphql-upload-8.1.0.tgz",
+      "integrity": "sha512-U2OiDI5VxYmzRKw0Z2dmfk0zkqMRaecH9Smh1U277gVgVe9Qn+18xqf4skwr4YJszGIh7iQDZ57+5ygOK9sM/Q==",
       "dev": true,
       "requires": {
         "busboy": "^0.3.1",
         "fs-capacitor": "^2.0.4",
-        "http-errors": "^1.7.2",
+        "http-errors": "^1.7.3",
         "object-path": "^0.11.4"
+      },
+      "dependencies": {
+        "http-errors": {
+          "version": "1.7.3",
+          "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.7.3.tgz",
+          "integrity": "sha512-ZTTX0MWrsQ2ZAhA1cejAwDLycFsd7I7nVtnkT3Ol0aqodaKW+0CTZDQ1uBv5whptCnc8e8HeRRJxRs0kmm/Qfw==",
+          "dev": true,
+          "requires": {
+            "depd": "~1.1.2",
+            "inherits": "2.0.4",
+            "setprototypeof": "1.1.1",
+            "statuses": ">= 1.5.0 < 2",
+            "toidentifier": "1.0.0"
+          }
+        }
       }
     },
     "growl": {
@@ -6894,9 +6717,9 @@
       }
     },
     "handlebars": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.2.0.tgz",
-      "integrity": "sha512-Kb4xn5Qh1cxAKvQnzNWZ512DhABzyFNmsaJf3OAkWNa4NkaqWcNI8Tao8Tasi0/F4JD9oyG0YxuFyvyR57d+Gw==",
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.4.3.tgz",
+      "integrity": "sha512-B0W4A2U1ww3q7VVthTKfh+epHx+q4mCt6iK+zEAzbMBpWQAwxCeKxEGpj/1oQTpzPXDNSOG7hmG14TsISH50yw==",
       "dev": true,
       "requires": {
         "neo-async": "^2.6.0",
@@ -7055,9 +6878,9 @@
       }
     },
     "hosted-git-info": {
-      "version": "2.8.4",
-      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.4.tgz",
-      "integrity": "sha512-pzXIvANXEFrc5oFFXRMkbLPQ2rXRoDERwDLyrcUxGhaZhgP54BBSl9Oheh7Vv0T090cszWBxPjkQQ5Sq1PbBRQ==",
+      "version": "2.8.5",
+      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.5.tgz",
+      "integrity": "sha512-kssjab8CvdXfcXMXVcvsXum4Hwdq9XGtRD3TteMEvEbq0LXyiNQr6AprqKqfeaDXze7SxWvRxdpwE6ku7ikLkg==",
       "dev": true
     },
     "html-encoding-sniffer": {
@@ -7183,9 +7006,9 @@
       "dev": true
     },
     "ignore-walk": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/ignore-walk/-/ignore-walk-3.0.1.tgz",
-      "integrity": "sha512-DTVlMx3IYPe0/JJcYP7Gxg7ttZZu3IInhuEhbchuqneY9wWe5Ojy2mXLBaQFUQmo0AW2r3qG7m1mg86js+gnlQ==",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/ignore-walk/-/ignore-walk-3.0.3.tgz",
+      "integrity": "sha512-m7o6xuOaT1aqheYHKf8W6J5pYH85ZI9w077erOzLje3JsB1gkafkAhHHY19dqjulgIZHFm32Cp5uNZgcQqdJKw==",
       "dev": true,
       "requires": {
         "minimatch": "^3.0.4"
@@ -9022,9 +8845,9 @@
       },
       "dependencies": {
         "yallist": {
-          "version": "3.0.3",
-          "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.0.3.tgz",
-          "integrity": "sha512-S+Zk8DEWE6oKpV+vI3qWkaK+jSbIK86pCwe2IF/xwIpQ8jEuxpw9NyaGjmp9+BoJv5FV2piqCDcoCtStppiq2A==",
+          "version": "3.1.1",
+          "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
+          "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
           "dev": true
         }
       }
@@ -9328,9 +9151,9 @@
       "dev": true
     },
     "minipass": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/minipass/-/minipass-2.5.0.tgz",
-      "integrity": "sha512-9FwMVYhn6ERvMR8XFdOavRz4QK/VJV8elU1x50vYexf9lslDcWe/f4HBRxCPd185ekRSjU6CfYyJCECa/CQy7Q==",
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-2.9.0.tgz",
+      "integrity": "sha512-wxfUjg9WebH+CUDX/CdbRlh5SmfZiy/hpkxaRI16Y9W56Pa75sWgd/rvFilSgrauD9NyFymP/+JFV3KwzIsJeg==",
       "dev": true,
       "optional": true,
       "requires": {
@@ -9339,22 +9162,22 @@
       },
       "dependencies": {
         "yallist": {
-          "version": "3.0.3",
-          "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.0.3.tgz",
-          "integrity": "sha512-S+Zk8DEWE6oKpV+vI3qWkaK+jSbIK86pCwe2IF/xwIpQ8jEuxpw9NyaGjmp9+BoJv5FV2piqCDcoCtStppiq2A==",
+          "version": "3.1.1",
+          "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
+          "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
           "dev": true,
           "optional": true
         }
       }
     },
     "minizlib": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-1.2.1.tgz",
-      "integrity": "sha512-7+4oTUOWKg7AuL3vloEWekXY2/D20cevzsrNT2kGWm+39J9hGTCBv8VI5Pm5lXZ/o3/mdR4f8rflAPhnQb8mPA==",
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-1.3.3.tgz",
+      "integrity": "sha512-6ZYMOEnmVsdCeTJVE0W9ZD+pVnE8h9Hma/iOwwRDsdQoePpoX56/8B6z3P9VNwppJuBKNRuFDRNRqRWexT9G9Q==",
       "dev": true,
       "optional": true,
       "requires": {
-        "minipass": "^2.2.1"
+        "minipass": "^2.9.0"
       }
     },
     "mixin-deep": {
@@ -9657,9 +9480,9 @@
       }
     },
     "node-rsa": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/node-rsa/-/node-rsa-1.0.5.tgz",
-      "integrity": "sha512-9o51yfV167CtQANnuAf+5owNs7aIMsAKVLhNaKuRxihsUUnfoBMN5OTVOK/2mHSOWaWq9zZBiRM3bHORbTZqrg==",
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/node-rsa/-/node-rsa-1.0.6.tgz",
+      "integrity": "sha512-v42495lozKpuQmrcIzld9ds/Tn7pwjuh0BHSHnhPrKkAVSyTAyrZodFLFafOfWiUKamLt4lgWdngP8W/LzCm2w==",
       "dev": true,
       "requires": {
         "asn1": "^0.2.4"
@@ -9714,9 +9537,9 @@
       "optional": true
     },
     "npm-packlist": {
-      "version": "1.4.4",
-      "resolved": "https://registry.npmjs.org/npm-packlist/-/npm-packlist-1.4.4.tgz",
-      "integrity": "sha512-zTLo8UcVYtDU3gdeaFu2Xu0n0EvelfHDGuqtNIn5RO7yQj4H1TqNdBc/yZjxnWA0PVB8D3Woyp0i5B43JwQ6Vw==",
+      "version": "1.4.6",
+      "resolved": "https://registry.npmjs.org/npm-packlist/-/npm-packlist-1.4.6.tgz",
+      "integrity": "sha512-u65uQdb+qwtGvEJh/DgQgW1Xg7sqeNbmxYyrvlNznaVTjV3E5P6F/EFjM+BVHXl7JJlsdG8A64M0XI8FI/IOlg==",
       "dev": true,
       "optional": true,
       "requires": {
@@ -10152,9 +9975,9 @@
       }
     },
     "parse": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/parse/-/parse-2.7.0.tgz",
-      "integrity": "sha512-q2o+YMh+JjmuN0/5TTcGQF07xOcSauL3tyb55OUDGjso8N3X7LXQ+h0g2MPDLyLBdZhAc2534xG5zw91N5GuIw==",
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/parse/-/parse-2.7.1.tgz",
+      "integrity": "sha512-JmargoFb20Z1u28Coz6tNlRlinD1aRj1fCTNaTVjJJXTGvorbIHLYSNWDKmbOM+uUSM1LBjxK2/1GgLR3FAQAw==",
       "dev": true,
       "requires": {
         "@babel/runtime": "7.5.5",
@@ -10192,9 +10015,9 @@
       }
     },
     "parse-asn1": {
-      "version": "5.1.4",
-      "resolved": "https://registry.npmjs.org/parse-asn1/-/parse-asn1-5.1.4.tgz",
-      "integrity": "sha512-Qs5duJcuvNExRfFZ99HDD3z4mAi3r9Wl/FOjEOijlxwCZs7E7mW2vjTpgQ4J8LpTF8x5v+1Vn5UQFejmWT11aw==",
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/parse-asn1/-/parse-asn1-5.1.5.tgz",
+      "integrity": "sha512-jkMYn1dcJqF6d5CpU689bq7w/b5ALS9ROVSpQDPrZsqqesUJii9qutvoT5ltGedNXMO2e16YUWIghG9KxaViTQ==",
       "dev": true,
       "requires": {
         "asn1.js": "^4.0.0",
@@ -10268,37 +10091,37 @@
       "dev": true
     },
     "parse-server": {
-      "version": "github:parse-community/parse-server#ac40bf66f7cdeeb578fd716a8e3dd540470209ca",
+      "version": "github:parse-community/parse-server#c9902ac0bc0e92249dd5255cf6a840534a4b3271",
       "from": "github:parse-community/parse-server#master",
       "dev": true,
       "requires": {
         "@apollographql/graphql-playground-html": "1.6.24",
         "@parse/fs-files-adapter": "1.0.1",
-        "@parse/push-adapter": "3.0.10",
-        "@parse/s3-files-adapter": "1.2.3",
+        "@parse/push-adapter": "3.1.0",
+        "@parse/s3-files-adapter": "1.3.0",
         "@parse/simple-mailgun-adapter": "1.1.0",
-        "apollo-server-express": "2.9.3",
+        "apollo-server-express": "2.9.6",
         "bcrypt": "3.0.6",
         "bcryptjs": "2.4.3",
         "body-parser": "1.19.0",
-        "commander": "3.0.1",
+        "commander": "3.0.2",
         "cors": "2.8.5",
         "deepcopy": "2.0.0",
         "express": "4.17.1",
-        "follow-redirects": "1.8.1",
-        "graphql": "14.5.4",
+        "follow-redirects": "1.9.0",
+        "graphql": "14.5.8",
         "graphql-list-fields": "2.0.2",
         "graphql-tools": "^4.0.5",
-        "graphql-upload": "8.0.7",
+        "graphql-upload": "8.1.0",
         "intersect": "1.0.1",
         "jsonwebtoken": "8.5.1",
         "lodash": "4.17.15",
         "lru-cache": "5.1.1",
         "mime": "2.4.4",
         "mongodb": "3.3.2",
-        "node-rsa": "1.0.5",
-        "parse": "2.7.0",
-        "pg-promise": "9.1.2",
+        "node-rsa": "1.0.6",
+        "parse": "2.7.1",
+        "pg-promise": "9.3.3",
         "pluralize": "^8.0.0",
         "redis": "2.8.0",
         "semver": "6.3.0",
@@ -10311,9 +10134,9 @@
       },
       "dependencies": {
         "commander": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/commander/-/commander-3.0.1.tgz",
-          "integrity": "sha512-UNgvDd+csKdc9GD4zjtkHKQbT8Aspt2jCBqNSPp53vAS0L1tS9sXB2TCEOPHJ7kt9bN/niWkYj8T3RQSoMXdSQ==",
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-3.0.2.tgz",
+          "integrity": "sha512-Gar0ASD4BDyKC4hl4DwHqDrmvjoxWKZigVnAbn5H1owvm4CxCPdb0HQDehwNYMJpla5+M2tPmPARzhtYuwpHow==",
           "dev": true
         },
         "mime": {
@@ -10492,9 +10315,9 @@
       "dev": true
     },
     "pg-minify": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/pg-minify/-/pg-minify-1.5.0.tgz",
-      "integrity": "sha512-qcH0oUJl6ayAlX8rIO6dGFIbtbMKw0NoMDfXCOpRFUryPJZKh7yj8hsWfGfBgeHW1zkpe8etLo3AdeU7nBPqmw==",
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/pg-minify/-/pg-minify-1.5.1.tgz",
+      "integrity": "sha512-nqUTo8y9T0VhiJoWC0sK0+2S8hYDiu7CdH0Z9ijPi2iikiQ44mfcAFxEJxfvF8H3h/bDBvXthtOQPIB3pLWIow==",
       "dev": true
     },
     "pg-pool": {
@@ -10504,15 +10327,15 @@
       "dev": true
     },
     "pg-promise": {
-      "version": "9.1.2",
-      "resolved": "https://registry.npmjs.org/pg-promise/-/pg-promise-9.1.2.tgz",
-      "integrity": "sha512-7b34YoxDechuN5rUKjxGzJ+OEW7GIAkbeJK/X1zZdkTDrnI37Is5+MnumnIziJWkgu65pnH3guu3oAAkR9e1ng==",
+      "version": "9.3.3",
+      "resolved": "https://registry.npmjs.org/pg-promise/-/pg-promise-9.3.3.tgz",
+      "integrity": "sha512-C7Mj5RSUvK0cGOaJ0p1fcOk5jhS1n+HgY+DoE8s1+Zjzf6ta70zYDIlOmy6MtYWs4DFHhUW654hb0FmtGKkIkg==",
       "dev": true,
       "requires": {
         "assert-options": "0.6.0",
         "manakin": "0.5.2",
         "pg": "7.12.1",
-        "pg-minify": "1.5.0",
+        "pg-minify": "1.5.1",
         "spex": "3.0.0"
       }
     },
@@ -10737,9 +10560,9 @@
       },
       "dependencies": {
         "@types/node": {
-          "version": "10.14.17",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-10.14.17.tgz",
-          "integrity": "sha512-p/sGgiPaathCfOtqu2fx5Mu1bcjuP8ALFg4xpGgNkcin7LwRyzUKniEHBKdcE1RPsenq5JVPIpMTJSygLboygQ==",
+          "version": "10.14.22",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-10.14.22.tgz",
+          "integrity": "sha512-9taxKC944BqoTVjE+UT3pQH0nHZlTvITwfsOZqyc+R3sfJuxaTtxWjfn1K2UlxyPcKHf0rnaXcVFrS9F9vf0bw==",
           "dev": true
         }
       }
@@ -10804,9 +10627,9 @@
       "dev": true
     },
     "psl": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/psl/-/psl-1.3.1.tgz",
-      "integrity": "sha512-2KLd5fKOdAfShtY2d/8XDWVRnmp3zp40Qt6ge2zBPFARLXOGUf2fHD5eg+TV/5oxBtQKVhjUaKFsAaE4HnwfSA==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/psl/-/psl-1.4.0.tgz",
+      "integrity": "sha512-HZzqCGPecFLyoRj5HLfuDSKYTJkAfB5thKBIkRHtGjWwY7p1dAyveIbXIq4tO0KYfDF2tHqPUgY9SDnGm00uFw==",
       "dev": true
     },
     "public-encrypt": {
@@ -10959,9 +10782,9 @@
       }
     },
     "react-is": {
-      "version": "16.9.0",
-      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.9.0.tgz",
-      "integrity": "sha512-tJBzzzIgnnRfEm046qRcURvwQnZVXmuCbscxUO5RWrGTXpon2d4c8mI0D8WE6ydVIm29JiLB6+RslkIvym9Rjw==",
+      "version": "16.10.2",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.10.2.tgz",
+      "integrity": "sha512-INBT1QEgtcCCgvccr5/86CfD71fw9EPmDxgiJX4I2Ddr6ZsV6iFXsuby+qWJPtmNuMY0zByTsG4468P7nHuNWA==",
       "dev": true
     },
     "read-only-stream": {
@@ -12181,23 +12004,23 @@
       }
     },
     "string.prototype.trimleft": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/string.prototype.trimleft/-/string.prototype.trimleft-2.0.0.tgz",
-      "integrity": "sha1-aLaqjhYsaoDnbjqKDC50cYbicf8=",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/string.prototype.trimleft/-/string.prototype.trimleft-2.1.0.tgz",
+      "integrity": "sha512-FJ6b7EgdKxxbDxc79cOlok6Afd++TTs5szo+zJTUyow3ycrRfJVE2pq3vcN53XexvKZu/DJMDfeI/qMiZTrjTw==",
       "dev": true,
       "requires": {
-        "define-properties": "^1.1.2",
-        "function-bind": "^1.0.2"
+        "define-properties": "^1.1.3",
+        "function-bind": "^1.1.1"
       }
     },
     "string.prototype.trimright": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/string.prototype.trimright/-/string.prototype.trimright-2.0.0.tgz",
-      "integrity": "sha1-q0pW2AKgH75yk+EehPJNyBZGYd0=",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/string.prototype.trimright/-/string.prototype.trimright-2.1.0.tgz",
+      "integrity": "sha512-fXZTSV55dNBwv16uw+hh5jkghxSnc5oHq+5K/gXgizHwAvMetdAJlHqqoFC1FSDVPYWLkAKl2cxpUT41sV7nSg==",
       "dev": true,
       "requires": {
-        "define-properties": "^1.1.2",
-        "function-bind": "^1.0.2"
+        "define-properties": "^1.1.3",
+        "function-bind": "^1.1.1"
       }
     },
     "string_decoder": {
@@ -12378,15 +12201,15 @@
       "dev": true
     },
     "tar": {
-      "version": "4.4.10",
-      "resolved": "https://registry.npmjs.org/tar/-/tar-4.4.10.tgz",
-      "integrity": "sha512-g2SVs5QIxvo6OLp0GudTqEf05maawKUxXru104iaayWA09551tFCTI8f1Asb4lPfkBr91k07iL4c11XO3/b0tA==",
+      "version": "4.4.13",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-4.4.13.tgz",
+      "integrity": "sha512-w2VwSrBoHa5BsSyH+KxEqeQBAllHhccyMFVHtGtdMpF4W7IRWfZjFiQceJPChOeTsSDVUpER2T8FA93pr0L+QA==",
       "dev": true,
       "optional": true,
       "requires": {
         "chownr": "^1.1.1",
         "fs-minipass": "^1.2.5",
-        "minipass": "^2.3.5",
+        "minipass": "^2.8.6",
         "minizlib": "^1.2.1",
         "mkdirp": "^0.5.0",
         "safe-buffer": "^5.1.2",
@@ -12394,9 +12217,9 @@
       },
       "dependencies": {
         "yallist": {
-          "version": "3.0.3",
-          "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.0.3.tgz",
-          "integrity": "sha512-S+Zk8DEWE6oKpV+vI3qWkaK+jSbIK86pCwe2IF/xwIpQ8jEuxpw9NyaGjmp9+BoJv5FV2piqCDcoCtStppiq2A==",
+          "version": "3.1.1",
+          "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
+          "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
           "dev": true,
           "optional": true
         }
@@ -12613,12 +12436,6 @@
         }
       }
     },
-    "trim-right": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/trim-right/-/trim-right-1.0.1.tgz",
-      "integrity": "sha1-yy4SAwZ+DI3h9hQJS5/kVwTqYAM=",
-      "dev": true
-    },
     "triple-beam": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/triple-beam/-/triple-beam-1.3.0.tgz",
@@ -12674,9 +12491,9 @@
       "dev": true
     },
     "type": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/type/-/type-1.0.3.tgz",
-      "integrity": "sha512-51IMtNfVcee8+9GJvj0spSuFcZHe9vSib6Xtgsny1Km9ugyz2mbS08I3rsUIRYgJohFRFU1160sgRodYz378Hg==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/type/-/type-1.2.0.tgz",
+      "integrity": "sha512-+5nt5AAniqsCnu2cEQQdpzCAh33kVx8n0VoFidKpB1dVVLAN/F+bgVOqOJqOnEnrhp222clB5p3vUlD+1QAnfg==",
       "dev": true
     },
     "type-check": {
@@ -12717,12 +12534,12 @@
       "dev": true
     },
     "uglify-js": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.6.0.tgz",
-      "integrity": "sha512-W+jrUHJr3DXKhrsS7NUVxn3zqMOFn0hL/Ei6v0anCIMoKC93TjcflTagwIHLW7SfMFfiQuktQyFVCFHGUE0+yg==",
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.6.2.tgz",
+      "integrity": "sha512-+gh/xFte41GPrgSMJ/oJVq15zYmqr74pY9VoM69UzMzq9NFk4YDylclb1/bhEzZSaUQjbW5RvniHeq1cdtRYjw==",
       "dev": true,
       "requires": {
-        "commander": "~2.20.0",
+        "commander": "2.20.0",
         "source-map": "~0.6.1"
       },
       "dependencies": {
@@ -12733,12 +12550,6 @@
           "dev": true
         }
       }
-    },
-    "ultron": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/ultron/-/ultron-1.1.1.tgz",
-      "integrity": "sha512-UIEXBNeYmKptWH6z8ZnqTeS8fV74zG0/eRU9VGkpzz+LIJNs8W/zM/L+7ctCkRrgbNnnR0xxw4bKOr0cW0N0Og==",
-      "dev": true
     },
     "umd": {
       "version": "3.0.3",
@@ -13666,9 +13477,9 @@
       "dev": true
     },
     "zen-observable-ts": {
-      "version": "0.8.19",
-      "resolved": "https://registry.npmjs.org/zen-observable-ts/-/zen-observable-ts-0.8.19.tgz",
-      "integrity": "sha512-u1a2rpE13G+jSzrg3aiCqXU5tN2kw41b+cBZGmnc+30YimdkKiDj9bTowcB41eL77/17RF/h+393AuVgShyheQ==",
+      "version": "0.8.20",
+      "resolved": "https://registry.npmjs.org/zen-observable-ts/-/zen-observable-ts-0.8.20.tgz",
+      "integrity": "sha512-2rkjiPALhOtRaDX6pWyNqK1fnP5KkJJybYebopNSn6wDG1lxBoFs2+nwwXKoA6glHIrtwrfBBy6da0stkKtTAA==",
       "dev": true,
       "requires": {
         "tslib": "^1.9.3",

--- a/src/ParseSchema.js
+++ b/src/ParseSchema.js
@@ -206,7 +206,7 @@ class ParseSchema {
     if (typeof options.required === 'boolean') {
       fieldOptions.required = options.required;
     }
-    if (typeof options.defaultValue !== undefined) {
+    if (options.defaultValue !== undefined) {
       fieldOptions.defaultValue = options.defaultValue;
     }
     this._fields[name] = fieldOptions;
@@ -342,7 +342,7 @@ class ParseSchema {
     if (typeof options.required === 'boolean') {
       fieldOptions.required = options.required;
     }
-    if (typeof options.defaultValue !== undefined) {
+    if (options.defaultValue !== undefined) {
       fieldOptions.defaultValue = options.defaultValue;
     }
     this._fields[name] = fieldOptions;

--- a/src/ParseSchema.js
+++ b/src/ParseSchema.js
@@ -13,13 +13,21 @@ import CoreManager from './CoreManager';
 
 const FIELD_TYPES = ['String', 'Number', 'Boolean', 'Date', 'File', 'GeoPoint', 'Polygon', 'Array', 'Object', 'Pointer', 'Relation'];
 
+type FieldOptions = {
+  required: boolean;
+  defaultValue: mixed;
+};
+
 /**
  * A Parse.Schema object is for handling schema data from Parse.
  * <p>All the schemas methods require MasterKey.
  *
+ * When adding fields, you may set required and default values. (Requires Parse Server 3.7.0+)
+ *
  * <pre>
+ * const options = { required: true, defaultValue: 'hello world' };
  * const schema = new Parse.Schema('MyClass');
- * schema.addString('field');
+ * schema.addString('field', options);
  * schema.addIndex('index_name', { 'field': 1 });
  * schema.save();
  * </pre>
@@ -180,10 +188,11 @@ class ParseSchema {
    * Adding a Field to Create / Update a Schema
    *
    * @param {String} name Name of the field that will be created on Parse
-   * @param {String} type TheCan be a (String|Number|Boolean|Date|Parse.File|Parse.GeoPoint|Array|Object|Pointer|Parse.Relation)
+   * @param {String} type Can be a (String|Number|Boolean|Date|Parse.File|Parse.GeoPoint|Array|Object|Pointer|Parse.Relation)
+   * @param {Object} options
    * @return {Parse.Schema} Returns the schema, so you can chain this call.
    */
-  addField(name: string, type: string) {
+  addField(name: string, type: string, options: FieldOptions = {}) {
     type = type || 'String';
 
     if (!name) {
@@ -192,9 +201,15 @@ class ParseSchema {
     if (FIELD_TYPES.indexOf(type) === -1) {
       throw new Error(`${type} is not a valid type.`);
     }
+    const fieldOptions = { type };
 
-    this._fields[name] = { type };
-
+    if (typeof options.required === 'boolean') {
+      fieldOptions.required = options.required;
+    }
+    if (typeof options.defaultValue !== undefined) {
+      fieldOptions.defaultValue = options.defaultValue;
+    }
+    this._fields[name] = fieldOptions;
     return this;
   }
 
@@ -224,8 +239,8 @@ class ParseSchema {
    * @param {String} name Name of the field that will be created on Parse
    * @return {Parse.Schema} Returns the schema, so you can chain this call.
    */
-  addString(name: string) {
-    return this.addField(name, 'String');
+  addString(name: string, options: FieldOptions) {
+    return this.addField(name, 'String', options);
   }
 
   /**
@@ -234,8 +249,8 @@ class ParseSchema {
    * @param {String} name Name of the field that will be created on Parse
    * @return {Parse.Schema} Returns the schema, so you can chain this call.
    */
-  addNumber(name: string) {
-    return this.addField(name, 'Number');
+  addNumber(name: string, options: FieldOptions) {
+    return this.addField(name, 'Number', options);
   }
 
   /**
@@ -244,8 +259,8 @@ class ParseSchema {
    * @param {String} name Name of the field that will be created on Parse
    * @return {Parse.Schema} Returns the schema, so you can chain this call.
    */
-  addBoolean(name: string) {
-    return this.addField(name, 'Boolean');
+  addBoolean(name: string, options: FieldOptions) {
+    return this.addField(name, 'Boolean', options);
   }
 
   /**
@@ -254,8 +269,8 @@ class ParseSchema {
    * @param {String} name Name of the field that will be created on Parse
    * @return {Parse.Schema} Returns the schema, so you can chain this call.
    */
-  addDate(name: string) {
-    return this.addField(name, 'Date');
+  addDate(name: string, options: FieldOptions) {
+    return this.addField(name, 'Date', options);
   }
 
   /**
@@ -264,8 +279,8 @@ class ParseSchema {
    * @param {String} name Name of the field that will be created on Parse
    * @return {Parse.Schema} Returns the schema, so you can chain this call.
    */
-  addFile(name: string) {
-    return this.addField(name, 'File');
+  addFile(name: string, options: FieldOptions) {
+    return this.addField(name, 'File', options);
   }
 
   /**
@@ -274,8 +289,8 @@ class ParseSchema {
    * @param {String} name Name of the field that will be created on Parse
    * @return {Parse.Schema} Returns the schema, so you can chain this call.
    */
-  addGeoPoint(name: string) {
-    return this.addField(name, 'GeoPoint');
+  addGeoPoint(name: string, options: FieldOptions) {
+    return this.addField(name, 'GeoPoint', options);
   }
 
   /**
@@ -284,8 +299,8 @@ class ParseSchema {
    * @param {String} name Name of the field that will be created on Parse
    * @return {Parse.Schema} Returns the schema, so you can chain this call.
    */
-  addPolygon(name: string) {
-    return this.addField(name, 'Polygon');
+  addPolygon(name: string, options: FieldOptions) {
+    return this.addField(name, 'Polygon', options);
   }
 
   /**
@@ -294,8 +309,8 @@ class ParseSchema {
    * @param {String} name Name of the field that will be created on Parse
    * @return {Parse.Schema} Returns the schema, so you can chain this call.
    */
-  addArray(name: string) {
-    return this.addField(name, 'Array');
+  addArray(name: string, options: FieldOptions) {
+    return this.addField(name, 'Array', options);
   }
 
   /**
@@ -304,8 +319,8 @@ class ParseSchema {
    * @param {String} name Name of the field that will be created on Parse
    * @return {Parse.Schema} Returns the schema, so you can chain this call.
    */
-  addObject(name: string) {
-    return this.addField(name, 'Object');
+  addObject(name: string, options: FieldOptions) {
+    return this.addField(name, 'Object', options);
   }
 
   /**
@@ -315,19 +330,22 @@ class ParseSchema {
    * @param {String} targetClass Name of the target Pointer Class
    * @return {Parse.Schema} Returns the schema, so you can chain this call.
    */
-  addPointer(name: string, targetClass: string) {
+  addPointer(name: string, targetClass: string, options: FieldOptions = {}) {
     if (!name) {
       throw new Error('field name may not be null.');
     }
     if (!targetClass) {
       throw new Error('You need to set the targetClass of the Pointer.');
     }
+    const fieldOptions = { type: 'Pointer', targetClass };
 
-    this._fields[name] = {
-      type: 'Pointer',
-      targetClass
-    };
-
+    if (typeof options.required === 'boolean') {
+      fieldOptions.required = options.required;
+    }
+    if (typeof options.defaultValue !== undefined) {
+      fieldOptions.defaultValue = options.defaultValue;
+    }
+    this._fields[name] = fieldOptions;
     return this;
   }
 

--- a/src/ParseSchema.js
+++ b/src/ParseSchema.js
@@ -10,6 +10,7 @@
  */
 
 import CoreManager from './CoreManager';
+import ParseObject from './ParseObject';
 
 const FIELD_TYPES = ['String', 'Number', 'Boolean', 'Date', 'File', 'GeoPoint', 'Polygon', 'Array', 'Object', 'Pointer', 'Relation'];
 
@@ -270,6 +271,9 @@ class ParseSchema {
    * @return {Parse.Schema} Returns the schema, so you can chain this call.
    */
   addDate(name: string, options: FieldOptions) {
+    if (options && options.defaultValue) {
+      options.defaultValue = { __type: 'Date', iso: new Date(options.defaultValue) }
+    }
     return this.addField(name, 'Date', options);
   }
 
@@ -344,6 +348,9 @@ class ParseSchema {
     }
     if (options.defaultValue !== undefined) {
       fieldOptions.defaultValue = options.defaultValue;
+      if (options.defaultValue instanceof ParseObject) {
+        fieldOptions.defaultValue = options.defaultValue.toPointer();
+      }
     }
     this._fields[name] = fieldOptions;
     return this;

--- a/src/ParseSchema.js
+++ b/src/ParseSchema.js
@@ -191,6 +191,10 @@ class ParseSchema {
    * @param {String} name Name of the field that will be created on Parse
    * @param {String} type Can be a (String|Number|Boolean|Date|Parse.File|Parse.GeoPoint|Array|Object|Pointer|Parse.Relation)
    * @param {Object} options
+   * Valid options are:<ul>
+   *   <li>required: If field is not set, save operation fails (Requires Parse Server 3.7.0+)
+   *   <li>defaultValue: If field is not set, a default value is selected (Requires Parse Server 3.7.0+)
+   * </ul>
    * @return {Parse.Schema} Returns the schema, so you can chain this call.
    */
   addField(name: string, type: string, options: FieldOptions = {}) {
@@ -238,6 +242,7 @@ class ParseSchema {
    * Adding String Field
    *
    * @param {String} name Name of the field that will be created on Parse
+   * @param {Object} options See {@link https://parseplatform.org/Parse-SDK-JS/api/master/Parse.Schema.html#addField addField}
    * @return {Parse.Schema} Returns the schema, so you can chain this call.
    */
   addString(name: string, options: FieldOptions) {
@@ -248,6 +253,7 @@ class ParseSchema {
    * Adding Number Field
    *
    * @param {String} name Name of the field that will be created on Parse
+   * @param {Object} options See {@link https://parseplatform.org/Parse-SDK-JS/api/master/Parse.Schema.html#addField addField}
    * @return {Parse.Schema} Returns the schema, so you can chain this call.
    */
   addNumber(name: string, options: FieldOptions) {
@@ -258,6 +264,7 @@ class ParseSchema {
    * Adding Boolean Field
    *
    * @param {String} name Name of the field that will be created on Parse
+   * @param {Object} options See {@link https://parseplatform.org/Parse-SDK-JS/api/master/Parse.Schema.html#addField addField}
    * @return {Parse.Schema} Returns the schema, so you can chain this call.
    */
   addBoolean(name: string, options: FieldOptions) {
@@ -268,6 +275,7 @@ class ParseSchema {
    * Adding Date Field
    *
    * @param {String} name Name of the field that will be created on Parse
+   * @param {Object} options See {@link https://parseplatform.org/Parse-SDK-JS/api/master/Parse.Schema.html#addField addField}
    * @return {Parse.Schema} Returns the schema, so you can chain this call.
    */
   addDate(name: string, options: FieldOptions) {
@@ -281,6 +289,7 @@ class ParseSchema {
    * Adding File Field
    *
    * @param {String} name Name of the field that will be created on Parse
+   * @param {Object} options See {@link https://parseplatform.org/Parse-SDK-JS/api/master/Parse.Schema.html#addField addField}
    * @return {Parse.Schema} Returns the schema, so you can chain this call.
    */
   addFile(name: string, options: FieldOptions) {
@@ -291,6 +300,7 @@ class ParseSchema {
    * Adding GeoPoint Field
    *
    * @param {String} name Name of the field that will be created on Parse
+   * @param {Object} options See {@link https://parseplatform.org/Parse-SDK-JS/api/master/Parse.Schema.html#addField addField}
    * @return {Parse.Schema} Returns the schema, so you can chain this call.
    */
   addGeoPoint(name: string, options: FieldOptions) {
@@ -301,6 +311,7 @@ class ParseSchema {
    * Adding Polygon Field
    *
    * @param {String} name Name of the field that will be created on Parse
+   * @param {Object} options See {@link https://parseplatform.org/Parse-SDK-JS/api/master/Parse.Schema.html#addField addField}
    * @return {Parse.Schema} Returns the schema, so you can chain this call.
    */
   addPolygon(name: string, options: FieldOptions) {
@@ -311,6 +322,7 @@ class ParseSchema {
    * Adding Array Field
    *
    * @param {String} name Name of the field that will be created on Parse
+   * @param {Object} options See {@link https://parseplatform.org/Parse-SDK-JS/api/master/Parse.Schema.html#addField addField}
    * @return {Parse.Schema} Returns the schema, so you can chain this call.
    */
   addArray(name: string, options: FieldOptions) {
@@ -321,6 +333,7 @@ class ParseSchema {
    * Adding Object Field
    *
    * @param {String} name Name of the field that will be created on Parse
+   * @param {Object} options See {@link https://parseplatform.org/Parse-SDK-JS/api/master/Parse.Schema.html#addField addField}
    * @return {Parse.Schema} Returns the schema, so you can chain this call.
    */
   addObject(name: string, options: FieldOptions) {
@@ -332,6 +345,7 @@ class ParseSchema {
    *
    * @param {String} name Name of the field that will be created on Parse
    * @param {String} targetClass Name of the target Pointer Class
+   * @param {Object} options See {@link https://parseplatform.org/Parse-SDK-JS/api/master/Parse.Schema.html#addField addField}
    * @return {Parse.Schema} Returns the schema, so you can chain this call.
    */
   addPointer(name: string, targetClass: string, options: FieldOptions = {}) {

--- a/src/__tests__/ParseFile-test.js
+++ b/src/__tests__/ParseFile-test.js
@@ -392,8 +392,7 @@ describe('FileController', () => {
     defaultController.download('http://example.com/image.png', options).then((data) => {
       expect(data).toEqual({});
     });
-    mockRequest.emit('aborted');
-    mockResponse.emit('end');
+    mockRequest.emit('abort');
     spy.mockRestore();
   });
 

--- a/src/__tests__/ParseSchema-test.js
+++ b/src/__tests__/ParseSchema-test.js
@@ -83,7 +83,7 @@ describe('ParseSchema', () => {
     done();
   });
 
-  it('can create schema fields required and default values', (done) => {
+  it('can create schema fields required and default values', () => {
     const object = new ParseObject('TestObject', '1234');
     const schema = new ParseSchema('SchemaTest');
     schema
@@ -104,7 +104,6 @@ describe('ParseSchema', () => {
       required: true,
       defaultValue: { __type: 'Date', iso: new Date('2000-01-01T00:00:00.000Z') }
     });
-    done();
   });
 
   it('can create schema indexes', (done) => {

--- a/src/__tests__/ParseSchema-test.js
+++ b/src/__tests__/ParseSchema-test.js
@@ -8,7 +8,21 @@
  */
 
 jest.autoMockOff();
+const mockObject = function(className, id) {
+  this.className = className;
+  this.id = id;
+  this.attributes = {};
+  this.toPointer = function() {
+    return {
+      className: this.className,
+      __type: 'Pointer',
+      objectId: this.id,
+    }
+  };
+};
+jest.setMock('../ParseObject', mockObject);
 
+const ParseObject = require('../ParseObject');
 const ParseSchema = require('../ParseSchema').default;
 const CoreManager = require('../CoreManager');
 
@@ -70,18 +84,26 @@ describe('ParseSchema', () => {
   });
 
   it('can create schema fields required and default values', (done) => {
+    const object = new ParseObject('TestObject', '1234');
     const schema = new ParseSchema('SchemaTest');
     schema
       .addField('defaultFieldString', 'String', { required: true, defaultValue: 'hello' })
-      .addPointer('pointerField', '_User', { required: true, defaultValue: { className: 'TestObject', id: 1234 } });
-    console.log(schema._fields);
+      .addDate('dateField', { required: true, defaultValue: '2000-01-01T00:00:00.000Z' })
+      .addPointer('pointerField', 'TestObject', { required: true, defaultValue: object })
+      .addPointer('pointerJSONField', 'TestObject', { required: true, defaultValue: object.toPointer() });
+
     expect(schema._fields.defaultFieldString.type).toEqual('String');
     expect(schema._fields.defaultFieldString.required).toEqual(true);
     expect(schema._fields.defaultFieldString.defaultValue).toEqual('hello');
     expect(schema._fields.pointerField.type).toEqual('Pointer');
-    expect(schema._fields.pointerField.targetClass).toEqual('_User');
+    expect(schema._fields.pointerField.targetClass).toEqual('TestObject');
     expect(schema._fields.pointerField.required).toEqual(true);
-    expect(schema._fields.pointerField.defaultValue).toEqual({ className: 'TestObject', id: 1234 });
+    expect(schema._fields.pointerField.defaultValue).toEqual(object.toPointer());
+    expect(schema._fields.dateField).toEqual({
+      type: 'Date',
+      required: true,
+      defaultValue: { __type: 'Date', iso: new Date('2000-01-01T00:00:00.000Z') }
+    });
     done();
   });
 

--- a/src/__tests__/ParseSchema-test.js
+++ b/src/__tests__/ParseSchema-test.js
@@ -69,6 +69,22 @@ describe('ParseSchema', () => {
     done();
   });
 
+  it('can create schema fields required and default values', (done) => {
+    const schema = new ParseSchema('SchemaTest');
+    schema
+      .addField('defaultFieldString', 'String', { required: true, defaultValue: 'hello' })
+      .addPointer('pointerField', '_User', { required: true, defaultValue: { className: 'TestObject', id: 1234 } });
+    console.log(schema._fields);
+    expect(schema._fields.defaultFieldString.type).toEqual('String');
+    expect(schema._fields.defaultFieldString.required).toEqual(true);
+    expect(schema._fields.defaultFieldString.defaultValue).toEqual('hello');
+    expect(schema._fields.pointerField.type).toEqual('Pointer');
+    expect(schema._fields.pointerField.targetClass).toEqual('_User');
+    expect(schema._fields.pointerField.required).toEqual(true);
+    expect(schema._fields.pointerField.defaultValue).toEqual({ className: 'TestObject', id: 1234 });
+    done();
+  });
+
   it('can create schema indexes', (done) => {
     const schema = new ParseSchema('SchemaTest');
     schema.addIndex('testIndex', { name: 1 });


### PR DESCRIPTION
Closes: https://github.com/parse-community/Parse-SDK-JS/issues/930

Requires Parse Server 3.7.0+

Feature: https://github.com/parse-community/parse-server/pull/5835

I added a FieldOption to addField and its counter parts. This will allow for future options like uppercase / lowercase for example.
