### PR TITLE
Fix #992

### DIFF
--- a/integration/test/ParseUserTest.js
+++ b/integration/test/ParseUserTest.js
@@ -49,6 +49,7 @@ describe('Parse User', () => {
     Parse.initialize('integration', null, 'notsosecret');
     Parse.CoreManager.set('SERVER_URL', 'http://localhost:1337/parse');
     Parse.Storage._clear();
+    Parse.Object.registerSubclass('_User', Parse.User);
   });
 
   beforeEach((done) => {
@@ -632,6 +633,7 @@ describe('Parse User', () => {
 
   it('can get current with subclass', async () => {
     Parse.User.enableUnsafeCurrentUser();
+    Parse.Object.registerSubclass('_User', CustomUser);
 
     const customUser = new CustomUser({ foo: 'bar' });
     customUser.setUsername('username');

--- a/src/ParseUser.js
+++ b/src/ParseUser.js
@@ -871,7 +871,7 @@ const DefaultController = {
     const json = user.toJSON();
     delete json.password;
 
-    json.className = user.constructor.name === ParseUser.name ? '_User' : user.constructor.name;
+    json.className = '_User';
     return Storage.setItemAsync(
       path, JSON.stringify(json)
     ).then(() => {


### PR DESCRIPTION
After much discussion the proper way to subclass is a user is `Parse.Object.registerSubclass('_User', CustomUser);`

Reverts https://github.com/parse-community/Parse-SDK-JS/pull/978