### PR TITLE
fix context when cascade-saving objects

### DIFF
--- a/src/RESTController.js
+++ b/src/RESTController.js
@@ -227,7 +227,6 @@ const RESTController = {
     const context = options.context;
     if (context !== undefined) {
       payload._context = context;
-      delete options.context;
     }
 
     if (method !== 'POST') {


### PR DESCRIPTION
Removed deletion of context from save options to preserve it when cascade-saving child objects.

related to https://github.com/parse-community/parse-server/issues/6736