### PR TITLE
Document SDK module import

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,8 @@ To use the npm modules for a browser based application, include it as you normal
 
 ```js
 const Parse = require('parse');
+// ES6 Minimized
+import Parse from 'parse/dist/parse.min.js';
 ```
 
 For server-side applications or Node.js command line tools, include `'parse/node'`:


### PR DESCRIPTION
Closes: https://github.com/parse-community/Parse-SDK-JS/issues/1249

I'm not sure this is the best way to document how to add Parse SDK to a Project. There are many types of imports like CommonJS, RequireJS, es6 etc, not to mention the browser bundlers like Webpack, rollup that don't like certain imports.

@davimacedo @TomWFox 