### PR TITLE
fix: crypto-js crashing React Native

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,6 @@
   "dependencies": {
     "@babel/runtime-corejs3": "7.11.2",
     "@babel/runtime": "7.11.2",
-    "crypto-js": "4.0.0",
     "react-native-crypto-js": "1.0.0",
     "uuid": "3.4.0",
     "ws": "7.3.1",
@@ -74,6 +73,9 @@
     "parse-server": "github:parse-community/parse-server#master",
     "regenerator-runtime": "0.13.5",
     "vinyl-source-stream": "2.0.0"
+  },
+  "optionalDependencies": {
+    "crypto-js": "4.0.0"
   },
   "scripts": {
     "build": "node build_releases.js",


### PR DESCRIPTION
Closes: https://github.com/parse-community/Parse-SDK-JS/issues/1201

Moves crypto-js to optionalDependencies