### PR TITLE
Delete .eslintignore

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,1 +1,0 @@
-node_modules


### PR DESCRIPTION
node_modules folder isn't checked by default or by lint script