### PR TITLE
Throw error when fetching an object without ID

### DIFF
--- a/src/ParseObject.js
+++ b/src/ParseObject.js
@@ -2121,6 +2121,12 @@ const DefaultController = {
       if (options && options.include) {
         params.include = options.include.join();
       }
+      if (!target.id) {
+        return Promise.reject(new ParseError(
+          ParseError.MISSING_OBJECT_ID,
+          'Object does not have an ID'
+        ));
+      }
       return RESTController.request(
         'GET',
         'classes/' + target.className + '/' + target._getId(),

--- a/src/__tests__/ParseObject-test.js
+++ b/src/__tests__/ParseObject-test.js
@@ -1411,6 +1411,23 @@ describe('ParseObject', () => {
     });
   });
 
+  it('throw for fetch with empty string as ID', async () => {
+    expect.assertions(1);
+    CoreManager.getRESTController()._setXHR(
+      mockXHR([{
+        status: 200,
+        response: {
+          count: 10
+        }
+      }])
+    );
+    const p = new ParseObject('Person');
+    p.id = '';
+    await expect(p.fetch())
+      .rejects
+      .toThrowError();
+  });
+
   it('should fail on invalid date', (done) => {
     const obj = new ParseObject('Item');
     obj.set('when', new Date(Date.parse(null)));

--- a/src/__tests__/ParseObject-test.js
+++ b/src/__tests__/ParseObject-test.js
@@ -1425,7 +1425,10 @@ describe('ParseObject', () => {
     p.id = '';
     await expect(p.fetch())
       .rejects
-      .toThrowError();
+      .toThrowError(new ParseError(
+        ParseError.MISSING_OBJECT_ID,
+        'Object does not have an ID'
+      ));
   });
 
   it('should fail on invalid date', (done) => {


### PR DESCRIPTION
Pull Request fixing issue #1063.

Add a check for ID definition before fetching data.