### PR TITLE
Improve eachBatch method

### DIFF
--- a/src/ParseQuery.js
+++ b/src/ParseQuery.js
@@ -926,18 +926,20 @@ class ParseQuery {
     let previousResults = [];
     return continueWhile(() => {
       return !finished;
-    }, () => {
-      return Promise.all([
+    }, async () => {
+      const [results] = await Promise.all([
         query.find(findOptions),
-        Promise.resolve(callback(previousResults))])
-        .then(([results]) => {
-          if (results.length == 0) {
-            finished = true;
-          } else {
-            query.greaterThan('objectId', results[results.length - 1].id);
-            previousResults = results;
-          }
-        });
+        Promise.resolve(previousResults.length > 0 && callback(previousResults))
+      ]);
+      if (results.length >= query._limit) {
+        query.greaterThan('objectId', results[results.length - 1].id);
+        previousResults = results;
+      } else if (results.length > 0) {
+        await Promise.resolve(callback(results));
+        finished = true;
+      } else {
+        finished = true;
+      }
     });
   }
 

--- a/src/ParseQuery.js
+++ b/src/ParseQuery.js
@@ -923,18 +923,21 @@ class ParseQuery {
     }
 
     let finished = false;
+    let previousResults = [];
     return continueWhile(() => {
       return !finished;
     }, () => {
-      return query.find(findOptions).then((results) => {
-        return Promise.resolve(callback(results)).then(() => {
-          if (results.length >= query._limit) {
-            query.greaterThan('objectId', results[results.length - 1].id);
-          } else {
+      return Promise.all([
+        query.find(findOptions),
+        Promise.resolve(callback(previousResults))])
+        .then(([results]) => {
+          if (results.length == 0) {
             finished = true;
+          } else {
+            query.greaterThan('objectId', results[results.length - 1].id);
+            previousResults = results;
           }
         });
-      });
     });
   }
 


### PR DESCRIPTION
Currently, what's happening with the `eachBatch` Query method is this:
- find X objects
- execute a callback on these objects
- find the next X objects
The issue is that while executing the callback, nothing is done, and we have to wait for the next Find to succeed to start again the callback.

An easy improvement is to launch the next query in parallel of the execution of the callback, so that when the callback is done, the next batch is already ready to be consumed (or more advanced if the query is longer than the callback execution)

It's done by changing the order of the promises, and waiting for both the query and the callback on the previous batch to be resolved.