### PR TITLE
add context to Parse.Object.save

### DIFF
--- a/src/ParseObject.js
+++ b/src/ParseObject.js
@@ -56,7 +56,8 @@ type SaveParams = {
 };
 
 type SaveOptions = FullOptions & {
-  cascadeSave?: boolean
+  cascadeSave?: boolean;
+  context?: AttributeMap;
 }
 
 // Mapping of class names to constructors, so we can populate objects from the
@@ -1250,6 +1251,9 @@ class ParseObject {
     }
     if (options.hasOwnProperty('installationId') && typeof options.installationId === 'string') {
       saveOptions.installationId = options.installationId;
+    }
+    if (options.hasOwnProperty('context') && typeof options.context === 'object') {
+      saveOptions.context = options.context;
     }
     const controller = CoreManager.getObjectController();
     const unsaved = options.cascadeSave !== false ? unsavedChildren(this) : null;

--- a/src/ParseObject.js
+++ b/src/ParseObject.js
@@ -1180,6 +1180,7 @@ class ParseObject {
    *       <li>sessionToken: A valid session token, used for making a request on
    *       behalf of a specific user.
    *       <li>cascadeSave: If `false`, nested objects will not be saved (default is `true`).
+   *       <li>context: A dictionary that is accessible in Cloud Code `beforeSave` and `afterSave` triggers.
    *     </ul>
    *   </li>
    * </ul>
@@ -1193,6 +1194,7 @@ class ParseObject {
    *   <li>sessionToken: A valid session token, used for making a request on
    *       behalf of a specific user.
    *   <li>cascadeSave: If `false`, nested objects will not be saved (default is `true`).
+   *   <li>context: A dictionary that is accessible in Cloud Code `beforeSave` and `afterSave` triggers.
    * </ul>
    *
    * @return {Promise} A promise that is fulfilled when the save

--- a/src/RESTController.js
+++ b/src/RESTController.js
@@ -21,6 +21,7 @@ export type RequestOptions = {
   batchSize?: number;
   include?: any;
   progress?: any;
+  context?: any;
 };
 
 export type FullOptions = {
@@ -220,6 +221,13 @@ const RESTController = {
       for (const k in data) {
         payload[k] = data[k];
       }
+    }
+
+    // Add context
+    const context = options.context;
+    if (context !== undefined) {
+      payload._context = context;
+      delete options.context;
     }
 
     if (method !== 'POST') {

--- a/src/__tests__/ParseObject-test.js
+++ b/src/__tests__/ParseObject-test.js
@@ -1219,6 +1219,26 @@ describe('ParseObject', () => {
     });
   });
 
+  it('accepts context on save', async () => {
+    // Mock XHR
+    CoreManager.getRESTController()._setXHR(
+      mockXHR([{
+        status: 200,
+        response: { objectId: 'newattributes' }
+      }])
+    );
+    // Spy on REST controller
+    const controller = CoreManager.getRESTController();
+    jest.spyOn(controller, 'ajax');
+    // Save object
+    const context = {a: "a"};
+    const obj = new ParseObject('Item');
+    await obj.save(null, {context});
+    // Validate
+    const jsonBody = JSON.parse(controller.ajax.mock.calls[0][2]);
+    expect(jsonBody._context).toEqual(context);
+  });
+
   it('interpolates delete operations', (done) => {
     CoreManager.getRESTController()._setXHR(
       mockXHR([{


### PR DESCRIPTION
Exposes the `context` object in `Parse.Object.save()` so that parameters can be made accessible in Cloud Code triggers `beforeSave`, `afterSave`.

Example:

```
const obj = new TestObject();
await obj.save(null, {context: {a: "a"}});

Parse.Cloud.beforeSave("TestObject", req => {
    console.log(req.context.a);
});

Parse.Cloud.afterSave("TestObject", req => {
    console.log(req.context.a);
});  
```
---
Don't merge until

- [ ] Concept agreed on in https://github.com/parse-community/parse-server/issues/6459
- [x] JS doc added in code for ‘context’