### PR TITLE
Fix #992

### DIFF
--- a/integration/test/ParseUserTest.js
+++ b/integration/test/ParseUserTest.js
@@ -630,22 +630,21 @@ describe('Parse User', () => {
     expect(user.get('foo')).toBe('bar');
   });
 
-  // TODO: @dplewis
-  // it('can get current with subclass', async () => {
-  //   Parse.User.enableUnsafeCurrentUser();
+  it('can get current with subclass', async () => {
+    Parse.User.enableUnsafeCurrentUser();
 
-  //   const customUser = new CustomUser({ foo: 'bar' });
-  //   customUser.setUsername('username');
-  //   customUser.setPassword('password');
+    const customUser = new CustomUser({ foo: 'bar' });
+    customUser.setUsername('username');
+    customUser.setPassword('password');
 
-  //   await customUser.signUp();
-  //   Parse.User._clearCache();
+    await customUser.signUp();
+    Parse.User._clearCache();
 
-  //   const user = CustomUser.current();
-  //   expect(user instanceof CustomUser).toBe(true);
-  //   expect(user.doSomething()).toBe(5);
-  //   expect(user.get('foo')).toBe('bar');
-  // });
+    const user = CustomUser.current();
+    expect(user instanceof CustomUser).toBe(true);
+    expect(user.doSomething()).toBe(5);
+    expect(user.get('foo')).toBe('bar');
+  });
 
   it('can logIn user with subclass', async () => {
     Parse.User.enableUnsafeCurrentUser();

--- a/integration/test/ParseUserTest.js
+++ b/integration/test/ParseUserTest.js
@@ -630,21 +630,22 @@ describe('Parse User', () => {
     expect(user.get('foo')).toBe('bar');
   });
 
-  it('can get current with subclass', async () => {
-    Parse.User.enableUnsafeCurrentUser();
+  // TODO: @dplewis
+  // it('can get current with subclass', async () => {
+  //   Parse.User.enableUnsafeCurrentUser();
 
-    const customUser = new CustomUser({ foo: 'bar' });
-    customUser.setUsername('username');
-    customUser.setPassword('password');
+  //   const customUser = new CustomUser({ foo: 'bar' });
+  //   customUser.setUsername('username');
+  //   customUser.setPassword('password');
 
-    await customUser.signUp();
-    Parse.User._clearCache();
+  //   await customUser.signUp();
+  //   Parse.User._clearCache();
 
-    const user = CustomUser.current();
-    expect(user instanceof CustomUser).toBe(true);
-    expect(user.doSomething()).toBe(5);
-    expect(user.get('foo')).toBe('bar');
-  });
+  //   const user = CustomUser.current();
+  //   expect(user instanceof CustomUser).toBe(true);
+  //   expect(user.doSomething()).toBe(5);
+  //   expect(user.get('foo')).toBe('bar');
+  // });
 
   it('can logIn user with subclass', async () => {
     Parse.User.enableUnsafeCurrentUser();

--- a/src/ParseUser.js
+++ b/src/ParseUser.js
@@ -869,7 +869,7 @@ const DefaultController = {
   updateUserOnDisk(user) {
     const path = Storage.generatePath(CURRENT_USER_KEY);
     const json = user.toJSON();
-    json.className = '_User';
+    json.className = user.constructor.name === ParseUser.name ? '_User' : user.constructor.name;
     return Storage.setItemAsync(
       path, JSON.stringify(json)
     ).then(() => {

--- a/src/ParseUser.js
+++ b/src/ParseUser.js
@@ -869,7 +869,7 @@ const DefaultController = {
   updateUserOnDisk(user) {
     const path = Storage.generatePath(CURRENT_USER_KEY);
     const json = user.toJSON();
-    json.className = user.constructor.name === 'ParseUser' ? '_User' : user.constructor.name;
+    json.className = '_User';
     return Storage.setItemAsync(
       path, JSON.stringify(json)
     ).then(() => {


### PR DESCRIPTION
Revert https://github.com/parse-community/Parse-SDK-JS/pull/978

`user.constructor.name === 'ParseUser'` would never be true in minimized code as `ParseUser` wouldn't exist (because it is minimized to a variable)