### PR TITLE
add idempotency error "duplicate request"

### DIFF
--- a/src/ParseError.js
+++ b/src/ParseError.js
@@ -354,6 +354,15 @@ ParseError.FILE_DELETE_ERROR = 153;
 ParseError.REQUEST_LIMIT_EXCEEDED = 155;
 
 /**
+ * Error code indicating that the request was a duplicate and has been discarded due to
+ * idempotency rules.
+ * @property DUPLICATE_REQUEST
+ * @static
+ * @final
+ */
+ParseError.DUPLICATE_REQUEST = 159;
+
+/**
  * Error code indicating an invalid event name.
  * @property INVALID_EVENT_NAME
  * @static


### PR DESCRIPTION
Adds new Parse Error 159: `DUPLICATE_REQUEST`.

This PR completes the server side implementation of https://github.com/parse-community/parse-server/pull/6748.