### PR TITLE
Change username signup error

### DIFF
--- a/src/ParseUser.js
+++ b/src/ParseUser.js
@@ -995,7 +995,7 @@ const DefaultController = {
       return Promise.reject(
         new ParseError(
           ParseError.OTHER_CAUSE,
-          'Cannot sign up user with an empty name.'
+          'Cannot sign up user with an empty username.'
         )
       );
     }

--- a/src/__tests__/ParseUser-test.js
+++ b/src/__tests__/ParseUser-test.js
@@ -171,7 +171,7 @@ describe('ParseUser', () => {
       // Should not be reached
       expect(true).toBe(false);
     }, (error) => {
-      expect(error.message).toBe('Cannot sign up user with an empty name.');
+      expect(error.message).toBe('Cannot sign up user with an empty username.');
     });
     ParseUser.signUp('username').then(() => {
       // Should not be reached


### PR DESCRIPTION
It was hard to determine that `name` actually refer to `username`. Can we make it specific?