### PR TITLE
Fix: Live Query Subscription Open Event

### DIFF
--- a/integration/test/ParseLiveQueryTest.js
+++ b/integration/test/ParseLiveQueryTest.js
@@ -205,4 +205,20 @@ describe('Parse LiveQuery', () => {
     })
     await object.save({ foo: 'bar' });
   });
+
+  it('can subscribe with open event', async (done) => {
+    const installationId = await Parse.CoreManager.getInstallationController().currentInstallationId();
+    const client = await Parse.CoreManager.getLiveQueryController().getDefaultLiveQueryClient();
+    const object = new TestObject();
+    await object.save();
+
+    const query = new Parse.Query(TestObject);
+    query.equalTo('objectId', object.id);
+    const subscription = await query.subscribe();
+    subscription.on('open', (response) => {
+      assert.equal(response.clientId, client.id);
+      assert.equal(response.installationId, installationId);
+      done();
+    })
+  });
 });

--- a/src/LiveQueryClient.js
+++ b/src/LiveQueryClient.js
@@ -374,7 +374,7 @@ class LiveQueryClient extends EventEmitter {
       if (subscription) {
         subscription.subscribed = true;
         subscription.subscribePromise.resolve();
-        subscription.emit(SUBSCRIPTION_EMMITER_TYPES.OPEN, response);
+        setTimeout(() => subscription.emit(SUBSCRIPTION_EMMITER_TYPES.OPEN, response), 200);
       }
       break;
     case OP_EVENTS.ERROR:

--- a/src/__tests__/LiveQueryClient-test.js
+++ b/src/__tests__/LiveQueryClient-test.js
@@ -182,7 +182,7 @@ describe('LiveQueryClient', () => {
     });
 
     liveQueryClient._handleWebSocketMessage(event);
-
+    jest.runOnlyPendingTimers();
     expect(isChecked).toBe(true);
   });
 


### PR DESCRIPTION
Closes: https://github.com/parse-community/Parse-SDK-JS/issues/1147

Waits 200 milliseconds to allow for client to set open event after the subscription resolves.