### PR TITLE
Fix subscribing to null sessionToken

### DIFF
--- a/integration/test/ParseLiveQueryTest.js
+++ b/integration/test/ParseLiveQueryTest.js
@@ -180,4 +180,29 @@ describe('Parse LiveQuery', () => {
     })
     await object.save({ foo: 'bar' });
   });
+
+  it('can subscribe to null sessionToken', async (done) => {
+    const user = await Parse.User.signUp('oooooo', 'password');
+
+    const readOnly = Parse.User.readOnlyAttributes();
+    Parse.User.readOnlyAttributes = null;
+    user.set('sessionToken', null);
+    assert.equal(user.getSessionToken(), null);
+
+    const object = new TestObject();
+    await object.save();
+
+    const query = new Parse.Query(TestObject);
+    query.equalTo('objectId', object.id);
+    const subscription = await query.subscribe();
+    subscription.on('update', async (object) => {
+      assert.equal(object.get('foo'), 'bar');
+      Parse.User.readOnlyAttributes = function() {
+        return readOnly;
+      };
+      await Parse.User.logOut();
+      done();
+    })
+    await object.save({ foo: 'bar' });
+  });
 });

--- a/src/LiveQueryClient.js
+++ b/src/LiveQueryClient.js
@@ -160,7 +160,7 @@ class LiveQueryClient extends EventEmitter {
     this.applicationId = applicationId;
     this.javascriptKey = javascriptKey;
     this.masterKey = masterKey;
-    this.sessionToken = sessionToken;
+    this.sessionToken = sessionToken || undefined;
     this.installationId = installationId;
     this.additionalProperties = true;
     this.connectPromise = resolvingPromise();


### PR DESCRIPTION
Closes: https://github.com/parse-community/Parse-SDK-JS/issues/1055

This PR just forces sessionToken null to be undefined when intializing the client.

If anybody knows how a sessionToken can be null instead of a string, '', or undefined, let me know.