### PR TITLE
Missing documentation for Custom Auth

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,10 @@ With Parse SDK 2.0.0, gone are the backbone style callbacks and Parse.Promises.
 
 We have curated a [migration guide](2.0.0.md) that should help you migrate your code.
 
+## 3rd Party Authentications
+
+Parse Server supports many [3rd Party Authenications][3rd-parth-auth]. It is possible to [linkWith][link-with] any 3rd Party Authentication by creating a [custom authentication module][custom-auth-module].
+
 ## Want to ride the bleeding edge?
 
 We recommend using the most recent tagged build published to npm for production. However, you can test not-yet-released versions of the Parse-SDK-JS by referencing specific branches in your `package.json`. For example, to use the master branch:
@@ -116,6 +120,8 @@ of patent rights can be found in the PATENTS file in the same directory.
 -----
 As of April 5, 2017, Parse, LLC has transferred this code to the parse-community organization, and will no longer be contributing to or distributing this code.
  
- [types-parse]: https://github.com/DefinitelyTyped/DefinitelyTyped/tree/master/types/parse
- 
- [open-collective-link]: https://opencollective.com/parse-server
+[3rd-party-auth]: http://docs.parseplatform.org/parse-server/guide/#oauth-and-3rd-party-authentication
+[custom-auth-module]:https://docs.parseplatform.org/js/guide/#custom-authentication-module).
+[link-with]: https://docs.parseplatform.org/js/guide/#linking-users
+[open-collective-link]: https://opencollective.com/parse-server
+[types-parse]: https://github.com/DefinitelyTyped/DefinitelyTyped/tree/master/types/parse 

--- a/integration/test/ParseUserTest.js
+++ b/integration/test/ParseUserTest.js
@@ -676,7 +676,7 @@ describe('Parse User', () => {
     user.setUsername('Alice');
     user.setPassword('sekrit');
     await user.signUp();
-    await user._linkWith(provider.getAuthType(), provider.getAuthData());
+    await user.linkWith(provider.getAuthType(), provider.getAuthData());
     expect(user._isLinked(provider)).toBe(true);
     await user._unlinkFrom(provider);
     expect(user._isLinked(provider)).toBe(false);
@@ -689,7 +689,7 @@ describe('Parse User', () => {
     user.setUsername('Alice');
     user.setPassword('sekrit');
     await user.save(null, { useMasterKey: true });
-    await user._linkWith(provider.getAuthType(), provider.getAuthData(), { useMasterKey: true });
+    await user.linkWith(provider.getAuthType(), provider.getAuthData(), { useMasterKey: true });
     expect(user._isLinked(provider)).toBe(true);
     await user._unlinkFrom(provider, { useMasterKey: true });
     expect(user._isLinked(provider)).toBe(false);
@@ -705,7 +705,7 @@ describe('Parse User', () => {
     expect(user.isCurrent()).toBe(false);
 
     const sessionToken = user.getSessionToken();
-    await user._linkWith(provider.getAuthType(), provider.getAuthData(), { sessionToken });
+    await user.linkWith(provider.getAuthType(), provider.getAuthData(), { sessionToken });
     expect(user._isLinked(provider)).toBe(true);
     await user._unlinkFrom(provider, { sessionToken });
     expect(user._isLinked(provider)).toBe(false);
@@ -716,7 +716,7 @@ describe('Parse User', () => {
     user.setUsername('Alice');
     user.setPassword('sekrit');
     await user.save(null, { useMasterKey: true });
-    await user._linkWith(provider.getAuthType(), provider.getAuthData(), { useMasterKey: true });
+    await user.linkWith(provider.getAuthType(), provider.getAuthData(), { useMasterKey: true });
     expect(user._isLinked(provider)).toBe(true);
     expect(user.authenticated()).toBeFalsy();
     Parse.User.enableUnsafeCurrentUser();
@@ -729,7 +729,7 @@ describe('Parse User', () => {
     user.setUsername('Alice');
     user.setPassword('sekrit');
     await user.save(null, { useMasterKey: true });
-    await user._linkWith(provider.getAuthType(), provider.getAuthData());
+    await user.linkWith(provider.getAuthType(), provider.getAuthData());
     expect(user.getSessionToken()).toBeDefined();
   });
 
@@ -758,7 +758,7 @@ describe('Parse User', () => {
     user.setUsername('Alice');
     user.setPassword('sekrit');
     await user.signUp();
-    await user._linkWith(provider.getAuthType(), provider.getAuthData());
+    await user.linkWith(provider.getAuthType(), provider.getAuthData());
     expect(user._isLinked(provider)).toBe(true);
     await user._unlinkFrom(provider);
     expect(user._isLinked(provider)).toBe(false);
@@ -812,7 +812,7 @@ describe('Parse User', () => {
     user.setPassword('sekrit');
     await user.signUp();
 
-    await user._linkWith('twitter', { authData });
+    await user.linkWith('twitter', { authData });
 
     expect(user.get('authData').twitter.id).toBe(authData.id);
     expect(user._isLinked('twitter')).toBe(true);
@@ -836,7 +836,7 @@ describe('Parse User', () => {
     user.setPassword('sekrit');
     await user.signUp();
 
-    await user._linkWith('twitter', { authData });
+    await user.linkWith('twitter', { authData });
     await Parse.FacebookUtils.link(user);
 
     expect(Parse.FacebookUtils.isLinked(user)).toBe(true);

--- a/src/AnonymousUtils.js
+++ b/src/AnonymousUtils.js
@@ -69,7 +69,7 @@ const AnonymousUtils = {
    */
   logIn(options?: RequestOptions) {
     const provider = this._getAuthProvider();
-    return ParseUser._logInWith(provider.getAuthType(), provider.getAuthData(), options);
+    return ParseUser.logInWith(provider.getAuthType(), provider.getAuthData(), options);
   },
 
   /**
@@ -84,7 +84,7 @@ const AnonymousUtils = {
    */
   link(user: ParseUser, options?: RequestOptions) {
     const provider = this._getAuthProvider();
-    return user._linkWith(provider.getAuthType(), provider.getAuthData(), options);
+    return user.linkWith(provider.getAuthType(), provider.getAuthData(), options);
   },
 
   _getAuthProvider() {

--- a/src/FacebookUtils.js
+++ b/src/FacebookUtils.js
@@ -170,10 +170,10 @@ const FacebookUtils = {
         );
       }
       requestedPermissions = permissions;
-      return ParseUser._logInWith('facebook', options);
+      return ParseUser.logInWith('facebook', options);
     }
     const authData = { authData: permissions };
-    return ParseUser._logInWith('facebook', authData, options);
+    return ParseUser.logInWith('facebook', authData, options);
   },
 
   /**
@@ -210,10 +210,10 @@ const FacebookUtils = {
         );
       }
       requestedPermissions = permissions;
-      return user._linkWith('facebook', options);
+      return user.linkWith('facebook', options);
     }
     const authData = { authData: permissions };
-    return user._linkWith('facebook', authData, options);
+    return user.linkWith('facebook', authData, options);
   },
 
   /**

--- a/src/ParseUser.js
+++ b/src/ParseUser.js
@@ -74,10 +74,20 @@ class ParseUser extends ParseObject {
   }
 
   /**
-   * Unlike in the Android/iOS SDKs, logInWith is unnecessary, since you can
-   * call linkWith on the user (even if it doesn't exist yet on the server).
+   * Parse allows you to link your users with {@link https://docs.parseplatform.org/parse-server/guide/#oauth-and-3rd-party-authentication 3rd party authentication}, enabling
+   * your users to sign up or log into your application using their existing identities.
+   *
+   * @see {@link https://docs.parseplatform.org/js/guide/#linking-users Linking Users}
+   * @param {String|AuthProvider} provider Name of auth provider or {@link https://parseplatform.org/Parse-SDK-JS/api/master/AuthProvider.html AuthProvider}
+   * @param {Object} options
+   * <ul>
+   *   <li>If provider is string, options is {@link http://docs.parseplatform.org/parse-server/guide/#supported-3rd-party-authentications authData}
+   *   <li>If provider is AuthProvider, options is saveOpts
+   * </ul>
+   * @param {Object} saveOpts useMasterKey / sessionToken
+   * @return {Promise} A promise that is fulfilled with the user is linked
    */
-  _linkWith(provider: any, options: { authData?: AuthData }, saveOpts?: FullOptions = {}): Promise<ParseUser> {
+  linkWith(provider: any, options: { authData?: AuthData }, saveOpts?: FullOptions = {}): Promise<ParseUser> {
     saveOpts.sessionToken = saveOpts.sessionToken || this.getSessionToken() || '';
     let authType;
     if (typeof provider === 'string') {
@@ -118,7 +128,7 @@ class ParseUser extends ParseObject {
           success: (provider, result) => {
             const opts = {};
             opts.authData = result;
-            this._linkWith(provider, opts, saveOpts).then(() => {
+            this.linkWith(provider, opts, saveOpts).then(() => {
               resolve(this);
             }, (error) => {
               reject(error);
@@ -130,6 +140,13 @@ class ParseUser extends ParseObject {
         });
       });
     }
+  }
+
+  /**
+   * @deprecated since 2.9.0 see {@link https://parseplatform.org/Parse-SDK-JS/api/master/Parse.User.html#linkWith linkWith}
+   */
+  _linkWith(provider: any, options: { authData?: AuthData }, saveOpts?: FullOptions = {}): Promise<ParseUser> {
+    return this.linkWith(provider, options, saveOpts);
   }
 
   /**
@@ -200,7 +217,7 @@ class ParseUser extends ParseObject {
     if (typeof provider === 'string') {
       provider = authProviders[provider];
     }
-    return this._linkWith(provider, { authData: null }, options).then(() => {
+    return this.linkWith(provider, { authData: null }, options).then(() => {
       this._synchronizeAuthData(provider);
       return Promise.resolve(this);
     });
@@ -687,8 +704,13 @@ class ParseUser extends ParseObject {
     return controller.hydrate(userJSON);
   }
 
+  /**
+   * Static version of {@link https://parseplatform.org/Parse-SDK-JS/api/master/Parse.User.html#linkWith linkWith}
+   * @static
+   */
   static logInWith(provider: any, options: { authData?: AuthData }, saveOpts?: FullOptions) {
-    return ParseUser._logInWith(provider, options, saveOpts);
+    const user = new ParseUser();
+    return user.linkWith(provider, options, saveOpts);
   }
 
   /**
@@ -796,6 +818,17 @@ class ParseUser extends ParseObject {
     canUseCurrentUser = false;
   }
 
+  /**
+   * When registering users with {@link https://parseplatform.org/Parse-SDK-JS/api/master/Parse.User.html#linkWith linkWith} a basic auth provider
+   * is automatically created for you.
+   *
+   * For advanced authentication, you can register an Auth provider to
+   * implement custom authentication, deauthentication.
+   *
+   * @see {@link https://parseplatform.org/Parse-SDK-JS/api/master/AuthProvider.html AuthProvider}
+   * @see {@link https://docs.parseplatform.org/js/guide/#custom-authentication-module Custom Authentication Module}
+   * @static
+   */
   static _registerAuthenticationProvider(provider: any) {
     authProviders[provider.getAuthType()] = provider;
     // Synchronize the current user with the auth provider.
@@ -806,9 +839,13 @@ class ParseUser extends ParseObject {
     });
   }
 
+  /**
+   * @deprecated since 2.9.0 see {@link https://parseplatform.org/Parse-SDK-JS/api/master/Parse.User.html#logInWith logInWith}
+   * @static
+   */
   static _logInWith(provider: any, options: { authData?: AuthData }, saveOpts?: FullOptions) {
     const user = new ParseUser();
-    return user._linkWith(provider, options, saveOpts);
+    return user.linkWith(provider, options, saveOpts);
   }
 
   static _clearCache() {

--- a/src/ParseUser.js
+++ b/src/ParseUser.js
@@ -76,6 +76,7 @@ class ParseUser extends ParseObject {
   /**
    * Parse allows you to link your users with {@link https://docs.parseplatform.org/parse-server/guide/#oauth-and-3rd-party-authentication 3rd party authentication}, enabling
    * your users to sign up or log into your application using their existing identities.
+   * Since 2.9.0
    *
    * @see {@link https://docs.parseplatform.org/js/guide/#linking-users Linking Users}
    * @param {String|AuthProvider} provider Name of auth provider or {@link https://parseplatform.org/Parse-SDK-JS/api/master/AuthProvider.html AuthProvider}

--- a/src/__tests__/AnonymousUtils-test.js
+++ b/src/__tests__/AnonymousUtils-test.js
@@ -15,9 +15,9 @@ class MockUser {
     this.attributes = {};
   }
   _isLinked() {}
-  _linkWith() {}
+  linkWith() {}
   static _registerAuthenticationProvider() {}
-  static _logInWith() {}
+  static logInWith() {}
 }
 
 jest.setMock('../ParseUser', MockUser);
@@ -71,18 +71,18 @@ describe('AnonymousUtils', () => {
 
   it('can link user', () => {
     const user = new MockUser();
-    jest.spyOn(user, '_linkWith');
+    jest.spyOn(user, 'linkWith');
     AnonymousUtils.link(user);
-    expect(user._linkWith).toHaveBeenCalledTimes(1);
-    expect(user._linkWith).toHaveBeenCalledWith('anonymous', mockProvider.getAuthData(), undefined);
+    expect(user.linkWith).toHaveBeenCalledTimes(1);
+    expect(user.linkWith).toHaveBeenCalledWith('anonymous', mockProvider.getAuthData(), undefined);
     expect(AnonymousUtils._getAuthProvider).toHaveBeenCalledTimes(1);
   });
 
   it('can login user', () => {
-    jest.spyOn(MockUser, '_logInWith');
+    jest.spyOn(MockUser, 'logInWith');
     AnonymousUtils.logIn();
-    expect(MockUser._logInWith).toHaveBeenCalledTimes(1);
-    expect(MockUser._logInWith).toHaveBeenCalledWith('anonymous', mockProvider.getAuthData(), undefined);
+    expect(MockUser.logInWith).toHaveBeenCalledTimes(1);
+    expect(MockUser.logInWith).toHaveBeenCalledWith('anonymous', mockProvider.getAuthData(), undefined);
     expect(AnonymousUtils._getAuthProvider).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/__tests__/FacebookUtils-test.js
+++ b/src/__tests__/FacebookUtils-test.js
@@ -15,10 +15,10 @@ class MockUser {
     this.attributes = {};
   }
   _isLinked() {}
-  _linkWith() {}
+  linkWith() {}
   _unlinkFrom() {}
   static _registerAuthenticationProvider() {}
-  static _logInWith() {}
+  static logInWith() {}
 }
 
 jest.setMock('../ParseUser', MockUser);
@@ -110,17 +110,17 @@ describe('FacebookUtils', () => {
     const authData = {
       id: '1234'
     };
-    jest.spyOn(user, '_linkWith');
+    jest.spyOn(user, 'linkWith');
     await FacebookUtils.link(user, authData);
-    expect(user._linkWith).toHaveBeenCalledWith('facebook', { authData: { id: '1234' } }, undefined);
+    expect(user.linkWith).toHaveBeenCalledWith('facebook', { authData: { id: '1234' } }, undefined);
   });
 
   it('can link with options', async () => {
     FacebookUtils.init();
     const user = new MockUser();
-    jest.spyOn(user, '_linkWith');
+    jest.spyOn(user, 'linkWith');
     await FacebookUtils.link(user, {}, { useMasterKey: true });
-    expect(user._linkWith).toHaveBeenCalledWith('facebook', { authData: {} }, { useMasterKey: true });
+    expect(user.linkWith).toHaveBeenCalledWith('facebook', { authData: {} }, { useMasterKey: true });
   });
 
   it('can check isLinked', async () => {
@@ -147,23 +147,23 @@ describe('FacebookUtils', () => {
 
   it('can login with permission string', async () => {
     FacebookUtils.init();
-    jest.spyOn(MockUser, '_logInWith');
+    jest.spyOn(MockUser, 'logInWith');
     await FacebookUtils.logIn('public_profile');
-    expect(MockUser._logInWith).toHaveBeenCalledTimes(1);
+    expect(MockUser.logInWith).toHaveBeenCalledTimes(1);
   });
 
   it('can login with authData', async () => {
     FacebookUtils.init();
-    jest.spyOn(MockUser, '_logInWith');
+    jest.spyOn(MockUser, 'logInWith');
     await FacebookUtils.logIn({ id: '1234' });
-    expect(MockUser._logInWith).toHaveBeenCalledTimes(1);
+    expect(MockUser.logInWith).toHaveBeenCalledTimes(1);
   });
 
   it('can login with options', async () => {
     FacebookUtils.init();
-    jest.spyOn(MockUser, '_logInWith');
+    jest.spyOn(MockUser, 'logInWith');
     await FacebookUtils.logIn({}, { useMasterKey: true });
-    expect(MockUser._logInWith).toHaveBeenCalledWith('facebook', { authData: {} }, {useMasterKey: true });
+    expect(MockUser.logInWith).toHaveBeenCalledWith('facebook', { authData: {} }, {useMasterKey: true });
   });
 
   it('provider getAuthType', async () => {

--- a/src/__tests__/ParseUser-test.js
+++ b/src/__tests__/ParseUser-test.js
@@ -837,17 +837,17 @@ describe('ParseUser', () => {
     const provider = AnonymousUtils._getAuthProvider();
     ParseUser._registerAuthenticationProvider(provider);
     const user = new ParseUser();
-    jest.spyOn(user, '_linkWith');
+    jest.spyOn(user, 'linkWith');
     user._unlinkFrom(provider);
-    expect(user._linkWith).toHaveBeenCalledTimes(1);
-    expect(user._linkWith).toHaveBeenCalledWith(provider, { authData: null }, undefined);
+    expect(user.linkWith).toHaveBeenCalledTimes(1);
+    expect(user.linkWith).toHaveBeenCalledWith(provider, { authData: null }, undefined);
   });
 
   it('can unlink with options', async () => {
     const provider = AnonymousUtils._getAuthProvider();
     ParseUser._registerAuthenticationProvider(provider);
     const user = new ParseUser();
-    jest.spyOn(user, '_linkWith')
+    jest.spyOn(user, 'linkWith')
       .mockImplementationOnce((authProvider, authData, saveOptions) => {
         expect(authProvider).toEqual(provider);
         expect(authData).toEqual({ authData: null});
@@ -855,7 +855,7 @@ describe('ParseUser', () => {
         return Promise.resolve();
       });
     user._unlinkFrom(provider.getAuthType(), { useMasterKey: true });
-    expect(user._linkWith).toHaveBeenCalledTimes(1);
+    expect(user.linkWith).toHaveBeenCalledTimes(1);
   });
 
   it('can destroy anonymous user when login new user', async () => {
@@ -1003,10 +1003,10 @@ describe('ParseUser', () => {
     await user._linkWith('testProvider', { authData: { id: 'test' } });
     expect(user.get('authData')).toEqual({ testProvider: { id: 'test' } });
 
-    jest.spyOn(user, '_linkWith');
+    jest.spyOn(user, 'linkWith');
 
     await user._unlinkFrom('testProvider');
-    const authProvider = user._linkWith.mock.calls[0][0];
+    const authProvider = user.linkWith.mock.calls[0][0];
     expect(authProvider.getAuthType()).toBe('testProvider');
   });
 });

--- a/src/interfaces/AuthProvider.js
+++ b/src/interfaces/AuthProvider.js
@@ -1,4 +1,4 @@
-/* eslint-disable */
+/* eslint no-unused-vars: "off" */
 /**
  * Copyright (c) 2015-present, Parse, LLC.
  * All rights reserved.

--- a/src/interfaces/AuthProvider.js
+++ b/src/interfaces/AuthProvider.js
@@ -1,3 +1,4 @@
+/* eslint-disable */
 /**
  * Copyright (c) 2015-present, Parse, LLC.
  * All rights reserved.
@@ -10,28 +11,30 @@
 
 /**
  * Interface declaration for Authentication Providers
+ *
+ * @interface AuthProvider
  */
-export interface AuthProvider {
+export class AuthProvider {
   /**
    * Called when _linkWith isn't passed authData.
    * Handle your own authentication here.
    *
    * @params {Object} options.success(provider, authData) or options.error(provider, error) on completion
    */
-  authenticate(options: any): void,
+  authenticate(options: any): void {}
 
   /**
    * (Optional) Called when service is unlinked.
    * Handle any cleanup here.
    */
-  deauthenticate(): void,
+  deauthenticate(): void {}
 
   /**
    * Unique identifier for this Auth Provider.
    *
    * @return {String} identifier
    */
-  getAuthType(): string,
+  getAuthType(): string {}
 
   /**
    * Called when auth data is syncronized.
@@ -40,5 +43,5 @@ export interface AuthProvider {
    * @params {Object} authData Data used when register provider
    * @return {Boolean} Indicate if service should continue to be linked
    */
-  restoreAuthentication(authData: any): boolean,
+  restoreAuthentication(authData: any): boolean {}
 }


### PR DESCRIPTION
Closes: https://github.com/parse-community/Parse-SDK-JS/issues/934
Addresses: https://github.com/parse-community/Parse-SDK-JS/issues/552

Adds deprecation for _linkWith and _loginWith

I can check the links works after this PR is merged. 