### PR TITLE
Update Cloud Code

### DIFF
--- a/src/CloudCode.js
+++ b/src/CloudCode.js
@@ -74,7 +74,7 @@
  * @method beforeDelete
  * @name Parse.Cloud.beforeDelete
  * @param {(String|Parse.Object)} arg1 The Parse.Object subclass to register the before delete function for. This can instead be a String that is the className of the subclass.
- * @param {Function} func The function to run after a save. This function should take just one parameter, {@link Parse.Cloud.TriggerRequest}.
+ * @param {Function} func The function to run before a delete. This function should take just one parameter, {@link Parse.Cloud.TriggerRequest}.
  */
 
 /**
@@ -98,7 +98,7 @@
  * @method beforeSave
  * @name Parse.Cloud.beforeSave
  * @param {(String|Parse.Object)} arg1 The Parse.Object subclass to register the after save function for. This can instead be a String that is the className of the subclass.
- * @param {Function} func The function to run after a save. This function should take just one parameter, {@link Parse.Cloud.TriggerRequest}.
+ * @param {Function} func The function to run before a save. This function should take just one parameter, {@link Parse.Cloud.TriggerRequest}.
  */
 
 /**


### PR DESCRIPTION
Hi all,

Not sure if my formatting is perfect but closes #1176 (removes pre. SDK 2.0 success functions), and adds documentation for LiveQuery triggers.

Also, for me, when I google "Parse Javascript SDK", it takes me to v1.11.0. Is there any way we can add "This SDK is outdated" or some other warning to point users to the latest SDK?

Thank you!