### PR TITLE
Add a findAll method to ParseQuery

### DIFF
--- a/integration/test/ParseQueryTest.js
+++ b/integration/test/ParseQueryTest.js
@@ -1223,6 +1223,18 @@ describe('Parse Query', () => {
     });
   });
 
+  it('can return all objects with findAll', async () => {
+    const objs = [...Array(101)].map(() => new Parse.Object('Container'));
+
+    await Parse.Object.saveAll(objs);
+
+    const query = new Parse.Query('Container');
+
+    const result = await query.findAll();
+
+    assert.equal(result.length, 101);
+  });
+
   it('can include nested objects via array', (done) => {
     const child = new TestObject();
     const parent = new Parse.Object('Container');

--- a/src/ParseQuery.js
+++ b/src/ParseQuery.js
@@ -674,6 +674,28 @@ class ParseQuery {
   }
 
   /**
+   * Retrieves a complete list of ParseObjects that satisfy this query.
+   * Using `eachBatch` under the hood to fetch all the valid objects.
+   *
+   * @param {Object} options Valid options are:<ul>
+   *   <li>batchSize: How many objects to yield in each batch (default: 100)
+   *   <li>useMasterKey: In Cloud Code and Node only, causes the Master Key to
+   *     be used for this request.
+   *   <li>sessionToken: A valid session token, used for making a request on
+   *       behalf of a specific user.
+   * </ul>
+   * @return {Promise} A promise that is resolved with the results when
+   * the query completes.
+   */
+  async findAll(options?: BatchOptions): Promise<Array<ParseObject>> {
+    let result: ParseObject[] = [];
+    await this.eachBatch((objects: ParseObject[]) => {
+      result = [...result, ...objects];
+    }, options);
+    return result;
+  }
+
+  /**
    * Counts the number of objects that match this query.
    * Either options.success or options.error is called when the count
    * completes.


### PR DESCRIPTION
To get around the 100 objects maximum retrieval on the Parse Server side I used to do `Parse.Query().limit(9999).find()`.

And after looking at the code I found out about the `eachBatch` method which is really neat and I wonder if you'd consider adding a `findAll` method the the Parse.Query class based on it.