### PR TITLE
Remove backbone callback documentation

### DIFF
--- a/src/ParseGeoPoint.js
+++ b/src/ParseGeoPoint.js
@@ -195,7 +195,6 @@ class ParseGeoPoint {
 
   /**
    * Creates a GeoPoint with the user's current location, if available.
-   * Calls options.success with a new GeoPoint instance or calls options.error.
    * @static
    */
   static current() {

--- a/src/ParseObject.js
+++ b/src/ParseObject.js
@@ -1237,26 +1237,9 @@ class ParseObject {
       options = arg3;
     }
 
-    // TODO: safely remove me
-    // Support save({ success: function() {}, error: function() {} })
-    if (!options && attrs) {
-      options = {};
-      if (typeof attrs.success === 'function') {
-        options.success = attrs.success;
-        delete attrs.success;
-      }
-      if (typeof attrs.error === 'function') {
-        options.error = attrs.error;
-        delete attrs.error;
-      }
-    }
-
     if (attrs) {
       const validation = this.validate(attrs);
       if (validation) {
-        if (options && typeof options.error === 'function') {
-          options.error(this, validation);
-        }
         return Promise.reject(validation);
       }
       this.set(attrs, options);

--- a/src/ParseQuery.js
+++ b/src/ParseQuery.js
@@ -554,8 +554,7 @@ class ParseQuery {
 
   /**
    * Constructs a Parse.Object whose id is already known by fetching data from
-   * the server.  Either options.success or options.error is called when the
-   * find completes. Unlike the <code>first</code> method, it never returns undefined.
+   * the server. Unlike the <code>first</code> method, it never returns undefined.
    *
    * @param {String} objectId The id of the object to be fetched.
    * @param {Object} options
@@ -599,8 +598,6 @@ class ParseQuery {
 
   /**
    * Retrieves a list of ParseObjects that satisfy this query.
-   * Either options.success or options.error is called when the find
-   * completes.
    *
    * @param {Object} options Valid options
    * are:<ul>
@@ -697,8 +694,6 @@ class ParseQuery {
 
   /**
    * Counts the number of objects that match this query.
-   * Either options.success or options.error is called when the count
-   * completes.
    *
    * @param {Object} options
    * Valid options are:<ul>
@@ -826,8 +821,7 @@ class ParseQuery {
   /**
    * Retrieves at most one Parse.Object that satisfies this query.
    *
-   * Either options.success or options.error is called when it completes.
-   * success is passed the object if there is one. otherwise, undefined.
+   * Returns the object if there is one, otherwise undefined.
    *
    * @param {Object} options Valid options are:<ul>
    *   <li>useMasterKey: In Cloud Code and Node only, causes the Master Key to

--- a/src/ParseUser.js
+++ b/src/ParseUser.js
@@ -398,9 +398,6 @@ class ParseUser extends ParseObject {
    *
    * <p>A username and password must be set before calling signUp.</p>
    *
-   * <p>Calls options.success or options.error on completion.</p>
-   *
-
    * @param {Object} attrs Extra fields to set on the new user, or null.
    * @param {Object} options
    * @return {Promise} A promise that is fulfilled when the signup
@@ -432,9 +429,6 @@ class ParseUser extends ParseObject {
    *
    * <p>A username and password must be set before calling logIn.</p>
    *
-   * <p>Calls options.success or options.error on completion.</p>
-   *
-
    * @param {Object} options
    * @return {Promise} A promise that is fulfilled with the user when
    *     the login is complete.
@@ -601,9 +595,6 @@ class ParseUser extends ParseObject {
    * session in localStorage so that you can access the user using
    * {@link #current}.
    *
-   * <p>Calls options.success or options.error on completion.</p>
-   *
-
    * @param {String} username The username (or email) to sign up with.
    * @param {String} password The password to sign up with.
    * @param {Object} attrs Extra fields to set on the new user.
@@ -625,9 +616,6 @@ class ParseUser extends ParseObject {
    * saves the session to disk, so you can retrieve the currently logged in
    * user using <code>current</code>.
    *
-   * <p>Calls options.success or options.error on completion.</p>
-   *
-
    * @param {String} username The username (or email) to log in with.
    * @param {String} password The password to log in with.
    * @param {Object} options
@@ -661,9 +649,6 @@ class ParseUser extends ParseObject {
    * to disk, so you can retrieve the currently logged in user using
    * <code>current</code>.
    *
-   * <p>Calls options.success or options.error on completion.</p>
-   *
-
    * @param {String} sessionToken The sessionToken to log in with.
    * @param {Object} options
    * @static
@@ -755,9 +740,6 @@ class ParseUser extends ParseObject {
    * associated with the user account. This email allows the user to securely
    * reset their password on the Parse site.
    *
-   * <p>Calls options.success or options.error on completion.</p>
-   *
-
    * @param {String} email The email address associated with the user that
    *     forgot their password.
    * @param {Object} options
@@ -780,8 +762,6 @@ class ParseUser extends ParseObject {
 
   /**
    * Request an email verification.
-   *
-   * <p>Calls options.success or options.error on completion.</p>
    *
    * @param {String} email The email address associated with the user that
    *     forgot their password.


### PR DESCRIPTION
Old backbone callbacks (options.success, options.error) are only used in linkWith authentication and object.set validation now.

i.e
```
object.set("currentPlayer", player2, {
  error: function(objectAgain, error) {
    // The set failed validation.
  }
});
```