### PR TITLE
Remove batch size from SaveAll and DestroyAll

### DIFF
--- a/src/RESTController.js
+++ b/src/RESTController.js
@@ -17,7 +17,6 @@ export type RequestOptions = {
   sessionToken?: string;
   installationId?: string;
   returnStatus?: boolean;
-  batchSize?: number;
   include?: any;
   progress?: any;
 };

--- a/src/__tests__/ParseObject-test.js
+++ b/src/__tests__/ParseObject-test.js
@@ -1681,7 +1681,6 @@ describe('ParseObject', () => {
     jest.runAllTicks();
   });
 
-    let current = 0;
   it('returns the first error when saving an array of objects', async (done) => {
     const xhrs = [];
     for (let i = 0; i < 2; i++) {


### PR DESCRIPTION
Closes: https://github.com/parse-community/Parse-SDK-JS/issues/1045

Adds slight improvement to `saveAll([ParseFiles])`. Should we return the parse files if only saving parse files?

Although batchSize is removed `saveAll` will still make multiple calls to the `/batch` endpoint to check for save cycles.