### PR TITLE
Can unlink without provider (cloud code)

### DIFF
--- a/src/ParseUser.js
+++ b/src/ParseUser.js
@@ -213,11 +213,13 @@ class ParseUser extends ParseObject {
 
   /**
    * Unlinks a user from a service.
+   *
+   * @param {String|AuthProvider} provider Name of auth provider or {@link https://parseplatform.org/Parse-SDK-JS/api/master/AuthProvider.html AuthProvider}
+   * @param {Object} options MasterKey / SessionToken
+   * @return {Promise} A promise that is fulfilled when the unlinking
+   *     finishes.
    */
-  _unlinkFrom(provider: any, options?: FullOptions) {
-    if (typeof provider === 'string') {
-      provider = authProviders[provider];
-    }
+  _unlinkFrom(provider: any, options?: FullOptions): Promise<ParseUser> {
     return this.linkWith(provider, { authData: null }, options).then(() => {
       this._synchronizeAuthData(provider);
       return Promise.resolve(this);

--- a/src/__tests__/ParseUser-test.js
+++ b/src/__tests__/ParseUser-test.js
@@ -849,7 +849,7 @@ describe('ParseUser', () => {
     const user = new ParseUser();
     jest.spyOn(user, 'linkWith')
       .mockImplementationOnce((authProvider, authData, saveOptions) => {
-        expect(authProvider).toEqual(provider);
+        expect(authProvider).toEqual(provider.getAuthType());
         expect(authData).toEqual({ authData: null});
         expect(saveOptions).toEqual({ useMasterKey: true });
         return Promise.resolve();
@@ -1007,6 +1007,6 @@ describe('ParseUser', () => {
 
     await user._unlinkFrom('testProvider');
     const authProvider = user.linkWith.mock.calls[0][0];
-    expect(authProvider.getAuthType()).toBe('testProvider');
+    expect(authProvider).toBe('testProvider');
   });
 });


### PR DESCRIPTION
This is specifically for facebook since you can't register a auth provider in cloud code (FB doesn't exist).

Removes duplicate logic (linkWith handles the providers)

```
Cannot read property 'getAuthType' of undefined
```

Note: I can't add an integration test for this. I have tested and this works.
`integration/tests` uses /lib/node
`integration/server.js` uses /node_modules/parse (this doesn't have changes made in /lib/node)
