### PR TITLE
Fix cascadeSave=false bug

### DIFF
--- a/src/ParseObject.js
+++ b/src/ParseObject.js
@@ -2335,9 +2335,10 @@ const DefaultController = {
       });
 
     } else if (target instanceof ParseObject) {
-      // copying target lets Flow guarantee the pointer isn't modified elsewhere
-      target._getId();
+      // generate _localId in case if cascadeSave=false
+      target._getId(); 
       const localId = target._localId;
+      // copying target lets Flow guarantee the pointer isn't modified elsewhere
       const targetCopy = target;
       const task = function() {
         const params = targetCopy._getSaveParams();

--- a/src/ParseObject.js
+++ b/src/ParseObject.js
@@ -2336,7 +2336,7 @@ const DefaultController = {
 
     } else if (target instanceof ParseObject) {
       // generate _localId in case if cascadeSave=false
-      target._getId(); 
+      target._getId();
       const localId = target._localId;
       // copying target lets Flow guarantee the pointer isn't modified elsewhere
       const targetCopy = target;

--- a/src/ParseObject.js
+++ b/src/ParseObject.js
@@ -2336,6 +2336,7 @@ const DefaultController = {
 
     } else if (target instanceof ParseObject) {
       // copying target lets Flow guarantee the pointer isn't modified elsewhere
+      target._getId();
       const localId = target._localId;
       const targetCopy = target;
       const task = function() {

--- a/src/__tests__/ParseObject-test.js
+++ b/src/__tests__/ParseObject-test.js
@@ -2892,4 +2892,21 @@ describe('ParseObject pin', () => {
       expect(error).toBe('Parse.enableLocalDatastore() must be called first');
     }
   });
+  it('gets id for new object when cascadeSave = false and singleInstance = false', (done) => {
+    ParseObject.disableSingleInstance();
+    CoreManager.getRESTController()._setXHR(
+      mockXHR([{
+        status: 200,
+        response: {
+          objectId: 'P5',
+        }
+      }])
+    );
+    const p = new ParseObject('Person');
+    p.save(null, {cascadeSave: false}).then((obj) => {
+      expect(obj).toBe(p);
+      expect(obj.id).toBe('P5');
+      done();
+    });
+  })
 });


### PR DESCRIPTION
On SDK 2.11 saving new objects with option cascadeSave=false returns object without id (id = undefined). 
Rationale:
_handleSaveResponse -> _migrateId demands _localId AND serverId to be defined
_localId is generated with _getId()
normally _getId() is called in object.save() method by calling unsavedChildren()
but when cascadeSave=false unsavedChildren is not called -> _localId is undefined -> migrateId does not save serverId from created object

Solution:
since _localId is needed in controller.save() method, just call _getId() there