### PR TITLE
fix(ParseRelation): Schema mismatch on empty array

### DIFF
--- a/integration/test/ParseRelationTest.js
+++ b/integration/test/ParseRelationTest.js
@@ -4,6 +4,8 @@ const assert = require('assert');
 const clear = require('./clear');
 const Parse = require('../../node');
 
+const TestObject = Parse.Object.extend('TestObject');
+
 describe('Parse Relation', () => {
   beforeEach((done) => {
     Parse.initialize('integration', null, 'notsosecret');
@@ -210,5 +212,39 @@ describe('Parse Relation', () => {
       assert.equal(wheels[0].id, origWheel.id);
       done();
     });
+  });
+
+  it('can add empty array to relation', async () => {
+    const object1 = new TestObject();
+    await object1.save();
+
+    const object2 = new TestObject();
+    object2.relation('related').add(object1);
+    await object2.save();
+
+    object2.relation('related').add([]);
+    await object2.save();
+
+    const relation = object2.relation('related');
+    const query = relation.query();
+    const results = await query.find();
+    expect(results.length).toBe(1);
+  });
+
+  it('can remove empty array from relation', async () => {
+    const object1 = new TestObject();
+    await object1.save();
+
+    const object2 = new TestObject();
+    object2.relation('related').add(object1);
+    await object2.save();
+
+    object2.relation('related').remove([]);
+    await object2.save();
+
+    const relation = object2.relation('related');
+    const query = relation.query();
+    const results = await query.find();
+    expect(results.length).toBe(1);
   });
 });

--- a/src/ParseRelation.js
+++ b/src/ParseRelation.js
@@ -85,6 +85,9 @@ class ParseRelation {
     if (!parent) {
       throw new Error('Cannot add to a Relation without a parent');
     }
+    if (objects.length === 0) {
+      return parent;
+    }
     parent.set(this.key, change);
     this.targetClassName = change._targetClassName;
     return parent;
@@ -103,6 +106,9 @@ class ParseRelation {
     const change = new RelationOp([], objects);
     if (!this.parent) {
       throw new Error('Cannot remove from a Relation without a parent');
+    }
+    if (objects.length === 0) {
+      return;
     }
     this.parent.set(this.key, change);
     this.targetClassName = change._targetClassName;

--- a/src/__tests__/ParseRelation-test.js
+++ b/src/__tests__/ParseRelation-test.js
@@ -118,6 +118,38 @@ describe('ParseRelation', () => {
     });
   });
 
+  it('can add empty array to a relation', () => {
+    const parent = new ParseObject('Item');
+    parent.id = 'I1234';
+    const r = new ParseRelation(parent, 'shipments');
+    const o = new ParseObject('Delivery');
+    o.id = 'D1234';
+    const p = r.add(o);
+    expect(p).toBeTruthy();
+    expect(r.toJSON()).toEqual({
+      __type: 'Relation',
+      className: 'Delivery'
+    });
+    expect(parent.op('shipments').toJSON()).toEqual({
+      __op: 'AddRelation',
+      objects: [
+        { __type: 'Pointer', objectId: 'D1234', className: 'Delivery' }
+      ]
+    });
+    // Adding empty array shouldn't change the relation
+    r.add([]);
+    expect(r.toJSON()).toEqual({
+      __type: 'Relation',
+      className: 'Delivery'
+    });
+    expect(parent.op('shipments').toJSON()).toEqual({
+      __op: 'AddRelation',
+      objects: [
+        { __type: 'Pointer', objectId: 'D1234', className: 'Delivery' }
+      ]
+    });
+  });
+
   it('can remove objects from a relation', () => {
     const parent = new ParseObject('Item');
     parent.id = 'I2';
@@ -151,6 +183,37 @@ describe('ParseRelation', () => {
         { __type: 'Pointer', objectId: 'D1', className: 'Delivery' },
         { __type: 'Pointer', objectId: 'D2', className: 'Delivery' },
         { __type: 'Pointer', objectId: 'D3', className: 'Delivery' },
+      ]
+    });
+  });
+
+  it('can remove empty array from a relation', () => {
+    const parent = new ParseObject('Item');
+    parent.id = 'I5678';
+    const r = new ParseRelation(parent, 'shipments');
+    const o = new ParseObject('Delivery');
+    o.id = 'D5678';
+    r.remove(o);
+    expect(r.toJSON()).toEqual({
+      __type: 'Relation',
+      className: 'Delivery'
+    });
+    expect(parent.op('shipments').toJSON()).toEqual({
+      __op: 'RemoveRelation',
+      objects: [
+        { __type: 'Pointer', objectId: 'D5678', className: 'Delivery' }
+      ]
+    });
+    // Removing empty array shouldn't change the relation
+    r.remove([]);
+    expect(r.toJSON()).toEqual({
+      __type: 'Relation',
+      className: 'Delivery'
+    });
+    expect(parent.op('shipments').toJSON()).toEqual({
+      __op: 'RemoveRelation',
+      objects: [
+        { __type: 'Pointer', objectId: 'D5678', className: 'Delivery' }
       ]
     });
   });


### PR DESCRIPTION
Closes: https://github.com/parse-community/Parse-SDK-JS/issues/1217