### PR TITLE
Make iteration query methods respect returned promises

### DIFF
--- a/src/ParseQuery.js
+++ b/src/ParseQuery.js
@@ -1074,11 +1074,12 @@ class ParseQuery {
     const array = [];
     let index = 0;
     await this.each((object) => {
-      const flag = callback(object, index, this);
-      if (flag) {
-        array.push(object);
-      }
-      index += 1;
+      return Promise.resolve(callback(object, index, this)).then((flag) => {
+        if (flag) {
+          array.push(object);
+        }
+        index += 1;
+      });
     }, options);
     return array;
   }

--- a/src/ParseQuery.js
+++ b/src/ParseQuery.js
@@ -999,8 +999,10 @@ class ParseQuery {
     const array = [];
     let index = 0;
     await this.each((object) => {
-      array.push(callback(object, index, this));
-      index += 1;
+      return Promise.resolve(callback(object, index, this)).then((result) => {
+        array.push(result);
+        index += 1;
+      });
     }, options);
     return array;
   }

--- a/src/ParseQuery.js
+++ b/src/ParseQuery.js
@@ -1045,6 +1045,11 @@ class ParseQuery {
         index += 1;
       });
     }, options);
+    if (index === 0 && initialValue === undefined) {
+      // Match Array.reduce behavior: "Calling reduce() on an empty array
+      // without an initialValue will throw a TypeError".
+      throw new TypeError("Reducing empty query result set with no initial value");
+    }
     return accumulator;
   }
 

--- a/src/__tests__/ParseQuery-test.js
+++ b/src/__tests__/ParseQuery-test.js
@@ -1770,6 +1770,20 @@ describe('ParseQuery', () => {
       expect(result.attributes.number).toBe(6);
       expect(callCount).toBe(2); // Not called for the first object when used as initial value
     });
+
+    it('rejects with a TypeError when there are no results and no initial value was provided', async () => {
+      CoreManager.setQueryController({
+        aggregate() {},
+        find() { return Promise.resolve({ results: [] }) },
+      });
+
+      const q = new ParseQuery('Item');
+      const callback = (accumulator, object) => {
+        accumulator.attributes.number += object.attributes.number;
+        return accumulator;
+      }
+      return expect(q.reduce(callback)).rejects.toThrow(TypeError);
+    });
   });
 
   describe('iterating over results with .filter()', () => {


### PR DESCRIPTION
These methods (`ParseQuery.map`, `ParseQuery.filter`, and `ParseQuery.reduce`) are documented as behaving similarly to `ParseQuery.each` (which they rely on under the hood): if the callback they are passed returns a promise, we should:
- wait for that promise to resolve before continuing iteration
- if that promise rejects, we should stop iteration and return a rejected promise

These methods weren't living up to that contract. Here's a series of adjustments to each one so that they follow those guidelines.