### PR TITLE
Improve Code Coverage

### DIFF
--- a/src/LiveQueryClient.js
+++ b/src/LiveQueryClient.js
@@ -167,6 +167,10 @@ class LiveQueryClient extends EventEmitter {
     this.connectPromise = resolvingPromise();
     this.subscriptions = new Map();
     this.state = CLIENT_STATE.INITIALIZED;
+
+    // adding listener so process does not crash
+    // best practice is for developer to register their own listener
+    this.on('error', () => {});
   }
 
   shouldOpen(): any {
@@ -447,7 +451,7 @@ class LiveQueryClient extends EventEmitter {
   _handleWebSocketError(error: any) {
     this.emit(CLIENT_EMMITER_TYPES.ERROR, error);
     for (const subscription of this.subscriptions.values()) {
-      subscription.emit(SUBSCRIPTION_EMMITER_TYPES.ERROR);
+      subscription.emit(SUBSCRIPTION_EMMITER_TYPES.ERROR, error);
     }
     this._handleReconnect();
   }

--- a/src/ParseACL.js
+++ b/src/ParseACL.js
@@ -46,11 +46,6 @@ class ParseACL {
       } else {
         for (const userId in arg1) {
           const accessList = arg1[userId];
-          if (typeof userId !== 'string') {
-            throw new TypeError(
-              'Tried to create an ACL with an invalid user id.'
-            );
-          }
           this.permissionsById[userId] = {};
           for (const permission in accessList) {
             const allowed = accessList[permission];

--- a/src/ParseACL.js
+++ b/src/ParseACL.js
@@ -46,6 +46,11 @@ class ParseACL {
       } else {
         for (const userId in arg1) {
           const accessList = arg1[userId];
+          if (typeof userId !== 'string') {
+            throw new TypeError(
+              'Tried to create an ACL with an invalid user id.'
+            );
+          }
           this.permissionsById[userId] = {};
           for (const permission in accessList) {
             const allowed = accessList[permission];

--- a/src/ParseConfig.js
+++ b/src/ParseConfig.js
@@ -116,6 +116,15 @@ class ParseConfig {
       return Promise.reject(error);
     });
   }
+
+  /**
+   * Used for testing
+   *
+   * @private
+   */
+  static _clearCache() {
+    currentConfig = null;
+  }
 }
 
 let currentConfig = null;
@@ -141,9 +150,8 @@ const DefaultController = {
 
     const config = new ParseConfig();
     const storagePath = Storage.generatePath(CURRENT_CONFIG_KEY);
-    let configData;
     if (!Storage.async()) {
-      configData = Storage.getItem(storagePath);
+      const configData = Storage.getItem(storagePath);
 
       if (configData) {
         const attributes = decodePayload(configData);

--- a/src/ParseFile.js
+++ b/src/ParseFile.js
@@ -441,9 +441,9 @@ const DefaultController = {
     const base64Data = await new Promise((res, rej) => {
       // eslint-disable-next-line no-undef
       const reader = new FileReader();
-      reader.readAsDataURL(source.file);
       reader.onload = () => res(reader.result);
       reader.onerror = error => rej(error);
+      reader.readAsDataURL(source.file);
     });
     // we only want the data after the comma
     // For example: "data:application/pdf;base64,JVBERi0xLjQKJ..." we would only want "JVBERi0xLjQKJ..."
@@ -556,8 +556,13 @@ const DefaultController = {
   _setXHR(xhr: any) {
     XHR = xhr;
   },
+
+  _getXHR() {
+    return XHR;
+  },
 };
 
 CoreManager.setFileController(DefaultController);
 
 export default ParseFile;
+exports.b64Digit = b64Digit;

--- a/src/ParseInstallation.js
+++ b/src/ParseInstallation.js
@@ -18,7 +18,7 @@ export default class Installation extends ParseObject {
     super('_Installation');
     if (attributes && typeof attributes === 'object'){
       if (!this.set(attributes || {})) {
-        throw new Error('Can\'t create an invalid Session');
+        throw new Error('Can\'t create an invalid Installation');
       }
     }
   }

--- a/src/ParseQuery.js
+++ b/src/ParseQuery.js
@@ -820,7 +820,9 @@ class ParseQuery {
     }
 
     if (Object.keys(this._where || {}).length) {
-      if(!Array.isArray(pipeline)) pipeline = [pipeline];
+      if(!Array.isArray(pipeline)) {
+        pipeline = [pipeline];
+      }
       pipeline.unshift({ match: this._where });
     }
 

--- a/src/ParseQuery.js
+++ b/src/ParseQuery.js
@@ -820,7 +820,7 @@ class ParseQuery {
     }
 
     if (Object.keys(this._where || {}).length) {
-      if(!Array.isArray(pipeline)) {
+      if (!Array.isArray(pipeline)) {
         pipeline = [pipeline];
       }
       pipeline.unshift({ match: this._where });

--- a/src/ParseUser.js
+++ b/src/ParseUser.js
@@ -105,7 +105,7 @@ class ParseUser extends ParseObject {
             return authType;
           },
         };
-        authProviders[authType] = authProvider;
+        authProviders[authProvider.getAuthType()] = authProvider;
         provider = authProvider;
       }
     } else {

--- a/src/Socket.weapp.js
+++ b/src/Socket.weapp.js
@@ -22,8 +22,8 @@ module.exports = class SocketWeapp {
     });
 
     wx.connectSocket({
-      url: serverURL
-    })
+      url: serverURL,
+    });
   }
 
   send(data) {

--- a/src/Socket.weapp.js
+++ b/src/Socket.weapp.js
@@ -5,10 +5,6 @@ module.exports = class SocketWeapp {
     this.onclose = () => {}
     this.onerror = () => {}
 
-    wx.connectSocket({
-      url: serverURL
-    })
-
     wx.onSocketOpen(() => {
       this.onopen();
     })
@@ -19,10 +15,14 @@ module.exports = class SocketWeapp {
 
     wx.onSocketClose(() => {
       this.onclose();
-    })
+    });
 
     wx.onSocketError((error) => {
       this.onerror(error);
+    });
+
+    wx.connectSocket({
+      url: serverURL
     })
   }
 

--- a/src/__tests__/Cloud-test.js
+++ b/src/__tests__/Cloud-test.js
@@ -11,6 +11,7 @@ jest.dontMock('../Cloud');
 jest.dontMock('../CoreManager');
 jest.dontMock('../decode');
 jest.dontMock('../encode');
+jest.dontMock('../ParseQuery');
 
 const Cloud = require('../Cloud');
 const CoreManager = require('../CoreManager');
@@ -222,4 +223,24 @@ describe('CloudController', () => {
     // Validate
     expect(controller.request.mock.calls[0][3].context).toEqual(context);
   });
+
+  // fit('can get job status', async () => {
+  //   const request = jest.fn();
+  //   request.mockReturnValue(Promise.resolve({ results: [] }));
+
+  //   const ajax = jest.fn();
+  //   CoreManager.setRESTController({ request: request, ajax: ajax });
+
+  //   await Cloud.getJobStatus('jobId1234');
+  //   const [ method, path, data, options] = CoreManager.getRESTController().request.mock.calls[0];
+  //   expect(method).toBe('GET');
+  //   expect(path).toBe('classes/_JobStatus');
+  //   expect(data).toEqual({
+  //     limit: 1,
+  //     where: {
+  //       objectId: 'jobId1234',
+  //     },
+  //   });
+  //   expect(options.useMasterKey).toBe(true);
+  // });
 });

--- a/src/__tests__/Cloud-test.js
+++ b/src/__tests__/Cloud-test.js
@@ -11,6 +11,8 @@ jest.dontMock('../Cloud');
 jest.dontMock('../CoreManager');
 jest.dontMock('../decode');
 jest.dontMock('../encode');
+jest.dontMock('../ParseError');
+jest.dontMock('../ParseObject');
 jest.dontMock('../ParseQuery');
 
 const Cloud = require('../Cloud');
@@ -224,23 +226,23 @@ describe('CloudController', () => {
     expect(controller.request.mock.calls[0][3].context).toEqual(context);
   });
 
-  // fit('can get job status', async () => {
-  //   const request = jest.fn();
-  //   request.mockReturnValue(Promise.resolve({ results: [] }));
+  it('can get job status', async () => {
+    const request = jest.fn();
+    request.mockReturnValue(Promise.resolve({
+      results: [{ className: '_JobStatus', objectId: 'jobId1234' }],
+    }));
+    CoreManager.setRESTController({ request: request, ajax: jest.fn() });
 
-  //   const ajax = jest.fn();
-  //   CoreManager.setRESTController({ request: request, ajax: ajax });
-
-  //   await Cloud.getJobStatus('jobId1234');
-  //   const [ method, path, data, options] = CoreManager.getRESTController().request.mock.calls[0];
-  //   expect(method).toBe('GET');
-  //   expect(path).toBe('classes/_JobStatus');
-  //   expect(data).toEqual({
-  //     limit: 1,
-  //     where: {
-  //       objectId: 'jobId1234',
-  //     },
-  //   });
-  //   expect(options.useMasterKey).toBe(true);
-  // });
+    await Cloud.getJobStatus('jobId1234');
+    const [ method, path, data, options] = request.mock.calls[0];
+    expect(method).toBe('GET');
+    expect(path).toBe('classes/_JobStatus');
+    expect(data).toEqual({
+      limit: 1,
+      where: {
+        objectId: 'jobId1234',
+      },
+    });
+    expect(options.useMasterKey).toBe(true);
+  });
 });

--- a/src/__tests__/Hooks-test.js
+++ b/src/__tests__/Hooks-test.js
@@ -11,11 +11,13 @@ jest.dontMock('../ParseHooks');
 jest.dontMock('../CoreManager');
 jest.dontMock('../decode');
 jest.dontMock('../encode');
+jest.dontMock('../ParseError');
 
 const Hooks = require('../ParseHooks');
 const CoreManager = require('../CoreManager');
 
 const defaultController = CoreManager.getHooksController();
+const { sendRequest } = defaultController;
 
 describe('Hooks', () => {
   beforeEach(() => {
@@ -200,5 +202,27 @@ describe('Hooks', () => {
     done();
   })
 
+  it('should sendRequest', async () => {
+    defaultController.sendRequest = sendRequest;
+    const request = function() {
+      return Promise.resolve(12);
+    };
+    CoreManager.setRESTController({ request, ajax: jest.fn() });
+    const decoded = await defaultController.sendRequest('POST', 'hooks/triggers/myhook');
+    expect(decoded).toBe(12);
+  });
 
+  it('handle sendRequest error', async () => {
+    defaultController.sendRequest = sendRequest;
+    const request = function() {
+      return Promise.resolve(undefined);
+    };
+    CoreManager.setRESTController({ request, ajax: jest.fn() });
+    try {
+      await defaultController.sendRequest('POST', 'hooks/triggers/myhook');
+      expect(false).toBe(true);
+    } catch (e) {
+      expect(e.message).toBe('The server returned an invalid response.');
+    }
+  });
 });

--- a/src/__tests__/InstallationController-test.js
+++ b/src/__tests__/InstallationController-test.js
@@ -59,4 +59,13 @@ describe('InstallationController', () => {
       done();
     });
   });
+
+  it('can set installation id', (done) => {
+    const iid = '12345678';
+    InstallationController._setInstallationIdCache(iid);
+    InstallationController.currentInstallationId().then((i) => {
+      expect(i).toBe(iid);
+      done();
+    });
+  });
 });

--- a/src/__tests__/LiveQueryClient-test.js
+++ b/src/__tests__/LiveQueryClient-test.js
@@ -700,8 +700,8 @@ describe('LiveQueryClient', () => {
     const subscription = new events.EventEmitter();
     liveQueryClient.subscriptions.set(1, subscription);
     const error = {}
-    liveQueryClient.on('error', () => {});
-    subscription.on('error', () => {
+    subscription.on('error', (errorAgain) => {
+      expect(errorAgain).toEqual(error);
       done();
     });
 

--- a/src/__tests__/LiveQueryClient-test.js
+++ b/src/__tests__/LiveQueryClient-test.js
@@ -47,25 +47,91 @@ const CoreManager = require('../CoreManager');
 const LiveQueryClient = require('../LiveQueryClient').default;
 const ParseObject = require('../ParseObject').default;
 const ParseQuery = require('../ParseQuery').default;
+const { resolvingPromise } = require('../promiseUtils');
 const events = require('events');
 
 CoreManager.setLocalDatastore(mockLocalDatastore);
 
-function resolvingPromise() {
-  let res;
-  let rej;
-  const promise = new Promise((resolve, reject) => {
-    res = resolve;
-    rej = reject;
-  });
-  promise.resolve = res;
-  promise.reject = rej;
-  return promise;
-}
-
 describe('LiveQueryClient', () => {
   beforeEach(() => {
     mockLocalDatastore.isEnabled = false;
+  });
+
+  it('serverURL required', () => {
+    expect(() => {
+      new LiveQueryClient({});
+    }).toThrow('You need to set a proper Parse LiveQuery server url before using LiveQueryClient');
+  });
+
+  it('WebSocketController required', (done) => {
+    const WebSocketImplementation = CoreManager.getWebSocketController();
+    CoreManager.setWebSocketController();
+    const liveQueryClient = new LiveQueryClient({
+      applicationId: 'applicationId',
+      serverURL: 'ws://test',
+      javascriptKey: 'javascriptKey',
+      masterKey: 'masterKey',
+      sessionToken: 'sessionToken'
+    });
+    liveQueryClient.on('error', (error) => {
+      expect(error).toBe('Can not find WebSocket implementation');
+      CoreManager.setWebSocketController(WebSocketImplementation);
+      done();
+    })
+    liveQueryClient.open();
+  });
+
+  it('can unsubscribe', async () => {
+    const liveQueryClient = new LiveQueryClient({
+      applicationId: 'applicationId',
+      serverURL: 'ws://test',
+      javascriptKey: 'javascriptKey',
+      masterKey: 'masterKey',
+      sessionToken: 'sessionToken'
+    });
+    liveQueryClient.socket = {
+      send: jest.fn()
+    };
+    const subscription = {
+      id: 1
+    }
+    liveQueryClient.subscriptions.set(1, subscription);
+
+    liveQueryClient.unsubscribe(subscription);
+    liveQueryClient.connectPromise.resolve();
+    expect(liveQueryClient.subscriptions.size).toBe(0);
+    await liveQueryClient.connectPromise;
+    const messageStr = liveQueryClient.socket.send.mock.calls[0][0];
+    const message = JSON.parse(messageStr);
+    expect(message).toEqual({
+      op: 'unsubscribe',
+      requestId: 1
+    });
+  });
+
+  it('can handle open / close states', () => {
+    const liveQueryClient = new LiveQueryClient({
+      applicationId: 'applicationId',
+      serverURL: 'ws://test',
+      javascriptKey: 'javascriptKey',
+      masterKey: 'masterKey',
+      sessionToken: 'sessionToken'
+    });
+    expect(liveQueryClient.shouldOpen()).toBe(true);
+    liveQueryClient.close();
+    expect(liveQueryClient.shouldOpen()).toBe(true);
+    liveQueryClient.open();
+    expect(liveQueryClient.shouldOpen()).toBe(false);
+  });
+
+  it('set undefined sessionToken default', () => {
+    const liveQueryClient = new LiveQueryClient({
+      applicationId: 'applicationId',
+      serverURL: 'ws://test',
+      javascriptKey: 'javascriptKey',
+      masterKey: 'masterKey',
+    });
+    expect(liveQueryClient.sessionToken).toBe(undefined);
   });
 
   it('can connect to server', () => {
@@ -154,6 +220,37 @@ describe('LiveQueryClient', () => {
     expect(liveQueryClient.state).toEqual('connected');
   });
 
+  it('can handle WebSocket reconnect on connected response message', async () => {
+    const liveQueryClient = new LiveQueryClient({
+      applicationId: 'applicationId',
+      serverURL: 'ws://test',
+      javascriptKey: 'javascriptKey',
+      masterKey: 'masterKey',
+      sessionToken: 'sessionToken'
+    });
+    const data = {
+      op: 'connected',
+      clientId: 1
+    };
+    const event = {
+      data: JSON.stringify(data)
+    }
+    // Register checked in advance
+    let isChecked = false;
+    liveQueryClient.on('open', function() {
+      isChecked = true;
+    });
+    jest.spyOn(liveQueryClient, 'resubscribe');
+    liveQueryClient._handleReconnect();
+    liveQueryClient._handleWebSocketMessage(event);
+
+    expect(isChecked).toBe(true);
+    expect(liveQueryClient.id).toBe(1);
+    await liveQueryClient.connectPromise;
+    expect(liveQueryClient.state).toEqual('connected');
+    expect(liveQueryClient.resubscribe).toHaveBeenCalledTimes(1);
+  });
+
   it('can handle WebSocket subscribed response message', () => {
     const liveQueryClient = new LiveQueryClient({
       applicationId: 'applicationId',
@@ -184,6 +281,30 @@ describe('LiveQueryClient', () => {
     liveQueryClient._handleWebSocketMessage(event);
     jest.runOnlyPendingTimers();
     expect(isChecked).toBe(true);
+  });
+
+  it('can handle WebSocket unsubscribed response message', () => {
+    const liveQueryClient = new LiveQueryClient({
+      applicationId: 'applicationId',
+      serverURL: 'ws://test',
+      javascriptKey: 'javascriptKey',
+      masterKey: 'masterKey',
+      sessionToken: 'sessionToken'
+    });
+    const subscription = new events.EventEmitter();
+    subscription.subscribePromise = resolvingPromise();
+
+    liveQueryClient.subscriptions.set(1, subscription);
+    const data = {
+      op: 'unsubscribed',
+      clientId: 1,
+      requestId: 1
+    };
+    const event = {
+      data: JSON.stringify(data)
+    }
+    liveQueryClient._handleWebSocketMessage(event);
+    expect(liveQueryClient.subscriptions.size).toBe(1);
   });
 
   it('can handle WebSocket error response message', () => {
@@ -282,6 +403,28 @@ describe('LiveQueryClient', () => {
     liveQueryClient._handleWebSocketMessage(event);
 
     expect(isChecked).toBe(true);
+  });
+
+  it('can handle WebSocket event response message without subscription', () => {
+    const liveQueryClient = new LiveQueryClient({
+      applicationId: 'applicationId',
+      serverURL: 'ws://test',
+      javascriptKey: 'javascriptKey',
+      masterKey: 'masterKey',
+      sessionToken: 'sessionToken'
+    });
+    const object = new ParseObject('Test');
+    object.set('key', 'value');
+    const data = {
+      op: 'create',
+      clientId: 1,
+      requestId: 1,
+      object: object._toFullJSON()
+    };
+    const event = {
+      data: JSON.stringify(data)
+    }
+    liveQueryClient._handleWebSocketMessage(event);
   });
 
   it('can handle WebSocket response with original', () => {
@@ -450,6 +593,34 @@ describe('LiveQueryClient', () => {
     expect(isCheckedAgain).toBe(true);
   });
 
+  it('can handle WebSocket close message while disconnected', () => {
+    const liveQueryClient = new LiveQueryClient({
+      applicationId: 'applicationId',
+      serverURL: 'ws://test',
+      javascriptKey: 'javascriptKey',
+      masterKey: 'masterKey',
+      sessionToken: 'sessionToken'
+    });
+    // Add mock subscription
+    const subscription = new events.EventEmitter();
+    liveQueryClient.subscriptions.set(1, subscription);
+    // Register checked in advance
+    let isChecked = false;
+    subscription.on('close', function() {
+      isChecked = true;
+    });
+    let isCheckedAgain = false;
+    liveQueryClient.on('close', function() {
+      isCheckedAgain = true;
+    });
+    liveQueryClient.open();
+    liveQueryClient.close();
+    liveQueryClient._handleWebSocketClose();
+
+    expect(isChecked).toBe(true);
+    expect(isCheckedAgain).toBe(true);
+  });
+
   it('can handle reconnect', () => {
     const liveQueryClient = new LiveQueryClient({
       applicationId: 'applicationId',
@@ -465,6 +636,33 @@ describe('LiveQueryClient', () => {
     liveQueryClient._handleReconnect();
     expect(liveQueryClient.state).toEqual('reconnecting');
 
+    jest.runOnlyPendingTimers();
+
+    expect(liveQueryClient.attempts).toEqual(attempts + 1);
+    expect(liveQueryClient.open).toBeCalled();
+  });
+
+  it('can handle reconnect and clear handler', () => {
+    const liveQueryClient = new LiveQueryClient({
+      applicationId: 'applicationId',
+      serverURL: 'ws://test',
+      javascriptKey: 'javascriptKey',
+      masterKey: 'masterKey',
+      sessionToken: 'sessionToken'
+    });
+
+    liveQueryClient.open = jest.fn();
+
+    const attempts = liveQueryClient.attempts;
+    liveQueryClient.state = 'disconnected';
+    liveQueryClient._handleReconnect();
+    expect(liveQueryClient.state).toEqual('disconnected');
+
+    liveQueryClient.state = 'connected';
+    liveQueryClient._handleReconnect();
+    expect(liveQueryClient.state).toEqual('reconnecting');
+
+    liveQueryClient._handleReconnect();
     jest.runOnlyPendingTimers();
 
     expect(liveQueryClient.attempts).toEqual(attempts + 1);
@@ -489,6 +687,25 @@ describe('LiveQueryClient', () => {
     liveQueryClient._handleWebSocketError(error);
 
     expect(isChecked).toBe(true);
+  });
+
+  it('can handle WebSocket error message with subscriptions', (done) => {
+    const liveQueryClient = new LiveQueryClient({
+      applicationId: 'applicationId',
+      serverURL: 'ws://test',
+      javascriptKey: 'javascriptKey',
+      masterKey: 'masterKey',
+      sessionToken: 'sessionToken'
+    });
+    const subscription = new events.EventEmitter();
+    liveQueryClient.subscriptions.set(1, subscription);
+    const error = {}
+    liveQueryClient.on('error', () => {});
+    subscription.on('error', () => {
+      done();
+    });
+
+    liveQueryClient._handleWebSocketError(error);
   });
 
   it('can handle WebSocket reconnect on error event', () => {
@@ -560,6 +777,45 @@ describe('LiveQueryClient', () => {
     });
   });
 
+  it('can subscribe with sessionToken', async () => {
+    const liveQueryClient = new LiveQueryClient({
+      applicationId: 'applicationId',
+      serverURL: 'ws://test',
+      javascriptKey: 'javascriptKey',
+      masterKey: 'masterKey',
+      sessionToken: 'sessionToken'
+    });
+    liveQueryClient.socket = {
+      send: jest.fn()
+    };
+    const query = new ParseQuery('Test');
+    query.equalTo('key', 'value');
+
+    const subscribePromise = liveQueryClient.subscribe(query, 'mySessionToken');
+    const clientSub = liveQueryClient.subscriptions.get(1);
+    clientSub.subscribePromise.resolve();
+
+    const subscription = await subscribePromise;
+    liveQueryClient.connectPromise.resolve();
+    expect(subscription).toBe(clientSub);
+    expect(subscription.sessionToken).toBe('mySessionToken');
+    expect(liveQueryClient.requestId).toBe(2);
+    await liveQueryClient.connectPromise;
+    const messageStr = liveQueryClient.socket.send.mock.calls[0][0];
+    const message = JSON.parse(messageStr);
+    expect(message).toEqual({
+      op: 'subscribe',
+      requestId: 1,
+      sessionToken: 'mySessionToken',
+      query: {
+        className: 'Test',
+        where: {
+          key: 'value'
+        }
+      }
+    });
+  });
+
   it('can unsubscribe', async () => {
     const liveQueryClient = new LiveQueryClient({
       applicationId: 'applicationId',
@@ -588,6 +844,23 @@ describe('LiveQueryClient', () => {
     });
   });
 
+  it('can unsubscribe without subscription', async () => {
+    const liveQueryClient = new LiveQueryClient({
+      applicationId: 'applicationId',
+      serverURL: 'ws://test',
+      javascriptKey: 'javascriptKey',
+      masterKey: 'masterKey',
+      sessionToken: 'sessionToken'
+    });
+    liveQueryClient.socket = {
+      send: jest.fn()
+    };
+    liveQueryClient.unsubscribe();
+    liveQueryClient.connectPromise.resolve();
+    await liveQueryClient.connectPromise;
+    expect(liveQueryClient.socket.send).toHaveBeenCalledTimes(0);
+  });
+
   it('can resubscribe', async () => {
     const liveQueryClient = new LiveQueryClient({
       applicationId: 'applicationId',
@@ -613,6 +886,41 @@ describe('LiveQueryClient', () => {
     expect(message).toEqual({
       op: 'subscribe',
       requestId: 1,
+      query: {
+        className: 'Test',
+        where: {
+          key: 'value'
+        }
+      }
+    });
+  });
+
+  it('can resubscribe with sessionToken', async () => {
+    const liveQueryClient = new LiveQueryClient({
+      applicationId: 'applicationId',
+      serverURL: 'ws://test',
+      javascriptKey: 'javascriptKey',
+      masterKey: 'masterKey',
+      sessionToken: 'sessionToken'
+    });
+    liveQueryClient.socket = {
+      send: jest.fn()
+    };
+    const query = new ParseQuery('Test');
+    query.equalTo('key', 'value');
+    liveQueryClient.subscribe(query, 'mySessionToken');
+    liveQueryClient.connectPromise.resolve();
+
+    liveQueryClient.resubscribe();
+
+    expect(liveQueryClient.requestId).toBe(2);
+    await liveQueryClient.connectPromise;
+    const messageStr = liveQueryClient.socket.send.mock.calls[0][0];
+    const message = JSON.parse(messageStr);
+    expect(message).toEqual({
+      op: 'subscribe',
+      requestId: 1,
+      sessionToken: 'mySessionToken',
       query: {
         className: 'Test',
         where: {
@@ -693,5 +1001,16 @@ describe('LiveQueryClient', () => {
     liveQueryClient._handleWebSocketMessage(event);
 
     expect(isChecked).toBe(true);
+  });
+
+  it('cannot subscribe without query', () => {
+    const liveQueryClient = new LiveQueryClient({
+      applicationId: 'applicationId',
+      serverURL: 'ws://test',
+      javascriptKey: 'javascriptKey',
+      masterKey: 'masterKey',
+    });
+    const subscription = liveQueryClient.subscribe();
+    expect(subscription).toBe(undefined);
   });
 });

--- a/src/__tests__/LocalDatastore-test.js
+++ b/src/__tests__/LocalDatastore-test.js
@@ -427,6 +427,21 @@ describe('LocalDatastore', () => {
     expect(mockLocalStorageController.fromPinWithName).toHaveBeenCalledTimes(3);
   });
 
+  it('_serializeObjectsFromPinName null pin', async () => {
+    const LDS = {
+      [DEFAULT_PIN]: null,
+    };
+
+    mockLocalStorageController
+      .getAllContents
+      .mockImplementationOnce(() => LDS);
+
+    const results = await LocalDatastore._serializeObjectsFromPinName(DEFAULT_PIN);
+    expect(results).toEqual([]);
+
+    expect(mockLocalStorageController.getAllContents).toHaveBeenCalledTimes(1);
+  });
+
   it('_serializeObject no children', async () => {
     const object = new ParseObject('Item');
     object.id = 1234;

--- a/src/__tests__/OfflineQuery-test.js
+++ b/src/__tests__/OfflineQuery-test.js
@@ -194,6 +194,12 @@ describe('OfflineQuery', () => {
     json = img.toJSON();
     json.owners[0].objectId = 'U3';
     expect(matchesQuery(json, q)).toBe(false);
+
+    const u3 = new ParseUser();
+    u3.id = 'U3';
+    img = new ParseObject('Image');
+    img.set('owners', [u3]);
+    expect(matchesQuery(q.className, img, [], q)).toBe(false);
   });
 
   it('matches on inequalities', () => {

--- a/src/__tests__/Parse-test.js
+++ b/src/__tests__/Parse-test.js
@@ -9,6 +9,8 @@
 
 jest.dontMock('../CoreManager');
 jest.dontMock('../CryptoController');
+jest.dontMock('../decode');
+jest.dontMock('../encode');
 jest.dontMock('../Parse');
 jest.dontMock('../LocalDatastore');
 jest.dontMock('crypto-js/aes');
@@ -46,6 +48,14 @@ describe('Parse module', () => {
     Parse.masterKey = '789';
     expect(CoreManager.get('MASTER_KEY')).toBe('789');
     expect(Parse.masterKey).toBe('789');
+
+    Parse.serverURL = 'http://example.com';
+    expect(CoreManager.get('SERVER_URL')).toBe('http://example.com');
+    expect(Parse.serverURL).toBe('http://example.com');
+
+    Parse.liveQueryServerURL = 'https://example.com';
+    expect(CoreManager.get('LIVEQUERY_SERVER_URL')).toBe('https://example.com');
+    expect(Parse.liveQueryServerURL).toBe('https://example.com');
   });
 
   it('can set auth type and token', () => {
@@ -141,5 +151,45 @@ describe('Parse module', () => {
     CoreManager.set('REQUEST_BATCH_SIZE', 4);
     expect(CoreManager.get('REQUEST_BATCH_SIZE')).toBe(4);
     CoreManager.set('REQUEST_BATCH_SIZE', 20);
+  });
+
+  it('_request', () => {
+    const controller = {
+      request: jest.fn(),
+      ajax: jest.fn(),
+    };
+    CoreManager.setRESTController(controller);
+    Parse._request('POST', 'classes/TestObject');
+    const [method, path] = controller.request.mock.calls[0];
+    expect(method).toBe('POST');
+    expect(path).toBe('classes/TestObject');
+  });
+
+  it('_ajax', () => {
+    const controller = {
+      request: jest.fn(),
+      ajax: jest.fn(),
+    };
+    CoreManager.setRESTController(controller);
+    Parse._ajax('POST', 'classes/TestObject');
+    const [method, path] = controller.ajax.mock.calls[0];
+    expect(method).toBe('POST');
+    expect(path).toBe('classes/TestObject');
+  });
+
+  it('_getInstallationId', () => {
+    const controller = {
+      currentInstallationId: () => '1234',
+    };
+    CoreManager.setInstallationController(controller);
+    expect(Parse._getInstallationId()).toBe('1234');
+  });
+
+  it('_decode', () => {
+    expect(Parse._decode(null, 12)).toBe(12);
+  });
+
+  it('_encode', () => {
+    expect(Parse._encode(12)).toBe(12);
   });
 });

--- a/src/__tests__/ParseACL-test.js
+++ b/src/__tests__/ParseACL-test.js
@@ -70,6 +70,10 @@ describe('ParseACL', () => {
     expect(a.setReadAccess.bind(a, 12, true)).toThrow(
       'userId must be a string.'
     );
+
+    expect(() => {
+      a.getReadAccess(new ParseUser(), true)
+    }).toThrow('Cannot get access for a ParseUser without an ID');
   });
 
   it('throws when setting an invalid access', () => {
@@ -77,6 +81,17 @@ describe('ParseACL', () => {
     expect(a.setReadAccess.bind(a, 'aUserId', 12)).toThrow(
       'allowed must be either true or false.'
     );
+  });
+
+  it('throws when role does not have name', () => {
+    const a = new ParseACL();
+    expect(() => {
+      a.setReadAccess(new ParseRole(), true)
+    }).toThrow('Role must have a name');
+
+    expect(() => {
+      a.getReadAccess(new ParseRole(), true)
+    }).toThrow('Role must have a name');
   });
 
   it('throws when setting an invalid role', () => {
@@ -339,5 +354,13 @@ describe('ParseACL', () => {
     b.setReadAccess('aUserId', true);
     expect(a.equals(b)).toBe(false);
     expect(b.equals(a)).toBe(false);
+    expect(a.equals({})).toBe(false);
+
+    b.setWriteAccess('newUserId', true);
+    expect(a.equals(b)).toBe(false);
+
+    a.setPublicReadAccess(false);
+    a.permissionsById.newUserId = { write: false };
+    expect(a.equals(b)).toBe(false);
   });
 });

--- a/src/__tests__/ParseGeoPoint-test.js
+++ b/src/__tests__/ParseGeoPoint-test.js
@@ -10,6 +10,16 @@
 jest.autoMockOff();
 
 const ParseGeoPoint = require('../ParseGeoPoint').default;
+global.navigator.geolocation = {
+  getCurrentPosition: (cb) => {
+    return cb({
+      coords: {
+        latitude: 10,
+        longitude: 20,
+      }
+    });
+  }
+}
 
 describe('GeoPoint', () => {
   it('can be constructed from various inputs', () => {
@@ -213,5 +223,11 @@ describe('GeoPoint', () => {
     a = new ParseGeoPoint(40, 50);
     expect(a.equals(b)).toBe(false);
     expect(b.equals(a)).toBe(false);
+  });
+
+  it('can get current location', async () => {
+    const geoPoint = ParseGeoPoint.current();
+    expect(geoPoint.latitude).toBe(10);
+    expect(geoPoint.longitude).toBe(20);
   });
 });

--- a/src/__tests__/ParseInstallation-test.js
+++ b/src/__tests__/ParseInstallation-test.js
@@ -1,0 +1,28 @@
+jest.dontMock('../CoreManager');
+jest.dontMock('../decode');
+jest.dontMock('../ObjectStateMutations');
+jest.dontMock('../ParseError');
+jest.dontMock('../ParseObject');
+jest.dontMock('../ParseOp');
+jest.dontMock('../ParseInstallation');
+jest.dontMock('../SingleInstanceStateController');
+jest.dontMock('../UniqueInstanceStateController');
+
+const ParseInstallation = require('../ParseInstallation').default;
+
+describe('ParseInstallation', () => {
+  it('can create ParseInstallation', () => {
+    let installation = new ParseInstallation();
+    expect(installation.className).toBe('_Installation');
+
+    installation = new ParseInstallation({});
+    expect(installation.className).toBe('_Installation');
+
+    installation = new ParseInstallation({ deviceToken: 'token' });
+    expect(installation.get('deviceToken')).toBe('token');
+
+    expect(() => {
+      new ParseInstallation({ 'invalid#name' : 'foo'})
+    }).toThrow("Can't create an invalid Installation");
+  });
+});

--- a/src/__tests__/ParseObject-test.js
+++ b/src/__tests__/ParseObject-test.js
@@ -180,6 +180,7 @@ function flushPromises() {
 describe('ParseObject', () => {
   beforeEach(() => {
     ParseObject.enableSingleInstance();
+    jest.clearAllMocks();
   });
 
   it('is initially created with no Id', () => {
@@ -196,6 +197,44 @@ describe('ParseObject', () => {
     });
     expect(o.className).toBe('Item');
     expect(o.attributes).toEqual({ value: 12 });
+  });
+
+  it('can be created with attributes parameter', () => {
+    const o = new ParseObject('Item', {
+      value: 12,
+    });
+    expect(o.className).toBe('Item');
+    expect(o.attributes).toEqual({ value: 12 });
+  });
+
+  it('can ignore setting invalid key', () => {
+    const o = new ParseObject('Item');
+    const o2 = o.set(1234);
+    expect(o).toEqual(o2);
+  });
+
+  it('can ignore setting createdAt', () => {
+    const o = new ParseObject('Item');
+    o.set('createdAt', '1234');
+    expect(o.get('createdAt')).toEqual(undefined);
+  });
+
+  it('can handle setting relationOp', () => {
+    const child = new ParseObject('Child');
+    child.id = 'child1234';
+    const relationOpJSON = { __op: 'AddRelation', objects: [child] };
+    const o = new ParseObject('Item');
+    o.set('friends', relationOpJSON);
+    expect(o.get('friends').targetClassName).toBe('Child');
+  });
+
+  it('cannot create with invalid attributes', () => {
+    expect(() => {
+      new ParseObject({
+        className: 'Item',
+        'invalid#name' : 'foo',
+      });
+    }).toThrow("Can't create an invalid Parse Object");
   });
 
   it('can ignore validation if ignoreValidation option is provided', () => {
@@ -283,6 +322,16 @@ describe('ParseObject', () => {
     expect(o.get('updatedAt')).toEqual(updated);
     expect(o.createdAt).toEqual(created);
     expect(o.updatedAt).toEqual(updated);
+  });
+
+  it('fetch ACL from serverData', () => {
+    const ACL = new ParseACL({ 'user1': { read: true } });
+    const o = new ParseObject('Item');
+    o._finishFetch({
+      objectId: 'O1',
+      ACL: { 'user1': { read: true } },
+    });
+    expect(o.getACL()).toEqual(ACL);
   });
 
   it('can be rendered to JSON', () => {
@@ -393,9 +442,11 @@ describe('ParseObject', () => {
     const o = new ParseObject('Person');
     o.set('age', 28);
     o.set('phoneProvider', 'AT&T');
+    o.set('objectField', { toString: 'hacking' });
     expect(o.escape('notSet')).toBe('');
     expect(o.escape('age')).toBe('28');
     expect(o.escape('phoneProvider')).toBe('AT&amp;T');
+    expect(o.escape('objectField')).toBe('');
   });
 
   it('can tell if it has an attribute', () => {
@@ -410,17 +461,21 @@ describe('ParseObject', () => {
     o._finishFetch({
       objectId: 'p99',
       age: 28,
-      human: true
+      human: true,
+      objectField: { foo: 'bar' },
     });
     expect(o.dirty()).toBe(false);
     expect(o.dirty('age')).toBe(false);
     expect(o.dirty('human')).toBe(false);
     expect(o.dirty('unset')).toBe(false);
+    expect(o.dirty('objectField')).toBe(false);
     o.set('human', false);
+    o.set('objectField', { foo: 'baz' });
     expect(o.dirty()).toBe(true);
     expect(o.dirty('age')).toBe(false);
     expect(o.dirty('human')).toBe(true);
     expect(o.dirty('unset')).toBe(false);
+    expect(o.dirty('objectField')).toBe(true);
   })
 
   it('can unset a field', () => {
@@ -705,6 +760,17 @@ describe('ParseObject', () => {
     expect(o2._getSaveJSON().aRelation).toEqual(relationJSON);
   });
 
+  it('can get relation from relation field', () => {
+    const relationJSON = {__type: 'Relation', className: 'Bar'};
+    const o = ParseObject.fromJSON({
+      objectId: '999',
+      className: 'Foo',
+      aRelation: relationJSON,
+    });
+    const rel = o.relation('aRelation');
+    expect(rel.toJSON()).toEqual(relationJSON);
+  });
+
   it('can detect dirty object children', () => {
     const o = new ParseObject('Person');
     o._finishFetch({
@@ -966,12 +1032,19 @@ describe('ParseObject', () => {
   it('updates the existed flag when saved', () => {
     const o = new ParseObject('Item');
     expect(o.existed()).toBe(false);
+    expect(o.isNew()).toBe(true);
     o._handleSaveResponse({
       objectId: 'I2'
     }, 201);
     expect(o.existed()).toBe(false);
     o._handleSaveResponse({}, 200);
     expect(o.existed()).toBe(true);
+  });
+
+  it('check existed without object state', () => {
+    const o = new ParseObject('Item');
+    o.id = 'test890';
+    expect(o.existed()).toBe(false);
   });
 
   it('commits changes to server data when saved', () => {
@@ -1184,11 +1257,60 @@ describe('ParseObject', () => {
     spy.mockRestore();
   });
 
+  it('can fetchAllIfNeededWithInclude', async () => {
+    const objectController = CoreManager.getObjectController();
+    const spy = jest.spyOn(
+      objectController,
+      'fetch'
+    )
+      .mockImplementationOnce(() => {})
+      .mockImplementationOnce(() => {})
+      .mockImplementationOnce(() => {});
+
+    const parent = new ParseObject('Person');
+    await ParseObject.fetchAllIfNeededWithInclude([parent], 'child', { useMasterKey: true, sessionToken: '123'});
+    await ParseObject.fetchAllIfNeededWithInclude([parent], ['child']);
+    await ParseObject.fetchAllIfNeededWithInclude([parent], [['child']]);
+    expect(objectController.fetch).toHaveBeenCalledTimes(3);
+
+    expect(objectController.fetch.mock.calls[0]).toEqual([
+      [parent], false, { useMasterKey: true, sessionToken: '123', include: ['child'] }
+    ]);
+    expect(objectController.fetch.mock.calls[1]).toEqual([
+      [parent], false, { include: ['child'] }
+    ]);
+    expect(objectController.fetch.mock.calls[2]).toEqual([
+      [parent], false, { include: ['child'] }
+    ]);
+
+    spy.mockRestore();
+  });
+
   it('can check if object exists', async () => {
     const parent = new ParseObject('Person');
     expect(await parent.exists()).toBe(false);
     parent.id = '1234'
     expect(await parent.exists()).toBe(true);
+
+    jest.spyOn(mockQuery.prototype, 'get').mockImplementationOnce(() => {
+      return Promise.reject({
+        code: 101,
+      });
+    });
+    expect(await parent.exists()).toBe(false);
+
+    jest.spyOn(mockQuery.prototype, 'get').mockImplementationOnce(() => {
+      return Promise.reject({
+        code: 1,
+        message: 'Internal Server Error',
+      });
+    });
+    try {
+      await parent.exists();
+      expect(true).toBe(false);
+    } catch (e) {
+      expect(e.code).toBe(1);
+    }
   });
 
   it('can save the object', (done) => {
@@ -1210,6 +1332,23 @@ describe('ParseObject', () => {
       expect(obj.get('count')).toBe(1);
       expect(obj.op('age')).toBe(undefined);
       expect(obj.dirty()).toBe(false);
+      done();
+    });
+  });
+
+  it('can save the object with key / value', (done) => {
+    CoreManager.getRESTController()._setXHR(
+      mockXHR([{
+        status: 200,
+        response: {
+          objectId: 'P8',
+        }
+      }])
+    );
+    const p = new ParseObject('Person');
+    p.save('foo', 'bar').then((obj) => {
+      expect(obj).toBe(p);
+      expect(obj.get('foo')).toBe('bar');
       done();
     });
   });
@@ -1592,11 +1731,11 @@ describe('ParseObject', () => {
     const controller = CoreManager.getRESTController();
     jest.spyOn(controller, 'ajax');
     // Save object
-    const context = {a: "a"};
+    const context = {a: "saveAll"};
     const obj = new ParseObject('Item');
     obj.id = 'pid';
     obj.set('test', 'value');
-    await ParseObject.saveAll([obj], {context})
+    await ParseObject.saveAll([obj], { context, useMasterKey: true })
     // Validate
     const jsonBody = JSON.parse(controller.ajax.mock.calls[0][2]);
     expect(jsonBody._context).toEqual(context);
@@ -1614,13 +1753,37 @@ describe('ParseObject', () => {
     const controller = CoreManager.getRESTController();
     jest.spyOn(controller, 'ajax');
     // Save object
-    const context = {a: "a"};
+    const context = {a: "b"};
     const obj = new ParseObject('Item');
     obj.id = 'pid';
     await ParseObject.destroyAll([obj], { context: context })
     // Validate
     const jsonBody = JSON.parse(controller.ajax.mock.calls[0][2]);
     expect(jsonBody._context).toEqual(context);
+  });
+
+  it('destroyAll with options', async () => {
+    // Mock XHR
+    CoreManager.getRESTController()._setXHR(
+      mockXHR([{
+        status: 200,
+        response: [{}]
+      }])
+    );
+    const controller = CoreManager.getRESTController();
+    jest.spyOn(controller, 'ajax');
+
+    const obj = new ParseObject('Item');
+    obj.id = 'pid';
+    await ParseObject.destroyAll([obj], {
+      useMasterKey: true,
+      sessionToken: 'r:1234',
+      batchSize: 25,
+    });
+
+    const jsonBody = JSON.parse(controller.ajax.mock.calls[0][2]);
+    expect(jsonBody._MasterKey).toBe('C')
+    expect(jsonBody._SessionToken).toBe('r:1234');
   });
 
   it('can save a chain of unsaved objects', async () => {
@@ -1810,6 +1973,17 @@ describe('ParseObject', () => {
     // Validate
     const jsonBody = JSON.parse(controller.ajax.mock.calls[0][2]);
     expect(jsonBody._context).toEqual(context);
+  });
+
+  it('handle destroy on new object', async () => {
+    const controller = CoreManager.getRESTController();
+    jest.spyOn(controller, 'ajax');
+
+    const obj = new ParseObject('Item');
+
+    await obj.destroy({ useMasterKey: true });
+
+    expect(controller.ajax).toHaveBeenCalledTimes(0);
   });
 
   it('can save an array of objects', async (done) => {
@@ -2031,6 +2205,10 @@ describe('ParseObject', () => {
 });
 
 describe('ObjectController', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
   it('can fetch a single object', async (done) => {
     const objectController = CoreManager.getObjectController();
     const xhr = {
@@ -2070,10 +2248,10 @@ describe('ObjectController', () => {
     const controller = CoreManager.getRESTController();
     jest.spyOn(controller, 'ajax');
     // Save object
-    const context = {a: "a"};
+    const context = { a: 'fetch' };
     const obj = new ParseObject('Item');
     obj.id = 'pid';
-    await obj.fetch({context});
+    await obj.fetch({ context });
     // Validate
     const jsonBody = JSON.parse(controller.ajax.mock.calls[0][2]);
     expect(jsonBody._context).toEqual(context);
@@ -2531,6 +2709,12 @@ describe('ObjectController', () => {
 
     expect(o).not.toBe(o2);
   });
+
+  it('cannot create a new instance of an object without className', () => {
+    expect(() => {
+      ParseObject.fromJSON({});
+    }).toThrow('Cannot create an object without a className');
+  });
 });
 
 describe('ParseObject (unique instance mode)', () => {
@@ -2790,6 +2974,20 @@ describe('ParseObject Subclasses', () => {
     );
   });
 
+  it('registerSubclass errors', () => {
+    expect(() => {
+      ParseObject.registerSubclass(1234);
+    }).toThrow('The first argument must be a valid class name.');
+
+    expect(() => {
+      ParseObject.registerSubclass('TestObject', undefined);
+    }).toThrow('You must supply a subclass constructor.');
+
+    expect(() => {
+      ParseObject.registerSubclass('TestObject', {});
+    }).toThrow('You must register the subclass constructor. Did you attempt to register an instance of the subclass?');
+  });
+
   it('can inflate subclasses from server JSON', () => {
     const json = {
       className: 'MyObject',
@@ -2817,6 +3015,21 @@ describe('ParseObject Subclasses', () => {
     });
     expect(o2.id).toBe(undefined);
     expect(o.equals(o2)).toBe(false);
+  });
+
+  it('can be cleared', () => {
+    const o = new MyObject();
+    o.set({
+      size: 'large',
+      count: 7,
+    });
+    jest.spyOn(o, 'set');
+    o.clear();
+    expect(o.set).toHaveBeenCalledWith({
+      count: true, size: true,
+    }, {
+      unset: true,
+    });
   });
 });
 
@@ -2883,6 +3096,34 @@ describe('ParseObject extensions', () => {
 
     const i = new InitObject()
     expect(i.get('field')).toBe(12);
+  });
+
+  it('can handle className parameters', () => {
+    expect(() => {
+      ParseObject.extend();
+    }).toThrow("Parse.Object.extend's first argument should be the className.");
+
+    let CustomObject = ParseObject.extend('Item');
+    expect(CustomObject.className).toBe('Item');
+
+    CustomObject = ParseObject.extend({ className: 'Test' });
+    expect(CustomObject.className).toBe('Test');
+  });
+
+  it('can extend with user rewrite', () => {
+    const CustomObject = ParseObject.extend('User');
+    expect(CustomObject.className).toBe('_User');
+  });
+
+  it('can extend multiple subclasses', () => {
+    const CustomObject = ParseObject.extend('Item');
+    expect(() => {
+      new CustomObject({ 'invalid#name': 'bar' });
+    }).toThrow("Can't create an invalid Parse Object");
+
+    const CustomUserObject = CustomObject.extend('User');
+    const CustomRewrite = CustomUserObject.extend();
+    expect(CustomRewrite.className).toBe('_User');
   });
 });
 

--- a/src/__tests__/ParseOp-test.js
+++ b/src/__tests__/ParseOp-test.js
@@ -9,6 +9,7 @@
 
 jest.dontMock('../arrayContainsObject');
 jest.dontMock('../encode');
+jest.dontMock('../decode');
 jest.dontMock('../ParseOp');
 jest.dontMock('../unique');
 
@@ -22,6 +23,9 @@ const mockObject = function(className, id) {
 }
 mockObject.prototype._getId = function() {
   return this.id || this._localId;
+}
+mockObject.fromJSON = function(json) {
+  return new mockObject(json.className, json.objectId);
 }
 mockObject.registerSubclass = function() {};
 jest.setMock('../ParseObject', mockObject);
@@ -43,10 +47,24 @@ const {
   AddOp,
   AddUniqueOp,
   RemoveOp,
-  RelationOp
+  RelationOp,
+  opFromJSON,
 } = ParseOp;
 
 describe('ParseOp', () => {
+  it('base class', () => {
+    const op = new Op();
+    expect(op.applyTo instanceof Function).toBe(true);
+    expect(op.mergeWith instanceof Function).toBe(true);
+    expect(op.toJSON instanceof Function).toBe(true);
+    expect(op.applyTo()).toBeUndefined();
+    expect(op.mergeWith()).toBeUndefined();
+    expect(op.toJSON()).toBeUndefined();
+    expect(opFromJSON({})).toBe(null);
+    expect(opFromJSON({ __op: 'Unknown' })).toBe(null);
+    expect(opFromJSON(op.toJSON())).toBe(null);
+  });
+
   it('is extended by all Ops', () => {
     expect(new SetOp(1) instanceof Op).toBe(true);
     expect(new UnsetOp() instanceof Op).toBe(true);
@@ -92,6 +110,7 @@ describe('ParseOp', () => {
     expect(unset.mergeWith(new RemoveOp(1)) instanceof UnsetOp).toBe(true);
 
     expect(unset.toJSON()).toEqual({ __op: 'Delete' });
+    expect(opFromJSON(unset.toJSON())).toEqual(unset);
   });
 
   it('can create and apply Increment Ops', () => {
@@ -113,16 +132,27 @@ describe('ParseOp', () => {
 
     const bigInc = new IncrementOp(99);
     expect(bigInc.applyTo(-98)).toBe(1);
+    expect(bigInc.applyTo()).toBe(99);
 
     expect(inc.toJSON()).toEqual({ __op: 'Increment', amount: 1 });
     expect(bigInc.toJSON()).toEqual({ __op: 'Increment', amount: 99 });
+    expect(opFromJSON(bigInc.toJSON())).toEqual(bigInc);
 
-    let merge = inc.mergeWith(new SetOp(11));
+    let merge = inc.mergeWith();
+    expect(merge instanceof IncrementOp).toBe(true);
+    expect(merge._amount).toBe(1);
+
+    merge = inc.mergeWith(new SetOp(11));
     expect(merge instanceof SetOp).toBe(true);
     expect(merge._value).toBe(12);
+
     merge = inc.mergeWith(new UnsetOp());
     expect(merge instanceof SetOp).toBe(true);
     expect(merge._value).toBe(1);
+
+    merge = inc.mergeWith(bigInc);
+    expect(merge instanceof IncrementOp).toBe(true);
+    expect(merge._amount).toBe(100);
 
     expect(inc.mergeWith.bind(inc, new AddOp(1))).toThrow(
       'Cannot merge Increment Op with the previous Op'
@@ -146,6 +176,7 @@ describe('ParseOp', () => {
     expect(add.applyTo([12])).toEqual([12, 'element']);
 
     expect(add.toJSON()).toEqual({ __op: 'Add', objects: ['element'] });
+    expect(opFromJSON(add.toJSON())).toEqual(add);
 
     const addMany = new AddOp([1, 2, 2, 3, 4, 5]);
 
@@ -153,9 +184,17 @@ describe('ParseOp', () => {
 
     expect(addMany.toJSON()).toEqual({ __op: 'Add', objects: [1, 2, 2, 3, 4, 5] });
 
-    let merge = add.mergeWith(new SetOp(['an']));
+    let merge = add.mergeWith(null);
+    expect(merge instanceof AddOp).toBe(true);
+    expect(merge._value).toEqual(['element']);
+
+    merge = add.mergeWith(new SetOp(['an']));
     expect(merge instanceof SetOp).toBe(true);
     expect(merge._value).toEqual(['an', 'element']);
+
+    merge = add.mergeWith(new UnsetOp(['an']));
+    expect(merge instanceof SetOp).toBe(true);
+    expect(merge._value).toEqual(['element']);
 
     merge = add.mergeWith(addMany);
     expect(merge instanceof AddOp).toBe(true);
@@ -184,6 +223,7 @@ describe('ParseOp', () => {
     expect(add.applyTo([12, 'element'])).toEqual([12, 'element']);
 
     expect(add.toJSON()).toEqual({ __op: 'AddUnique', objects: ['element'] });
+    expect(opFromJSON(add.toJSON())).toEqual(add);
 
     const addMany = new AddUniqueOp([1, 2, 2, 3, 4, 5]);
 
@@ -196,9 +236,17 @@ describe('ParseOp', () => {
       objects: [1, 2, 3, 4, 5]
     });
 
-    let merge = add.mergeWith(new SetOp(['an', 'element']));
+    let merge = add.mergeWith(null);
+    expect(merge instanceof AddUniqueOp).toBe(true);
+    expect(merge._value).toEqual(['element']);
+
+    merge = add.mergeWith(new SetOp(['an', 'element']));
     expect(merge instanceof SetOp).toBe(true);
     expect(merge._value).toEqual(['an', 'element']);
+
+    merge = add.mergeWith(new UnsetOp(['an']));
+    expect(merge instanceof SetOp).toBe(true);
+    expect(merge._value).toEqual(['element']);
 
     merge = new AddUniqueOp(['an', 'element'])
       .mergeWith(new AddUniqueOp([1, 2, 'element', 3]));
@@ -215,7 +263,7 @@ describe('ParseOp', () => {
       'Cannot merge AddUnique Op with the previous Op'
     );
 
-    const addObjects = new AddUniqueOp(new ParseObject('Item', 'i2'));
+    let addObjects = new AddUniqueOp(new ParseObject('Item', 'i2'));
     expect(addObjects.applyTo([
       new ParseObject('Item', 'i1'),
       new ParseObject('Item', 'i2'),
@@ -224,6 +272,16 @@ describe('ParseOp', () => {
       new ParseObject('Item', 'i1'),
       new ParseObject('Item', 'i2'),
       new ParseObject('Item', 'i3'),
+    ]);
+
+    addObjects = new AddUniqueOp(new ParseObject('Item', 'i2'));
+    expect(addObjects.applyTo([
+      new ParseObject('Item', 'i1'),
+      new ParseObject('Item', 'i3'),
+    ])).toEqual([
+      new ParseObject('Item', 'i1'),
+      new ParseObject('Item', 'i3'),
+      new ParseObject('Item', 'i2'),
     ]);
   });
 
@@ -240,6 +298,7 @@ describe('ParseOp', () => {
     expect(rem.applyTo(['element', 12, 'element', 'element'])).toEqual([12]);
 
     expect(rem.toJSON()).toEqual({ __op: 'Remove', objects: ['element'] });
+    expect(opFromJSON(rem.toJSON())).toEqual(rem);
 
     const removeMany = new RemoveOp([1, 2, 2, 3, 4, 5]);
 
@@ -250,15 +309,28 @@ describe('ParseOp', () => {
       objects: [1, 2, 3, 4, 5]
     });
 
-    let merge = rem.mergeWith(new SetOp(['an', 'element']));
+    let merge = rem.mergeWith(null);
+    expect(merge instanceof RemoveOp).toBe(true);
+    expect(merge._value).toEqual(['element']);
+
+    merge = rem.mergeWith(new SetOp(['an', 'element']));
     expect(merge instanceof SetOp).toBe(true);
     expect(merge._value).toEqual(['an']);
+
+    merge = rem.mergeWith(new UnsetOp(['an']));
+    expect(merge instanceof UnsetOp).toBe(true);
+    expect(merge._value).toEqual(undefined);
 
     merge = new RemoveOp([1, 2, 3]).mergeWith(new RemoveOp([2, 4]));
     expect(merge instanceof RemoveOp).toBe(true);
     expect(merge._value).toEqual([2, 4, 1, 3]);
 
+    expect(rem.mergeWith.bind(rem, new IncrementOp(1))).toThrow(
+      'Cannot merge Remove Op with the previous Op'
+    );
+
     const removeObjects = new RemoveOp(new ParseObject('Item', 'i2'));
+    const previousOp = new RemoveOp(new ParseObject('Item', 'i5'));
     expect(removeObjects.applyTo([
       new ParseObject('Item', 'i1'),
       new ParseObject('Item', 'i2'),
@@ -277,6 +349,11 @@ describe('ParseOp', () => {
     ])).toEqual([
       new ParseObject('Item', 'i1'),
       new ParseObject('Item', 'i3'),
+    ]);
+    const merged = removeObjects.mergeWith(previousOp);
+    expect(merged._value).toEqual([
+      new ParseObject('Item', 'i5'),
+      new ParseObject('Item', 'i2'),
     ]);
   });
 
@@ -320,6 +397,7 @@ describe('ParseOp', () => {
         { __type: 'Pointer', objectId: 'I2', className: 'Item' }
       ]
     });
+    expect(opFromJSON(r.toJSON())).toEqual(r);
 
     const o3 = new ParseObject('Item');
     o3.id = 'I3';
@@ -333,18 +411,30 @@ describe('ParseOp', () => {
         { __type: 'Pointer', objectId: 'I1', className: 'Item' }
       ]
     });
+    expect(opFromJSON(r2.toJSON())).toEqual(r2);
 
     const rel = r.applyTo(undefined, { className: 'Delivery', id: 'D3' }, 'shipments');
     expect(rel.targetClassName).toBe('Item');
     expect(r2.applyTo(rel, { className: 'Delivery', id: 'D3' })).toBe(rel);
+
+    const relLocal = r.applyTo(undefined, { className: 'Delivery', id: 'localD4' }, 'shipments');
+    expect(relLocal.parent._localId).toBe('localD4');
+
     expect(r.applyTo.bind(r, 'string')).toThrow(
       'Relation cannot be applied to a non-relation field'
+    );
+    expect(r.applyTo.bind(r)).toThrow(
+      'Cannot apply a RelationOp without either a previous value, or an object and a key'
     );
     const p = new ParseObject('Person');
     p.id = 'P4';
     const r3 = new RelationOp([p]);
     expect(r3.applyTo.bind(r3, rel, { className: 'Delivery', id: 'D3' }, 'packages'))
       .toThrow('Related object must be a Item, but a Person was passed in.');
+
+    const noRelation = new ParseRelation(null, null);
+    r3.applyTo(noRelation, { className: 'Delivery', id: 'D3' }, 'packages');
+    expect(noRelation.targetClassName).toEqual(r3._targetClassName);
 
     expect(r.mergeWith(null)).toBe(r);
     expect(r.mergeWith.bind(r, new UnsetOp())).toThrow(
@@ -370,13 +460,31 @@ describe('ParseOp', () => {
         }
       ]
     });
+    expect(opFromJSON(merged.toJSON())).toEqual(merged);
   });
 
   it('can merge Relation Op with the previous Op', () => {
     const r = new RelationOp();
     const relation = new ParseRelation(null, null);
     const set = new SetOp(relation);
-
     expect(r.mergeWith(set)).toEqual(r);
+
+    const a = new ParseObject('Item');
+    a.id = 'I1';
+    const b = new ParseObject('Item');
+    b.id = 'D1';
+    const r1 = new RelationOp([a, b], []);
+    const r2 = new RelationOp([], [b]);
+    expect(() => {
+      r.mergeWith(r1)
+    }).toThrow('Related object must be of class Item, but null was passed in.');
+    expect(r1.mergeWith(r2)).toEqual(r1);
+    expect(r2.mergeWith(r1)).toEqual(new RelationOp([a], [b]));
+  });
+
+  it('opFromJSON Relation', () => {
+    const r = new RelationOp([], []);
+    expect(opFromJSON({ __op: 'AddRelation', objects: '' })).toEqual(r);
+    expect(opFromJSON({ __op: 'RemoveRelation', objects: '' })).toEqual(r);
   });
 });

--- a/src/__tests__/ParsePolygon-test.js
+++ b/src/__tests__/ParsePolygon-test.js
@@ -1,0 +1,79 @@
+jest.autoMockOff();
+
+const ParseGeoPoint = require('../ParseGeoPoint').default;
+const ParsePolygon = require('../ParsePolygon').default;
+
+const points = [[0, 0], [0, 1], [1, 1], [1, 0], [0, 0]];
+
+describe('Polygon', () => {
+  it('can initialize with points', () => {
+    const polygon = new ParsePolygon(points);
+    expect(polygon.coordinates).toEqual(points);
+  });
+
+  it('can initialize with geopoints', () => {
+    const geopoints = [
+      new ParseGeoPoint(0, 0),
+      new ParseGeoPoint(0, 1),
+      new ParseGeoPoint(1, 1),
+      new ParseGeoPoint(1, 0),
+      new ParseGeoPoint(0, 0)
+    ];
+    const polygon = new ParsePolygon(geopoints);
+    expect(polygon.coordinates).toEqual(points);
+  });
+
+  it('can set points', () => {
+    const newPoints = [[0, 0], [0, 10], [10, 10], [10, 0], [0, 0]];
+
+    const polygon = new ParsePolygon(points);
+    expect(polygon.coordinates).toEqual(points);
+
+    polygon.coordinates = newPoints;
+    expect(polygon.coordinates).toEqual(newPoints);
+  });
+
+  it('toJSON', () => {
+    const polygon = new ParsePolygon(points);
+    expect(polygon.toJSON()).toEqual({
+      __type: 'Polygon',
+      coordinates: points,
+    });
+  });
+
+  it('equals', () => {
+    const polygon1 = new ParsePolygon(points);
+    const polygon2 = new ParsePolygon(points);
+    const geopoint = new ParseGeoPoint(0, 0);
+
+    expect(polygon1.equals(polygon2)).toBe(true);
+    expect(polygon1.equals(geopoint)).toBe(false);
+
+    const newPoints = [[0, 0], [0, 10], [10, 10], [10, 0], [0, 0]];
+    polygon1.coordinates = newPoints;
+    expect(polygon1.equals(polygon2)).toBe(false);
+  });
+
+  it('containsPoint', () => {
+    const polygon = new ParsePolygon(points);
+    const outside = new ParseGeoPoint(10, 10);
+    const inside = new ParseGeoPoint(.5, .5);
+
+    expect(polygon.containsPoint(inside)).toBe(true);
+    expect(polygon.containsPoint(outside)).toBe(false);
+  });
+
+  it('throws error on invalid input', () => {
+    expect(() => {
+      new ParsePolygon()
+    }).toThrow('Coordinates must be an Array');
+
+    expect(() => {
+      new ParsePolygon([])
+    }).toThrow('Polygon must have at least 3 GeoPoints or Points');
+
+    expect(() => {
+      new ParsePolygon([1, 2, 3])
+    }).toThrow('Coordinates must be an Array of GeoPoints or Points');
+  });
+});

--- a/src/__tests__/ParseRelation-test.js
+++ b/src/__tests__/ParseRelation-test.js
@@ -150,6 +150,27 @@ describe('ParseRelation', () => {
     });
   });
 
+  it('cannot add to relation without parent', () => {
+    const relation = new ParseRelation();
+    expect(() => {
+      relation.add([]);
+    }).toThrow('Cannot add to a Relation without a parent')
+  });
+
+  it('cannot remove from relation without parent', () => {
+    const relation = new ParseRelation();
+    expect(() => {
+      relation.remove([]);
+    }).toThrow('Cannot remove from a Relation without a parent')
+  });
+
+  it('cannot construct query from relation without parent', () => {
+    const relation = new ParseRelation();
+    expect(() => {
+      relation.query();
+    }).toThrow('Cannot construct a query for a Relation without a parent')
+  });
+
   it('can remove objects from a relation', () => {
     const parent = new ParseObject('Item');
     parent.id = 'I2';
@@ -262,8 +283,23 @@ describe('ParseRelation', () => {
     const r = new ParseRelation(parent, 'shipments');
     expect(r._ensureParentAndKey.bind(r, new ParseObject('Item'), 'shipments'))
       .toThrow('Internal Error. Relation retrieved from two different Objects.');
+    expect(() => {
+      r._ensureParentAndKey(new ParseObject('TestObject'), 'shipments')
+    }).toThrow('Internal Error. Relation retrieved from two different Objects.')
     expect(r._ensureParentAndKey.bind(r, parent, 'partners'))
       .toThrow('Internal Error. Relation retrieved from two different keys.');
     expect(r._ensureParentAndKey.bind(r, parent, 'shipments')).not.toThrow();
+
+    const noParent = new ParseRelation(null, null);
+    noParent._ensureParentAndKey(parent);
+    expect(noParent.parent).toEqual(parent);
+
+    const noIdParent = new ParseObject('Item');
+    const newParent = new ParseObject('Item');
+    newParent.id = 'newId';
+
+    const hasParent = new ParseRelation(noIdParent);
+    hasParent._ensureParentAndKey(newParent);
+    expect(hasParent.parent).toEqual(newParent);
   });
 });

--- a/src/__tests__/ParseRole-test.js
+++ b/src/__tests__/ParseRole-test.js
@@ -20,6 +20,7 @@ jest.dontMock('../UniqueInstanceStateController');
 const ParseACL = require('../ParseACL').default;
 const ParseError = require('../ParseError').default;
 const ParseObject = require('../ParseObject').default;
+const ParseRelation = require('../ParseRelation').default;
 const ParseRole = require('../ParseRole').default;
 
 describe('ParseRole', () => {
@@ -36,6 +37,12 @@ describe('ParseRole', () => {
     role = new ParseRole('admin', acl);
     expect(role.getName()).toBe('admin');
     expect(role.getACL()).toBe(acl);
+  });
+
+  it('handle non string name', () => {
+    const role = new ParseRole();
+    role.get = () => 1234;
+    expect(role.getName()).toBe('');
   });
 
   it('can validate attributes', () => {
@@ -68,6 +75,10 @@ describe('ParseRole', () => {
     expect(role.validate({
       name: 'admin'
     })).toBe(false);
+    const result = role.validate({
+      'invalid#field': 'admin'
+    });
+    expect(result.code).toBe(ParseError.INVALID_KEY_NAME);
   });
 
   it('can be constructed from JSON', () => {
@@ -79,5 +90,11 @@ describe('ParseRole', () => {
     expect(role instanceof ParseObject).toBe(true);
     expect(role instanceof ParseRole).toBe(true);
     expect(role.getName()).toBe('admin');
+  });
+
+  it('can get relations', () => {
+    const role = new ParseRole();
+    expect(role.getUsers() instanceof ParseRelation).toBe(true);
+    expect(role.getRoles() instanceof ParseRelation).toBe(true);
   });
 });

--- a/src/__tests__/ParseUser-test.js
+++ b/src/__tests__/ParseUser-test.js
@@ -1228,7 +1228,7 @@ describe('ParseUser', () => {
     user.set('authData', { toRemove: null, test: true });
     user._cleanupAuthData();
     expect(user.get('authData')).toEqual({ toRemove: null, test: true });
- 
+
     ParseUser._setCurrentUserCache(user);
     user._cleanupAuthData();
     expect(user.get('authData')).toEqual({ test: true });

--- a/src/__tests__/ParseUser-test.js
+++ b/src/__tests__/ParseUser-test.js
@@ -101,6 +101,19 @@ describe('ParseUser', () => {
     expect(u2.getEmail()).toBe('bono@u2.com');
   });
 
+  it('can handle invalid setters and getters', () => {
+    const u = ParseObject.fromJSON({
+      className: '_User',
+      username: 123,
+      email: 456,
+      sessionToken: 789,
+    });
+    expect(u instanceof ParseUser).toBe(true);
+    expect(u.getUsername()).toBe('');
+    expect(u.getEmail()).toBe('');
+    expect(u.getSessionToken()).toBe('');
+  });
+
   it('can clone User objects', () => {
     const u = ParseObject.fromJSON({
       className: '_User',
@@ -229,6 +242,32 @@ describe('ParseUser', () => {
     });
   });
 
+  it('can log in as a user with options', async () => {
+    ParseUser.enableUnsafeCurrentUser();
+    ParseUser._clearCache();
+    CoreManager.setRESTController({
+      request(method, path, body, options) {
+        expect(method).toBe('GET');
+        expect(path).toBe('login');
+        expect(body.username).toBe('username');
+        expect(body.password).toBe('password');
+        expect(options.useMasterKey).toBe(true);
+        expect(options.installationId).toBe('installation1234')
+        return Promise.resolve({
+          objectId: 'uid2',
+          username: 'username',
+          sessionToken: '123abc'
+        }, 200);
+      },
+      ajax() {}
+    });
+    const user = await ParseUser.logIn('username', 'password', {
+      useMasterKey: true,
+      installationId: 'installation1234',
+    });
+    expect(user.id).toBe('uid2');
+  });
+
   it('can log in as a user with POST method', (done) => {
     ParseUser.enableUnsafeCurrentUser();
     ParseUser._clearCache();
@@ -345,7 +384,7 @@ describe('ParseUser', () => {
         expect(method).toBe('GET');
         expect(path).toBe('users/me');
         expect(options.sessionToken).toBe('123abc');
-
+        expect(options.useMasterKey).toBe(true);
         return Promise.resolve({
           objectId: 'uid3',
           username: 'username',
@@ -355,11 +394,23 @@ describe('ParseUser', () => {
       ajax() {}
     });
 
-    const u = await ParseUser.become('123abc');
+    const u = await ParseUser.become('123abc', { useMasterKey: true });
     expect(u.id).toBe('uid3');
     expect(u.isCurrent()).toBe(true);
     expect(u.existed()).toBe(true);
     CoreManager.setStorageController(currentStorage);
+  });
+
+  it('cannot get synchronous current user with async storage', async () => {
+    const StorageController = CoreManager.getStorageController();
+    CoreManager.setStorageController(mockAsyncStorage);
+    ParseUser.enableUnsafeCurrentUser();
+    ParseUser._clearCache();
+    expect(() => {
+      ParseUser.current();
+    }).toThrow('Cannot call currentUser() when using a platform with an async storage system. Call currentUserAsync() instead.');
+
+    CoreManager.setStorageController(StorageController);
   });
 
 
@@ -415,6 +466,19 @@ describe('ParseUser', () => {
     });
 
     ParseUser.requestPasswordReset('me@parse.com');
+
+    CoreManager.setRESTController({
+      request(method, path, body, options) {
+        expect(method).toBe('POST');
+        expect(path).toBe('requestPasswordReset');
+        expect(body).toEqual({ email: 'me@parse.com' });
+        expect(options.useMasterKey).toBe(true);
+        return Promise.resolve({}, 200);
+      },
+      ajax() {}
+    });
+
+    ParseUser.requestPasswordReset('me@parse.com', { useMasterKey: true });
   });
 
   it('can log out a user', (done) => {
@@ -505,6 +569,11 @@ describe('ParseUser', () => {
       expect(u instanceof ParseUser).toBe(true);
       expect(u.getUsername()).toBe('username');
       expect(u.id).toBe('uid6');
+
+      ParseUser.disableUnsafeCurrentUser();
+      return ParseUser.currentAsync();
+    }).then((u) => {
+      expect(u).toBe(null);
       done();
     });
   });
@@ -1052,6 +1121,31 @@ describe('ParseUser', () => {
     expect(user.get('authData')).toEqual({ test: { id: 'id', access_token: 'access_token' } });
   });
 
+  it('handle linkWith authentication failure', async () => {
+    const provider = {
+      authenticate(options) {
+        if (options.error) {
+          options.error(this, {
+            message: 'authentication failed',
+          });
+        }
+      },
+      restoreAuthentication() {},
+      getAuthType() {
+        return 'test';
+      },
+      deauthenticate() {}
+    };
+
+    const user = new ParseUser();
+    try {
+      await user.linkWith(provider, null);
+      expect(false).toBe(true);
+    } catch (e) {
+      expect(e.message).toBe('authentication failed')
+    }
+  });
+
   it('can linkWith if no provider', async () => {
     ParseUser._clearCache();
     CoreManager.setRESTController({
@@ -1077,6 +1171,123 @@ describe('ParseUser', () => {
     await user._unlinkFrom('testProvider');
     const authProvider = user.linkWith.mock.calls[0][0];
     expect(authProvider).toBe('testProvider');
+  });
+
+  it('cannot linkWith invalid authData', async () => {
+    ParseUser._clearCache();
+    const user = new ParseUser();
+    user.set('authData', 1234);
+    try {
+      await user.linkWith('testProvider', { authData: { id: 'test' } });
+      expect(false).toBe(true);
+    } catch (e) {
+      expect(e.message).toBe('Invalid type: authData field should be an object');
+    }
+  });
+
+  it('_synchronizeAuthData can unlink on failure to restore auth ', async () => {
+    ParseUser.enableUnsafeCurrentUser();
+    ParseUser._clearCache();
+
+    const provider = {
+      restoreAuthentication() {
+        return false;
+      },
+      getAuthType() {
+        return 'test';
+      },
+    };
+
+    const user = new ParseUser();
+    user.id = 'sync123';
+    user.set('authData', { test: true });
+
+    ParseUser._setCurrentUserCache(user);
+    jest.spyOn(user, '_unlinkFrom');
+    user._synchronizeAuthData(provider);
+    expect(user._unlinkFrom).toHaveBeenCalledTimes(1);
+  });
+
+  it('_isLinked', () => {
+    const user = new ParseUser();
+    const provider = {
+      getAuthType: () => 'customAuth',
+    };
+
+    user.set('authData', { 'customAuth': true });
+    expect(user._isLinked(provider)).toBe(true);
+
+    user.set('authData', 1234);
+    expect(user._isLinked(provider)).toBe(false);
+  });
+
+  it('_cleanupAuthData', () => {
+    ParseUser.enableUnsafeCurrentUser();
+    const user = new ParseUser();
+    user.id = 'cleanupData1';
+    user.set('authData', { toRemove: null, test: true });
+    user._cleanupAuthData();
+    expect(user.get('authData')).toEqual({ toRemove: null, test: true });
+ 
+    ParseUser._setCurrentUserCache(user);
+    user._cleanupAuthData();
+    expect(user.get('authData')).toEqual({ test: true });
+
+    user.set('authData', 1234);
+    user._cleanupAuthData();
+    expect(user.get('authData')).toEqual(1234);
+  });
+
+  it('_logOutWith', () => {
+    const user = new ParseUser();
+    user.id = 'logout1234';
+    const provider = {
+      deauthenticate: jest.fn(),
+    };
+    user._logOutWith(provider);
+    expect(provider.deauthenticate).toHaveBeenCalledTimes(0);
+
+    ParseUser._setCurrentUserCache(user);
+    user._logOutWith(provider);
+    expect(provider.deauthenticate).toHaveBeenCalledTimes(1);
+  });
+
+  it('_logInWith', async () => {
+    ParseUser.disableUnsafeCurrentUser();
+    ParseUser._clearCache();
+    CoreManager.setRESTController({
+      request() {
+        return Promise.resolve({
+          objectId: 'uid10',
+          sessionToken: 'r:123abc',
+          authData: {
+            test: {
+              id: 'id',
+              access_token: 'access_token'
+            }
+          }
+        }, 200);
+      },
+      ajax() {}
+    });
+    const provider = {
+      authenticate(options) {
+        if (options.success) {
+          options.success(this, {
+            id: 'id',
+            access_token: 'access_token'
+          });
+        }
+      },
+      restoreAuthentication() {},
+      getAuthType() {
+        return 'test';
+      },
+      deauthenticate() {}
+    };
+
+    const user = await ParseUser._logInWith(provider, null, { useMasterKey: true });
+    expect(user.get('authData')).toEqual({ test: { id: 'id', access_token: 'access_token' } });
   });
 
   it('can encrypt user', async () => {
@@ -1193,6 +1404,7 @@ describe('ParseUser', () => {
         expect(method).toBe('POST');
         expect(path).toBe('users');
         expect(options.installationId).toBe(installationId);
+        expect(options.useMasterKey).toBe(true);
         return Promise.resolve({
           objectId: 'uid3',
           username: 'username',
@@ -1202,7 +1414,7 @@ describe('ParseUser', () => {
       ajax() {}
     });
 
-    const user = await ParseUser.signUp('username', 'password', null, { installationId });
+    const user = await ParseUser.signUp('username', 'password', null, { installationId, useMasterKey: true });
     expect(user.id).toBe('uid3');
     expect(user.isCurrent()).toBe(false);
     expect(user.existed()).toBe(true);
@@ -1252,6 +1464,12 @@ describe('ParseUser', () => {
     expect(user.objectId).toBe('uid2');
     expect(user.username).toBe('username');
 
+    const notStatic = new ParseUser();
+    notStatic.setUsername('username');
+    const userAgain = await notStatic.verifyPassword('password', { useMasterKey: true });
+    expect(userAgain.objectId).toBe('uid2');
+    expect(userAgain.username).toBe('username');
+
     CoreManager.setRESTController({
       request() {
         const parseError = new ParseError(
@@ -1269,6 +1487,19 @@ describe('ParseUser', () => {
       expect(error.code).toBe(101);
       expect(error.message).toBe('Invalid username/password.');
     }
+    try {
+      await ParseUser.verifyPassword(null, 'password');
+    } catch(error) {
+      expect(error.code).toBe(-1);
+      expect(error.message).toBe('Username must be a string.');
+    }
+
+    try {
+      await ParseUser.verifyPassword('username', null);
+    } catch(error) {
+      expect(error.code).toBe(-1);
+      expect(error.message).toBe('Password must be a string.');
+    }
   });
 
   it('can send an email verification request', () => {
@@ -1284,5 +1515,84 @@ describe('ParseUser', () => {
     });
 
     ParseUser.requestEmailVerification("me@parse.com");
+
+    CoreManager.setRESTController({
+      request(method, path, body, options) {
+        expect(method).toBe('POST');
+        expect(path).toBe("verificationEmailRequest");
+        expect(body).toEqual({ email: "me@parse.com" });
+        expect(options.useMasterKey).toBe(true);
+        return Promise.resolve({}, 200);
+      },
+      ajax() {}
+    });
+    ParseUser.requestEmailVerification("me@parse.com", { useMasterKey: true });
+  });
+
+  it('allowCustomUserClass', () => {
+    expect(CoreManager.get('PERFORM_USER_REWRITE')).toBe(true);
+    ParseUser.allowCustomUserClass(true);
+    expect(CoreManager.get('PERFORM_USER_REWRITE')).toBe(false);
+    ParseUser.allowCustomUserClass(false);
+    expect(CoreManager.get('PERFORM_USER_REWRITE')).toBe(true);
+  });
+
+  it('enableRevocableSession', async () => {
+    const result = await ParseUser.enableRevocableSession();
+    expect(CoreManager.get('FORCE_REVOCABLE_SESSION')).toBe(true);
+    expect(result).toBeUndefined();
+
+    ParseUser.enableUnsafeCurrentUser();
+    ParseUser._clearCache();
+    CoreManager.setRESTController({
+      request() {
+        return Promise.resolve({
+          objectId: 'uid2',
+          username: 'username',
+          sessionToken: '123abc'
+        }, 200);
+      },
+      ajax() {}
+    });
+    const user = await ParseUser.logIn('username', 'password');
+    jest.spyOn(user, '_upgradeToRevocableSession');
+    await ParseUser.enableRevocableSession({ useMasterKey: true });
+    expect(user._upgradeToRevocableSession).toHaveBeenCalled();
+  });
+
+  it('upgradeToRevocableSession', async () => {
+    try {
+      const unsavedUser = new ParseUser();
+      await unsavedUser._upgradeToRevocableSession();
+    } catch (e) {
+      expect(e.message).toBe('Cannot upgrade a user with no session token');
+    }
+
+    ParseUser.disableUnsafeCurrentUser();
+    ParseUser._clearCache();
+    CoreManager.setRESTController({
+      request() {
+        return Promise.resolve({
+          objectId: 'uid2',
+          username: 'username',
+          sessionToken: '123abc'
+        }, 200);
+      },
+      ajax() {}
+    });
+    const user = await ParseUser.logIn('username', 'password');
+    const upgradedUser = await user._upgradeToRevocableSession();
+    expect(user).toEqual(upgradedUser);
+  });
+
+  it('extend', () => {
+    let CustomUser = ParseUser.extend();
+    expect(CustomUser instanceof ParseUser);
+
+    CustomUser = ParseUser.extend({ test: true, className: 'Item' }, { test: false, className: 'Item' });
+    expect(CustomUser instanceof ParseUser);
+
+    const user = new CustomUser();
+    expect(user.test).toBe(true);
   });
 });

--- a/src/__tests__/ParseUser-test.js
+++ b/src/__tests__/ParseUser-test.js
@@ -595,6 +595,41 @@ describe('ParseUser', () => {
       expect(u.getUsername()).toBe('bob');
       expect(u.id).toBe('abc');
       expect(u.getSessionToken()).toBe('12345');
+
+      ParseUser._clearCache();
+      const user = ParseUser.current();
+      expect(user instanceof ParseUser).toBe(true);
+      expect(user.getUsername()).toBe('bob');
+      expect(user.id).toBe('abc');
+      expect(user.getSessionToken()).toBe('12345');
+      done();
+    });
+  });
+
+  it('can inflate users stored from previous SDK versions override _id', (done) => {
+    ParseUser.enableUnsafeCurrentUser();
+    ParseUser._clearCache();
+    Storage._clear();
+    const path = Storage.generatePath('currentUser');
+    Storage.setItem(path, JSON.stringify({
+      _id: 'abc',
+      _sessionToken: '12345',
+      objectId: 'SET',
+      username: 'bob',
+      count: 12
+    }));
+    ParseUser.currentAsync().then((u) => {
+      expect(u instanceof ParseUser).toBe(true);
+      expect(u.getUsername()).toBe('bob');
+      expect(u.id).toBe('abc');
+      expect(u.getSessionToken()).toBe('12345');
+
+      ParseUser._clearCache();
+      const user = ParseUser.current();
+      expect(user instanceof ParseUser).toBe(true);
+      expect(user.getUsername()).toBe('bob');
+      expect(user.id).toBe('abc');
+      expect(user.getSessionToken()).toBe('12345');
       done();
     });
   });

--- a/src/__tests__/SingleInstanceStateController-test.js
+++ b/src/__tests__/SingleInstanceStateController-test.js
@@ -385,4 +385,23 @@ describe('SingleInstanceStateController', () => {
     });
     expect(SingleInstanceStateController.getState({ className: 'someClass', id: 'P' })).toBe(null);
   });
+
+  it('can duplicate the state of an object', () => {
+    const obj = { className: 'someClass', id: 'someId' };
+    SingleInstanceStateController.setServerData(obj, { counter: 12, name: 'original' });
+    const setCount = new ParseOps.SetOp(44);
+    const setValid = new ParseOps.SetOp(true);
+    SingleInstanceStateController.setPendingOp(obj, 'counter', setCount);
+    SingleInstanceStateController.setPendingOp(obj, 'valid', setValid);
+
+    const duplicate = { className: 'someClass', id: 'dupId' };
+    SingleInstanceStateController.duplicateState(obj, duplicate);
+    expect(SingleInstanceStateController.getState(duplicate)).toEqual({
+      serverData: { counter: 12, name: 'original' },
+      pendingOps: [{ counter: setCount, valid: setValid }],
+      objectCache: {},
+      tasks: new TaskQueue(),
+      existed: false
+    });
+  });
 });

--- a/src/__tests__/Storage-test.js
+++ b/src/__tests__/Storage-test.js
@@ -10,7 +10,10 @@
 jest.autoMockOff();
 
 const mockRNStorageInterface = require('./test_helpers/mockRNStorage');
+const mockWeChat = require('./test_helpers/mockWeChat');
 const CoreManager = require('../CoreManager');
+
+global.wx = mockWeChat;
 
 let mockStorage = {};
 const mockStorageInterface = {
@@ -207,6 +210,35 @@ describe('Default StorageController', () => {
   });
 });
 
+const WeappStorageController = require('../StorageController.weapp');
+
+describe('WeChat StorageController', () => {
+  beforeEach(() => {
+    WeappStorageController.clear();
+  });
+
+  it('is synchronous', () => {
+    expect(WeappStorageController.async).toBe(0);
+    expect(typeof WeappStorageController.getItem).toBe('function');
+    expect(typeof WeappStorageController.setItem).toBe('function');
+    expect(typeof WeappStorageController.removeItem).toBe('function');
+  });
+
+  it('can store and retrieve values', () => {
+    expect(WeappStorageController.getItem('myKey')).toBe(undefined);
+    WeappStorageController.setItem('myKey', 'myValue');
+    expect(WeappStorageController.getItem('myKey')).toBe('myValue');
+    expect(WeappStorageController.getAllKeys()).toEqual(['myKey']);
+  });
+
+  it('can remove values', () => {
+    WeappStorageController.setItem('myKey', 'myValue');
+    expect(WeappStorageController.getItem('myKey')).toBe('myValue');
+    WeappStorageController.removeItem('myKey');
+    expect(WeappStorageController.getItem('myKey')).toBe(undefined);
+  });
+});
+
 const Storage = require('../Storage');
 
 describe('Storage (Default StorageController)', () => {
@@ -254,6 +286,16 @@ describe('Storage (Default StorageController)', () => {
     );
     expect(Storage.generatePath('hello')).toBe('Parse/appid/hello');
     expect(Storage.generatePath('/hello')).toBe('Parse/appid/hello');
+  });
+
+  it('can clear if controller does not implement clear', () => {
+    CoreManager.setStorageController({
+      getItem: () => {},
+      setItem: () => {},
+      removeItem: () => {},
+      getAllKeys: () => {},
+    });
+    Storage._clear();
   });
 });
 

--- a/src/__tests__/browser-test.js
+++ b/src/__tests__/browser-test.js
@@ -1,0 +1,134 @@
+jest.dontMock('../CoreManager');
+jest.dontMock('../CryptoController');
+jest.dontMock('../decode');
+jest.dontMock('../encode');
+jest.dontMock('../ParseError');
+jest.dontMock('../EventEmitter');
+jest.dontMock('../Parse');
+jest.dontMock('../RESTController');
+jest.dontMock('../Storage');
+jest.dontMock('crypto-js/aes');
+
+const ParseError = require('../ParseError').default;
+
+class XMLHttpRequest {}
+class XDomainRequest {
+  open() {}
+  send() {}
+}
+global.XMLHttpRequest = XMLHttpRequest;
+global.XDomainRequest = XDomainRequest;
+
+describe('Browser', () => {
+  beforeEach(() => {
+    process.env.PARSE_BUILD = 'browser';
+    jest.clearAllMocks();
+  });
+
+  afterEach(() => {
+    process.env.PARSE_BUILD = 'node';
+  });
+
+  it('warning initializing parse/node in browser', () => {
+    const Parse = require('../Parse');
+    jest.spyOn(console, 'log').mockImplementationOnce(() => {});
+    jest.spyOn(Parse, '_initialize').mockImplementationOnce(() => {});
+    Parse.initialize('A', 'B');
+    expect(console.log).toHaveBeenCalledWith("It looks like you're using the browser version of the SDK in a node.js environment. You should require('parse/node') instead.");
+    expect(Parse._initialize).toHaveBeenCalledTimes(1);
+  });
+
+  it('initializing parse/node in browser with server rendering', () => {
+    process.env.SERVER_RENDERING = true;
+    const Parse = require('../Parse');
+    jest.spyOn(console, 'log').mockImplementationOnce(() => {});
+    jest.spyOn(Parse, '_initialize').mockImplementationOnce(() => {});
+    Parse.initialize('A', 'B');
+    expect(console.log).toHaveBeenCalledTimes(0);
+    expect(Parse._initialize).toHaveBeenCalledTimes(1);
+  });
+
+  it('load StorageController', () => {
+    const StorageController = require('../StorageController.browser');
+    jest.spyOn(StorageController, 'setItem');
+    const storage = require('../Storage');
+    storage.setItem('key', 'value');
+    expect(StorageController.setItem).toHaveBeenCalledTimes(1);
+  });
+
+  it('load RESTController with IE9', async () => {
+    let called = false;
+    class XDomainRequest {
+      open() {
+        called = true;
+      }
+      send() {
+        this.responseText = JSON.stringify({ status: 200 });
+        this.onprogress();
+        this.onload();
+      }
+    }
+    global.XDomainRequest = XDomainRequest;
+    console.log('hererer');
+    const RESTController = require('../RESTController');
+    const options = {
+      progress: () => {},
+      requestTask: () => {},
+    };
+    const { response } = await RESTController.ajax('POST', 'classes/TestObject', null, null, options);
+    expect(response.status).toBe(200);
+    expect(called).toBe(true);
+  });
+
+  it('RESTController IE9 Ajax timeout error', async () => {
+    let called = false;
+    class XDomainRequest {
+      open() {
+        called = true;
+      }
+      send() {
+        this.responseText = '';
+        this.ontimeout();
+      }
+    }
+    class XMLHttpRequest {}
+    global.XDomainRequest = XDomainRequest;
+    global.XMLHttpRequest = XMLHttpRequest;
+    const RESTController = require('../RESTController');
+    try {
+      await RESTController.ajax('POST', 'classes/TestObject');
+      expect(true).toBe(false);
+    } catch (e) {
+      const errorResponse = JSON.stringify({
+        code: ParseError.X_DOMAIN_REQUEST,
+        error: 'IE\'s XDomainRequest does not supply error info.'
+      });
+      expect(e.responseText).toEqual(errorResponse);
+    }
+    expect(called).toBe(true);
+  });
+
+  it('RESTController IE9 Ajax response error', async () => {
+    let called = false;
+    class XDomainRequest {
+      open() {
+        called = true;
+      }
+      send() {
+        this.responseText = '';
+        this.onload();
+      }
+    }
+    class XMLHttpRequest {}
+    global.XDomainRequest = XDomainRequest;
+    global.XMLHttpRequest = XMLHttpRequest;
+    const RESTController = require('../RESTController');
+    try {
+      await RESTController.ajax('POST', 'classes/TestObject');
+      expect(true).toBe(false);
+    } catch (e) {
+      expect(e.message).toBe('Unexpected end of JSON input');
+    }
+    expect(called).toBe(true);
+  });
+});

--- a/src/__tests__/canBeSerialized-test.js
+++ b/src/__tests__/canBeSerialized-test.js
@@ -27,6 +27,7 @@ jest.setMock('../ParseFile', mockFile);
 const canBeSerialized = require('../canBeSerialized').default;
 const ParseFile = require('../ParseFile');
 const ParseObject = require('../ParseObject');
+const ParseRelation = require('../ParseRelation').default;
 
 describe('canBeSerialized', () => {
   it('returns true for anything that is not a ParseObject', () => {
@@ -76,6 +77,14 @@ describe('canBeSerialized', () => {
     child.attributes.parent = parent;
     expect(canBeSerialized(parent)).toBe(true);
     expect(canBeSerialized(child)).toBe(false);
+  });
+
+  it('returns true for relations', () => {
+    const relation = new ParseRelation(null, null);
+    const parent = new ParseObject(undefined, {
+      child: relation,
+    });
+    expect(canBeSerialized(parent)).toBe(true);
   });
 
   it('traverses nested arrays and objects', () => {

--- a/src/__tests__/decode-test.js
+++ b/src/__tests__/decode-test.js
@@ -10,12 +10,14 @@
 jest.dontMock('../decode');
 jest.dontMock('../ParseFile');
 jest.dontMock('../ParseGeoPoint');
+jest.dontMock('../ParsePolygon');
 
 const decode = require('../decode').default;
 
 const ParseFile = require('../ParseFile').default;
 const ParseGeoPoint = require('../ParseGeoPoint').default;
 const ParseObject = require('../ParseObject').default;
+const ParsePolygon = require('../ParsePolygon').default;
 
 describe('decode', () => {
   it('ignores primitives', () => {
@@ -42,6 +44,16 @@ describe('decode', () => {
     expect(point instanceof ParseGeoPoint).toBe(true);
     expect(point.latitude).toBe(40.5);
     expect(point.longitude).toBe(50.4);
+  });
+
+  it('decodes Polygons', () => {
+    const points = [[0, 0], [0, 1], [1, 1], [1, 0], [0, 0]];
+    const polygon = decode({
+      __type: 'Polygon',
+      coordinates: points,
+    });
+    expect(polygon instanceof ParsePolygon).toBe(true);
+    expect(polygon.coordinates).toEqual(points);
   });
 
   it('decodes Files', () => {

--- a/src/__tests__/promiseUtils-test.js
+++ b/src/__tests__/promiseUtils-test.js
@@ -1,0 +1,19 @@
+jest.autoMockOff();
+
+const { when } = require('../promiseUtils');
+
+describe('promiseUtils', () => {
+  it('when', async () => {
+    const promise1 = Promise.resolve(1);
+    const promise2 = Promise.resolve(2);
+
+    let result = await when([]);
+    expect(result).toEqual([[]]);
+
+    result = await when(promise1, promise2);
+    expect(result).toEqual([1, 2]);
+
+    result = await when(promise1, 'not a promise');
+    expect(result).toEqual([1, 'not a promise']);
+  });
+});

--- a/src/__tests__/react-native-test.js
+++ b/src/__tests__/react-native-test.js
@@ -4,8 +4,9 @@ jest.dontMock('../CryptoController');
 jest.dontMock('../decode');
 jest.dontMock('../encode');
 jest.dontMock('../EventEmitter');
-jest.dontMock('../ParseObject');
 jest.dontMock('../LiveQueryClient');
+jest.dontMock('../LocalDatastore');
+jest.dontMock('../ParseObject');
 jest.dontMock('../Storage');
 
 jest.mock('../../../../react-native/Libraries/vendor/emitter/EventEmitter', () => {
@@ -44,6 +45,13 @@ describe('React Native', () => {
     const phrase = CryptoController.encrypt({}, 'salt');
     expect(phrase).toBe('World');
     expect(CryptoJS.AES.encrypt).toHaveBeenCalled();
+  });
+
+  it('load LocalDatastoreController', () => {
+    const LocalDatastoreController = require('../LocalDatastoreController.react-native');
+    require('../LocalDatastore');
+    const LDC = CoreManager.getLocalDatastoreController();
+    expect(LocalDatastoreController).toEqual(LDC);
   });
 
   it('load StorageController', () => {

--- a/src/__tests__/react-native-test.js
+++ b/src/__tests__/react-native-test.js
@@ -1,0 +1,45 @@
+const events = require('events');
+
+jest.dontMock('../CoreManager');
+jest.dontMock('../decode');
+jest.dontMock('../encode');
+jest.dontMock('../EventEmitter');
+jest.dontMock('../Storage');
+
+jest.mock('../../../../react-native/Libraries/vendor/emitter/EventEmitter', () => {
+  return {
+    prototype: {
+      addListener: new (require('events').EventEmitter)(),
+    },
+  };
+}, { virtual: true });
+
+const mockEmitter = require('../../../../react-native/Libraries/vendor/emitter/EventEmitter');
+
+describe('React Native', () => {
+  beforeEach(() => {
+    process.env.PARSE_BUILD = 'react-native';
+  });
+
+  afterEach(() => {
+    process.env.PARSE_BUILD = 'node';
+  });
+
+  it('load EventEmitter', () => {
+    const eventEmitter = require('../EventEmitter');
+    // console.log(eventEmitter);
+  });
+
+  it('load CryptoController', () => {
+    const CryptoController = require('../CryptoController');
+    // console.log(CryptoController);
+  });
+
+  it('load StorageController', () => {
+    const StorageController = require('../StorageController.react-native');
+    jest.spyOn(StorageController, 'setItemAsync');
+    const storage = require('../Storage');
+    storage.setItemAsync('key', 'value');
+    expect(StorageController.setItemAsync).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/__tests__/test_helpers/mockWeChat.js
+++ b/src/__tests__/test_helpers/mockWeChat.js
@@ -1,5 +1,9 @@
 let mockStorage = {};
 let progressCallback = () => {};
+let socketOpenCallback = () => {};
+let socketMessageCallback = () => {};
+let socketCloseCallback = () => {};
+let SocketErrorCallback = () => {};
 
 const mockWeChat = {
   getStorageSync(path) {
@@ -41,7 +45,35 @@ const mockWeChat = {
         options.fail();
       }
     }
-  }
+  },
+
+  connectSocket() {},
+
+  onSocketOpen(cb) {
+    socketOpenCallback = cb;
+  },
+
+  onSocketMessage(cb) {
+    socketMessageCallback = cb;
+  },
+
+  onSocketClose(cb) {
+    socketCloseCallback = cb;
+  },
+
+  onSocketError(cb) {
+    SocketErrorCallback = cb;
+  },
+
+  sendSocketMessage(data) {
+    socketOpenCallback();
+    socketMessageCallback(data);
+  },
+
+  closeSocket() {
+    socketCloseCallback();
+    SocketErrorCallback();
+  },
 };
 
 module.exports = mockWeChat;

--- a/src/__tests__/test_helpers/mockWeChat.js
+++ b/src/__tests__/test_helpers/mockWeChat.js
@@ -1,0 +1,47 @@
+let mockStorage = {};
+let progressCallback = () => {};
+
+const mockWeChat = {
+  getStorageSync(path) {
+    return mockStorage[path];
+  },
+
+  setStorageSync(path, value) {
+    mockStorage[path] = value;
+  },
+
+  removeStorageSync(path) {
+    delete mockStorage[path];
+  },
+
+  getStorageInfoSync() {
+    return {
+      keys: Object.keys(mockStorage),
+    };
+  },
+
+  clearStorageSync() {
+    mockStorage = {};
+  },
+
+  request(options) {
+    return {
+      onProgressUpdate: (cb) => {
+        progressCallback = cb;
+      },
+      abort: () => {
+        progressCallback({
+          totalBytesExpectedToWrite: 0,
+          totalBytesWritten: 0,
+        });
+        options.success({
+          statusCode: 0,
+          data: {},
+        });
+        options.fail();
+      }
+    }
+  }
+};
+
+module.exports = mockWeChat;

--- a/src/__tests__/unsavedChildren-test.js
+++ b/src/__tests__/unsavedChildren-test.js
@@ -30,6 +30,7 @@ jest.setMock('../ParseObject', mockObject);
 
 const ParseFile = require('../ParseFile').default;
 const ParseObject = require('../ParseObject');
+const ParseRelation = require('../ParseRelation').default;
 const unsavedChildren = require('../unsavedChildren').default;
 
 describe('unsavedChildren', () => {
@@ -197,5 +198,17 @@ describe('unsavedChildren', () => {
     a.attributes.b.attributes.a = a;
 
     expect(unsavedChildren(a)).toEqual([ a.attributes.b ]);
+  });
+
+  it('skips Relation', () => {
+    const relation = new ParseRelation(null, null);
+    const f = new ParseObject({
+      className: 'Folder',
+      id: '121',
+      attributes: {
+        r: relation,
+      },
+    });
+    expect(unsavedChildren(f)).toEqual([]);
   });
 });

--- a/src/__tests__/weapp-test.js
+++ b/src/__tests__/weapp-test.js
@@ -1,0 +1,33 @@
+jest.dontMock('../CoreManager');
+jest.dontMock('../CryptoController');
+jest.dontMock('../decode');
+jest.dontMock('../encode');
+jest.dontMock('../EventEmitter');
+jest.dontMock('../Parse');
+jest.dontMock('../RESTController');
+jest.dontMock('../Storage');
+jest.dontMock('crypto-js/aes');
+
+describe('WeChat', () => {
+  beforeEach(() => {
+    process.env.PARSE_BUILD = 'weapp';
+  });
+
+  afterEach(() => {
+    process.env.PARSE_BUILD = 'node';
+  });
+
+  it('load StorageController', () => {
+    const StorageController = require('../StorageController.weapp');
+    jest.spyOn(StorageController, 'setItem');
+    const storage = require('../Storage');
+    storage.setItem('key', 'value');
+    expect(StorageController.setItem).toHaveBeenCalledTimes(1);
+  });
+
+  it('load RESTController', () => {
+    const XHR = require('../Xhr.weapp');
+    const RESTController = require('../RESTController');
+    expect(RESTController._getXHR()).toEqual(XHR);
+  });
+});

--- a/src/__tests__/weapp-test.js
+++ b/src/__tests__/weapp-test.js
@@ -3,10 +3,20 @@ jest.dontMock('../CryptoController');
 jest.dontMock('../decode');
 jest.dontMock('../encode');
 jest.dontMock('../EventEmitter');
+jest.dontMock('../LiveQueryClient');
 jest.dontMock('../Parse');
+jest.dontMock('../ParseFile');
+jest.dontMock('../ParseObject');
 jest.dontMock('../RESTController');
+jest.dontMock('../Socket.weapp');
 jest.dontMock('../Storage');
 jest.dontMock('crypto-js/aes');
+jest.dontMock('./test_helpers/mockWeChat');
+
+const CoreManager = require('../CoreManager');
+const mockWeChat = require('./test_helpers/mockWeChat');
+
+global.wx = mockWeChat;
 
 describe('WeChat', () => {
   beforeEach(() => {
@@ -29,5 +39,45 @@ describe('WeChat', () => {
     const XHR = require('../Xhr.weapp');
     const RESTController = require('../RESTController');
     expect(RESTController._getXHR()).toEqual(XHR);
+  });
+
+  it('load ParseFile', () => {
+    const XHR = require('../Xhr.weapp');
+    require('../ParseFile');
+    const fileController = CoreManager.getFileController();
+    expect(fileController._getXHR()).toEqual(XHR);
+  });
+
+  it('load WebSocketController', () => {
+    const socket = require('../Socket.weapp');
+    require('../LiveQueryClient');
+    const websocket = CoreManager.getWebSocketController();
+    expect(websocket).toEqual(socket);
+  });
+
+  describe('Socket', () => {
+    it('send', () => {
+      const Websocket = require('../Socket.weapp');
+      jest.spyOn(mockWeChat, 'connectSocket');
+      const socket = new Websocket('wss://examples.com');
+      socket.onopen();
+      socket.onmessage();
+      socket.onclose();
+      socket.onerror();
+      socket.onopen = jest.fn();
+      socket.onmessage = jest.fn();
+      socket.onclose = jest.fn();
+      socket.onerror = jest.fn();
+
+      expect(mockWeChat.connectSocket).toHaveBeenCalled();
+
+      socket.send('{}');
+      expect(socket.onopen).toHaveBeenCalled();
+      expect(socket.onmessage).toHaveBeenCalled();
+
+      socket.close();
+      expect(socket.onclose).toHaveBeenCalled();
+      expect(socket.onerror).toHaveBeenCalled();
+    });
   });
 });


### PR DESCRIPTION
Giving the SDK some much needed love

Fixes a few bugs

* Set default emitter error on LiveQueryClient to prevent crashing
* Query subscriptions will return error on socket error
* WeChat socket sets handlers first before connecting
* Fix Parse Installation error message
* ParseACL remove unreachable code
