### PR TITLE
Fix File Progress Type

### DIFF
--- a/src/ParseFile.js
+++ b/src/ParseFile.js
@@ -233,7 +233,17 @@ class ParseFile {
    *     be used for this request.
    *   <li>sessionToken: A valid session token, used for making a request on
    *     behalf of a specific user.
-   *   <li>progress: In Browser only, callback for upload progress
+   *   <li>progress: In Browser only, callback for upload progress. For example:
+   * <pre>
+   * let parseFile = new Parse.File(name, file);
+   * parseFile.save({
+   *   progress: (progressValue, loaded, total, { type }) => {
+   *     if (type === "upload" && progressValue !== null) {
+   *       // Update the UI using progressValue
+   *     }
+   *   }
+   * });
+   * </pre>
    * </ul>
    * @return {Promise} Promise that is resolved when the save finishes.
    */

--- a/src/RESTController.js
+++ b/src/RESTController.js
@@ -163,13 +163,13 @@ const RESTController = {
         if (options && typeof options.progress === 'function') {
           if (event.lengthComputable) {
             options.progress(
-              type,
               event.loaded / event.total,
               event.loaded,
-              event.total
+              event.total,
+              { type }
             );
           } else {
-            options.progress(type, null);
+            options.progress(null, null, null, { type });
           }
         }
       }

--- a/src/RESTController.js
+++ b/src/RESTController.js
@@ -159,27 +159,28 @@ const RESTController = {
         headers[key] = customHeaders[key];
       }
 
-      function handleProgress(event) {
+      function handleProgress(type, event) {
         if (options && typeof options.progress === 'function') {
           if (event.lengthComputable) {
             options.progress(
+              type,
               event.loaded / event.total,
               event.loaded,
               event.total
             );
           } else {
-            options.progress(null);
+            options.progress(type, null);
           }
         }
       }
 
       xhr.onprogress = (event) => {
-        handleProgress(event);
+        handleProgress('download', event);
       };
 
       if (xhr.upload) {
         xhr.upload.onprogress = (event) => {
-          handleProgress(event);
+          handleProgress('upload', event);
         }
       }
 

--- a/src/__tests__/ParseFile-test.js
+++ b/src/__tests__/ParseFile-test.js
@@ -30,7 +30,7 @@ jest.setMock('../LocalDatastore', mockLocalDatastore);
 function generateSaveMock(prefix) {
   return function(name, payload, options) {
     if (options && typeof options.progress === 'function') {
-      options.progress('upload', 0.5, 5, 10);
+      options.progress(0.5, 5, 10, { type: 'upload' });
     }
     return Promise.resolve({
       name: name,
@@ -236,7 +236,7 @@ describe('ParseFile', () => {
     jest.spyOn(options, 'progress');
 
     return file.save(options).then(function(f) {
-      expect(options.progress).toHaveBeenCalledWith('upload', 0.5, 5, 10);
+      expect(options.progress).toHaveBeenCalledWith(0.5, 5, 10, { type: 'upload' });
       expect(f).toBe(file);
       expect(f.name()).toBe('progress.txt');
       expect(f.url()).toBe('http://files.parsetfss.com/a/progress.txt');

--- a/src/__tests__/ParseFile-test.js
+++ b/src/__tests__/ParseFile-test.js
@@ -30,7 +30,7 @@ jest.setMock('../LocalDatastore', mockLocalDatastore);
 function generateSaveMock(prefix) {
   return function(name, payload, options) {
     if (options && typeof options.progress === 'function') {
-      options.progress(0.5, 5, 10);
+      options.progress('upload', 0.5, 5, 10);
     }
     return Promise.resolve({
       name: name,
@@ -236,7 +236,7 @@ describe('ParseFile', () => {
     jest.spyOn(options, 'progress');
 
     return file.save(options).then(function(f) {
-      expect(options.progress).toHaveBeenCalledWith(0.5, 5, 10);
+      expect(options.progress).toHaveBeenCalledWith('upload', 0.5, 5, 10);
       expect(f).toBe(file);
       expect(f.name()).toBe('progress.txt');
       expect(f.url()).toBe('http://files.parsetfss.com/a/progress.txt');

--- a/src/__tests__/RESTController-test.js
+++ b/src/__tests__/RESTController-test.js
@@ -444,8 +444,8 @@ describe('RESTController', () => {
     jest.spyOn(options, 'progress');
 
     RESTController.ajax('POST', 'files/upload.txt', {}, {}, options).then(({ response, status }) => {
-      expect(options.progress).toHaveBeenCalledWith(0.5, 5, 10);
-      expect(options.progress).toHaveBeenCalledTimes(2);
+      expect(options.progress).toHaveBeenCalledWith('download', 0.5, 5, 10);
+      expect(options.progress).toHaveBeenCalledWith('upload', 0.5, 5, 10);
       expect(response).toEqual({ success: true });
       expect(status).toBe(200);
       done();
@@ -468,7 +468,7 @@ describe('RESTController', () => {
     jest.spyOn(options, 'progress');
 
     RESTController.ajax('POST', 'files/upload.txt', {}, {}, options).then(({ response, status }) => {
-      expect(options.progress).toHaveBeenCalledWith(null);
+      expect(options.progress).toHaveBeenCalledWith('upload', null);
       expect(response).toEqual({ success: true });
       expect(status).toBe(200);
       done();

--- a/src/__tests__/RESTController-test.js
+++ b/src/__tests__/RESTController-test.js
@@ -444,8 +444,8 @@ describe('RESTController', () => {
     jest.spyOn(options, 'progress');
 
     RESTController.ajax('POST', 'files/upload.txt', {}, {}, options).then(({ response, status }) => {
-      expect(options.progress).toHaveBeenCalledWith('download', 0.5, 5, 10);
-      expect(options.progress).toHaveBeenCalledWith('upload', 0.5, 5, 10);
+      expect(options.progress).toHaveBeenCalledWith(0.5, 5, 10, { type: 'download' });
+      expect(options.progress).toHaveBeenCalledWith(0.5, 5, 10, { type: 'upload' });
       expect(response).toEqual({ success: true });
       expect(status).toBe(200);
       done();
@@ -468,7 +468,7 @@ describe('RESTController', () => {
     jest.spyOn(options, 'progress');
 
     RESTController.ajax('POST', 'files/upload.txt', {}, {}, options).then(({ response, status }) => {
-      expect(options.progress).toHaveBeenCalledWith('upload', null);
+      expect(options.progress).toHaveBeenCalledWith(null, null, null, { type: 'upload' });
       expect(response).toEqual({ success: true });
       expect(status).toBe(200);
       done();


### PR DESCRIPTION
According to @ladigitale from [last PR](https://github.com/parse-community/Parse-SDK-JS/pull/1133)

> I just found the time to test the pacth.
> As expected at the end of the upload with this code you will yet have 2 consecutive callbacks of the same function with different meanings :
> 
> 1 14535341 14535341 (meaning end of the upload)
> 1 165 165 (meaning end of the download sent as one chunk because of the low size of the response)
> 
> Thats why aditionnal imformations / api evolution would have been usefull.

