### PR TITLE
fix(fetchAll): Properly handle passed in values

### DIFF
--- a/src/ParseObject.js
+++ b/src/ParseObject.js
@@ -2178,7 +2178,7 @@ const DefaultController = {
         }
         return Promise.resolve(results);
       });
-    } else {
+    } else if (target instanceof ParseObject) {
       if (!target.id) {
         return Promise.reject(new ParseError(
           ParseError.MISSING_OBJECT_ID,
@@ -2196,15 +2196,14 @@ const DefaultController = {
         params,
         options
       ).then(async (response) => {
-        if (target instanceof ParseObject) {
-          target._clearPendingOps();
-          target._clearServerData();
-          target._finishFetch(response);
-        }
+        target._clearPendingOps();
+        target._clearServerData();
+        target._finishFetch(response);
         await localDatastore._updateObjectIfPinned(target);
         return target;
       });
     }
+    return Promise.resolve();
   },
 
   async destroy(target: ParseObject | Array<ParseObject>, options: RequestOptions): Promise<Array<void> | ParseObject> {
@@ -2278,7 +2277,6 @@ const DefaultController = {
         return Promise.resolve(target);
       });
     }
-    await localDatastore._destroyObjectIfPinned(target);
     return Promise.resolve(target);
   },
 

--- a/src/__tests__/ParseObject-test.js
+++ b/src/__tests__/ParseObject-test.js
@@ -1257,6 +1257,21 @@ describe('ParseObject', () => {
     expect(controller.ajax).toHaveBeenCalledTimes(0);
   });
 
+  it('fetchAll with null', async () => {
+    CoreManager.getRESTController()._setXHR(
+      mockXHR([{
+        status: 200,
+        response: [{}]
+      }])
+    );
+    const controller = CoreManager.getRESTController();
+    jest.spyOn(controller, 'ajax');
+
+    const results = await ParseObject.fetchAll(null);
+    expect(results).toEqual(undefined);
+    expect(controller.ajax).toHaveBeenCalledTimes(0);
+  });
+
   it('fetchAll unique instance', async () => {
     ParseObject.disableSingleInstance();
     const obj = new ParseObject('Item');


### PR DESCRIPTION
Prevents `TypeError: Cannot read property 'id' of null`

Handles input the same way saveAll and destroyAll.

Also removed unnecessary LDS call on destroy all for non ParseObject / Array<ParseObject>

Let me know if I need to change anything.