### PR TITLE
fix(AddUniqueOp): Remove unnecessary object reference and comment

### DIFF
--- a/src/ParseOp.js
+++ b/src/ParseOp.js
@@ -199,16 +199,14 @@ export class AddUniqueOp extends Op {
       return this._value || [];
     }
     if (Array.isArray(value)) {
-      // copying value lets Flow guarantee the pointer isn't modified elsewhere
-      const valueCopy = value;
       const toAdd = [];
       this._value.forEach((v) => {
         if (v instanceof ParseObject) {
-          if (!arrayContainsObject(valueCopy, v)) {
+          if (!arrayContainsObject(value, v)) {
             toAdd.push(v);
           }
         } else {
-          if (valueCopy.indexOf(v) < 0) {
+          if (value.indexOf(v) < 0) {
             toAdd.push(v);
           }
         }


### PR DESCRIPTION
Addresses: https://github.com/parse-community/Parse-SDK-JS/issues/443

Removing this to prevent confusion. Does anybody want to explain why this is needed? Its been there since the beginning of the SDK