### PR TITLE
User signup with installationId

### DIFF
--- a/integration/test/ParseUserTest.js
+++ b/integration/test/ParseUserTest.js
@@ -109,6 +109,41 @@ describe('Parse User', () => {
     });
   });
 
+  it('can login users with installationId', async () => {
+    Parse.User.enableUnsafeCurrentUser();
+    const currentInstallation = await Parse.CoreManager.getInstallationController().currentInstallationId();
+    const installationId = '12345678';
+    const user = new Parse.User();
+    user.set('username', 'parse');
+    user.set('password', 'mypass');
+    await user.signUp(null, { installationId });
+
+    const query = new Parse.Query(Parse.Session);
+    query.equalTo('user', user);
+    const result = await query.first({ useMasterKey: true });
+    expect(result.get('installationId')).toBe(installationId);
+    expect(result.get('sessionToken')).toBe(user.getSessionToken());
+
+    // Should not clean up sessions
+    const loggedUser = await Parse.User.logIn('parse', 'mypass');
+    const sessionQuery = new Parse.Query(Parse.Session);
+    let sessions = await sessionQuery.find({ useMasterKey: true });
+    expect(sessions.length).toBe(2);
+    expect(sessions[0].get('installationId')).toBe(installationId);
+    expect(sessions[1].get('installationId')).toBe(currentInstallation);
+    expect(sessions[0].get('sessionToken')).toBe(user.getSessionToken());
+    expect(sessions[1].get('sessionToken')).toBe(loggedUser.getSessionToken());
+
+    // Should clean up sessions
+    const installationUser = await Parse.User.logIn('parse', 'mypass', { installationId });
+    sessions = await sessionQuery.find({ useMasterKey: true });
+    expect(sessions.length).toBe(2);
+    expect(sessions[0].get('installationId')).toBe(currentInstallation);
+    expect(sessions[1].get('installationId')).toBe(installationId);
+    expect(sessions[0].get('sessionToken')).toBe(loggedUser.getSessionToken());
+    expect(sessions[1].get('sessionToken')).toBe(installationUser.getSessionToken());
+  });
+
   it('can become a user', (done) => {
     Parse.User.enableUnsafeCurrentUser();
     let session = null;

--- a/src/ParseObject.js
+++ b/src/ParseObject.js
@@ -1232,6 +1232,9 @@ class ParseObject {
     if (options.hasOwnProperty('sessionToken') && typeof options.sessionToken === 'string') {
       saveOptions.sessionToken = options.sessionToken;
     }
+    if (options.hasOwnProperty('installationId') && typeof options.installationId === 'string') {
+      saveOptions.installationId = options.installationId;
+    }
     const controller = CoreManager.getObjectController();
     const unsaved = options.cascadeSave !== false ? unsavedChildren(this) : null;
     return controller.save(unsaved, saveOptions).then(() => {

--- a/src/__tests__/ParseUser-test.js
+++ b/src/__tests__/ParseUser-test.js
@@ -1009,4 +1009,57 @@ describe('ParseUser', () => {
     const authProvider = user.linkWith.mock.calls[0][0];
     expect(authProvider).toBe('testProvider');
   });
+
+  it('can static signup a user with installationId', async () => {
+    ParseUser.disableUnsafeCurrentUser();
+    ParseUser._clearCache();
+    const installationId = '12345678';
+    CoreManager.setRESTController({
+      request(method, path, body, options) {
+        expect(method).toBe('POST');
+        expect(path).toBe('users');
+        console.log(options);
+        expect(options.installationId).toBe(installationId);
+        return Promise.resolve({
+          objectId: 'uid3',
+          username: 'username',
+          sessionToken: '123abc'
+        }, 200);
+      },
+      ajax() {}
+    });
+
+    const user = await ParseUser.signUp('username', 'password', null, { installationId });
+    expect(user.id).toBe('uid3');
+    expect(user.isCurrent()).toBe(false);
+    expect(user.existed()).toBe(true);
+  });
+
+  it('can signup a user with installationId', async () => {
+    ParseUser.disableUnsafeCurrentUser();
+    ParseUser._clearCache();
+    const installationId = '12345678';
+    CoreManager.setRESTController({
+      request(method, path, body, options) {
+        expect(method).toBe('POST');
+        expect(path).toBe('users');
+        console.log(options);
+        expect(options.installationId).toBe(installationId);
+        return Promise.resolve({
+          objectId: 'uid3',
+          username: 'username',
+          sessionToken: '123abc'
+        }, 200);
+      },
+      ajax() {}
+    });
+
+    const user = new ParseUser();
+    user.setUsername('name');
+    user.setPassword('pass');
+    await user.signUp(null, { installationId });
+    expect(user.id).toBe('uid3');
+    expect(user.isCurrent()).toBe(false);
+    expect(user.existed()).toBe(true);
+  });
 });


### PR DESCRIPTION
Fixes: https://github.com/parse-community/Parse-SDK-JS/issues/536

Parse.User.signUp actually does a ParseObject.save() at its core which does not send an installationId.

This is useful to prevent invalid session token and tests session clean up.