### PR TITLE
Fix: Live Query Subscription Error Event

### DIFF
--- a/src/LiveQueryClient.js
+++ b/src/LiveQueryClient.js
@@ -381,7 +381,7 @@ class LiveQueryClient extends EventEmitter {
       if (data.requestId) {
         if (subscription) {
           subscription.subscribePromise.resolve();
-          subscription.emit(SUBSCRIPTION_EMMITER_TYPES.ERROR, data.error);
+          setTimeout(() => subscription.emit(SUBSCRIPTION_EMMITER_TYPES.ERROR, data.error), 200);
         }
       } else {
         this.emit(CLIENT_EMMITER_TYPES.ERROR, data.error);

--- a/src/__tests__/LiveQueryClient-test.js
+++ b/src/__tests__/LiveQueryClient-test.js
@@ -244,6 +244,7 @@ describe('LiveQueryClient', () => {
 
     liveQueryClient._handleWebSocketMessage(event);
 
+    jest.runOnlyPendingTimers();
     expect(isChecked).toBe(true);
   });
 


### PR DESCRIPTION
Similar to https://github.com/parse-community/Parse-SDK-JS/pull/1151

Waits 200 milliseconds to allow for client to set error event after the subscription resolves.