### PR TITLE
Support query.fromNetwork()

### DIFF
--- a/src/ParseQuery.js
+++ b/src/ParseQuery.js
@@ -1775,6 +1775,17 @@ class ParseQuery {
   }
 
   /**
+   * Change the source of this query to the server.
+   *
+   * @return {Parse.Query} Returns the query, so you can chain this call.
+   */
+  fromNetwork(): ParseQuery {
+    this._queriesLocalDatastore = false;
+    this._localDatastorePinName = null;
+    return this;
+  }
+
+  /**
    * Changes the source of this query to all pinned objects.
    *
    * @return {Parse.Query} Returns the query, so you can chain this call.

--- a/src/__tests__/ParseQuery-test.js
+++ b/src/__tests__/ParseQuery-test.js
@@ -2346,6 +2346,10 @@ describe('ParseQuery LocalDatastore', () => {
     q.fromPin();
     expect(q._queriesLocalDatastore).toBe(true);
     expect(q._localDatastorePinName).toBe(DEFAULT_PIN);
+    const query = q.fromNetwork();
+    expect(q._queriesLocalDatastore).toBe(false);
+    expect(q._localDatastorePinName).toBe(null);
+    expect(query).toEqual(q);
   });
 
   it('can query from pin with name', () => {


### PR DESCRIPTION
Taken from Android API [fromNetwork()](http://parseplatform.org/Parse-SDK-Android/api/com/parse/ParseQuery.html#fromNetwork--)

Can be used to switch from localDatastore back to the server.