### PR TITLE
Add installationId to LiveQuery

### DIFF
--- a/src/LiveQueryClient.js
+++ b/src/LiveQueryClient.js
@@ -397,7 +397,6 @@ class LiveQueryClient extends EventEmitter {
       if (!subscription) {
         break;
       }
-      console.log(data);
       let override = false;
       if (data.original) {
         override = true;

--- a/src/LiveQueryClient.js
+++ b/src/LiveQueryClient.js
@@ -122,6 +122,8 @@ class LiveQueryClient extends EventEmitter {
   javascriptKey: ?string;
   masterKey: ?string;
   sessionToken: ?string;
+  installationId: ?string;
+  additionalProperties: boolean;
   connectPromise: Promise;
   subscriptions: Map;
   socket: any;
@@ -134,13 +136,15 @@ class LiveQueryClient extends EventEmitter {
    * @param {string} options.javascriptKey (optional)
    * @param {string} options.masterKey (optional) Your Parse Master Key. (Node.js only!)
    * @param {string} options.sessionToken (optional)
+   * @param {string} options.installationId (optional)
    */
   constructor({
     applicationId,
     serverURL,
     javascriptKey,
     masterKey,
-    sessionToken
+    sessionToken,
+    installationId,
   }) {
     super();
 
@@ -157,6 +161,8 @@ class LiveQueryClient extends EventEmitter {
     this.javascriptKey = javascriptKey;
     this.masterKey = masterKey;
     this.sessionToken = sessionToken;
+    this.installationId = installationId;
+    this.additionalProperties = true;
     this.connectPromise = resolvingPromise();
     this.subscriptions = new Map();
     this.state = CLIENT_STATE.INITIALIZED;
@@ -334,6 +340,9 @@ class LiveQueryClient extends EventEmitter {
       masterKey: this.masterKey,
       sessionToken: this.sessionToken
     };
+    if (this.additionalProperties) {
+      connectRequest.installationId = this.installationId;
+    }
     this.socket.send(JSON.stringify(connectRequest));
   }
 
@@ -373,6 +382,12 @@ class LiveQueryClient extends EventEmitter {
       } else {
         this.emit(CLIENT_EMMITER_TYPES.ERROR, data.error);
       }
+      if (data.error === 'Additional properties not allowed') {
+        this.additionalProperties = false;
+      }
+      if (data.reconnect) {
+        this._handleReconnect();
+      }
       break;
     case OP_EVENTS.UNSUBSCRIBED:
       // We have already deleted subscription in unsubscribe(), do nothing here
@@ -382,6 +397,7 @@ class LiveQueryClient extends EventEmitter {
       if (!subscription) {
         break;
       }
+      console.log(data);
       let override = false;
       if (data.original) {
         override = true;

--- a/src/ParseLiveQuery.js
+++ b/src/ParseLiveQuery.js
@@ -86,9 +86,11 @@ const DefaultLiveQueryController = {
     if (defaultLiveQueryClient) {
       return defaultLiveQueryClient;
     }
-    const currentUser = await CoreManager.getUserController().currentUserAsync();
+    const [currentUser, installationId] = await Promise.all([
+      CoreManager.getUserController().currentUserAsync(),
+      CoreManager.getInstallationController().currentInstallationId()
+    ]);
     const sessionToken = currentUser ? currentUser.getSessionToken() : undefined;
-    const installationId = await CoreManager.getInstallationController().currentInstallationId();
 
     let liveQueryServerURL = CoreManager.get('LIVEQUERY_SERVER_URL');
     if (liveQueryServerURL && liveQueryServerURL.indexOf('ws') !== 0) {

--- a/src/ParseLiveQuery.js
+++ b/src/ParseLiveQuery.js
@@ -88,6 +88,7 @@ const DefaultLiveQueryController = {
     }
     const currentUser = await CoreManager.getUserController().currentUserAsync();
     const sessionToken = currentUser ? currentUser.getSessionToken() : undefined;
+    const installationId = await CoreManager.getInstallationController().currentInstallationId();
 
     let liveQueryServerURL = CoreManager.get('LIVEQUERY_SERVER_URL');
     if (liveQueryServerURL && liveQueryServerURL.indexOf('ws') !== 0) {
@@ -115,6 +116,7 @@ const DefaultLiveQueryController = {
       javascriptKey,
       masterKey,
       sessionToken,
+      installationId,
     });
     defaultLiveQueryClient.on('error', (error) => {
       LiveQuery.emit('error', error);

--- a/src/__tests__/LiveQueryClient-test.js
+++ b/src/__tests__/LiveQueryClient-test.js
@@ -490,6 +490,38 @@ describe('LiveQueryClient', () => {
     expect(isChecked).toBe(true);
   });
 
+  it('can handle WebSocket reconnect on error event', () => {
+    const liveQueryClient = new LiveQueryClient({
+      applicationId: 'applicationId',
+      serverURL: 'ws://test',
+      javascriptKey: 'javascriptKey',
+      masterKey: 'masterKey',
+      sessionToken: 'sessionToken'
+    });
+    expect(liveQueryClient.additionalProperties).toBe(true);
+    const data = {
+      op: 'error',
+      code: 1,
+      reconnect: true,
+      error: 'Additional properties not allowed',
+    };
+    const event = {
+      data: JSON.stringify(data)
+    }
+    let isChecked = false;
+    liveQueryClient.on('error', function(error) {
+      isChecked = true;
+      expect(error).toEqual(data.error);
+    });
+    const spy = jest.spyOn(liveQueryClient, '_handleReconnect');
+    liveQueryClient._handleWebSocketMessage(event);
+
+    expect(isChecked).toBe(true);
+    expect(liveQueryClient._handleReconnect).toHaveBeenCalledTimes(1);
+    expect(liveQueryClient.additionalProperties).toBe(false);
+    spy.mockRestore();
+  });
+
   it('can subscribe', async () => {
     const liveQueryClient = new LiveQueryClient({
       applicationId: 'applicationId',

--- a/src/__tests__/ParseLiveQuery-test.js
+++ b/src/__tests__/ParseLiveQuery-test.js
@@ -9,6 +9,7 @@
 
 jest.dontMock('../ParseLiveQuery');
 jest.dontMock('../CoreManager');
+jest.dontMock('../InstallationController');
 jest.dontMock('../LiveQueryClient');
 jest.dontMock('../LiveQuerySubscription');
 jest.dontMock('../ParseObject');
@@ -30,6 +31,11 @@ describe('ParseLiveQuery', () => {
   beforeEach(() => {
     const controller = CoreManager.getLiveQueryController();
     controller._clearCachedDefaultClient();
+    CoreManager.set('InstallationController', {
+      currentInstallationId() {
+        return Promise.resolve('1234');
+      }
+    });
   });
 
   it('fails with an invalid livequery server url', (done) => {
@@ -63,6 +69,8 @@ describe('ParseLiveQuery', () => {
       expect(client.applicationId).toBe('appid');
       expect(client.javascriptKey).toBe('jskey');
       expect(client.sessionToken).toBe(undefined);
+      expect(client.installationId).toBe('1234');
+      expect(client.additionalProperties).toBe(true);
       done();
     });
   });


### PR DESCRIPTION
Adds reconnect for error event from server (already reconnects with web socket error).
Adds backwards compatibility for additionalProperties that do not exist in the server.

This PR will require a server update.

Use Case: Determine which client the live query request was sent from.

Will open a PR separately for the following.
```
subscription.on('create', (object, options) => {
  options.installationId, options.clientId, etc
});
```

