### PR TITLE
Add sending unsaved ParseObjects to Clients 

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -2,5 +2,7 @@
   "jasmineExplorer.config": "jasmine.json",
   "jasmineExplorer.env": {
     "TESTING": "1"
-  }
+  },
+  "flow.useNPMPackagedFlow": true,
+  "javascript.validate.enable": false
 }

--- a/integration/cloud/main.js
+++ b/integration/cloud/main.js
@@ -49,3 +49,22 @@ Parse.Cloud.job('CloudJob2', function() {
 Parse.Cloud.job('CloudJobFailing', function() {
   throw 'cloud job failed';
 });
+
+//ugly patch. Should not stay here, but I don't know how to test changes in Cloud Code otherwise
+//parse-server uses the published parse SDK version, but we want to test the patched version via cloud code
+const PatchedParse = require('../../node').Parse;
+//FunctionsRouter.js 104 calls Parse._encode directly, so it must be patched.
+Parse._encode = PatchedParse._encode;
+//Parse.Object calls encode, so it must be patched.
+Parse.Object = PatchedParse.Object;
+
+Parse.Cloud.define('getUnsavedObject', function(){
+  const parent = new Parse.Object("Unsaved");
+  const child = new Parse.Object("secondUnsaved");
+  const childOfChild = new Parse.Object("thirdUnsaved");
+  child.set("foz", "baz");
+  child.set("child", childOfChild);
+  parent.set("foo", "bar");
+  parent.set("child", child);
+  return parent;
+});

--- a/integration/test/ParseCloudTest.js
+++ b/integration/test/ParseCloudTest.js
@@ -133,4 +133,15 @@ describe('Parse Cloud', () => {
       done();
     });
   });
+
+  it('should transfer unsaved object as full JSON', (done) => {
+    Parse.Cloud.run('getUnsavedObject').then((result) => {
+      expect(result).toBeInstanceOf(Parse.Object);
+      expect(result.get('foo')).toEqual('bar');
+      expect(result.get('child')).toBeInstanceOf(Parse.Object);
+      expect(result.get('child').get('child')).toBeInstanceOf(Parse.Object);
+      expect(result.get('child').get('foz')).toEqual('baz');
+      done();
+    }).catch(done.fail);
+  });
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -1293,47 +1293,6 @@
         "kuler": "^2.0.0"
       }
     },
-    "@graphql-tools/batch-delegate": {
-      "version": "6.2.2",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/batch-delegate/-/batch-delegate-6.2.2.tgz",
-      "integrity": "sha512-xXJKVvBxafdn9tVWe3oJreTHuFAKWblw4zK0KvKhEVJOjPytKweGCZI3kTs9hdmjgPz1ZjSQEVvgmZJ0GubrWA==",
-      "dev": true,
-      "requires": {
-        "@graphql-tools/delegate": "6.2.2",
-        "dataloader": "2.0.0",
-        "tslib": "~2.0.1"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "2.0.3",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.0.3.tgz",
-          "integrity": "sha512-uZtkfKblCEQtZKBF6EBXVZeQNl82yqtDQdv+eck8u7tdPxjLu2/lp5/uPW+um2tpuxINHWy3GhiccY7QgEaVHQ==",
-          "dev": true
-        }
-      }
-    },
-    "@graphql-tools/delegate": {
-      "version": "6.2.2",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/delegate/-/delegate-6.2.2.tgz",
-      "integrity": "sha512-8VycfZYQ+m4HgajewQT6v6BzAEFxc6mh6rO+uqewnvh143nvv3ud4nXEAfOddUm0PrE6iD3Ng2BZtPSWF5mt+w==",
-      "dev": true,
-      "requires": {
-        "@ardatan/aggregate-error": "0.0.6",
-        "@graphql-tools/schema": "6.2.2",
-        "@graphql-tools/utils": "6.2.2",
-        "dataloader": "2.0.0",
-        "is-promise": "4.0.0",
-        "tslib": "~2.0.1"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "2.0.3",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.0.3.tgz",
-          "integrity": "sha512-uZtkfKblCEQtZKBF6EBXVZeQNl82yqtDQdv+eck8u7tdPxjLu2/lp5/uPW+um2tpuxINHWy3GhiccY7QgEaVHQ==",
-          "dev": true
-        }
-      }
-    },
     "@graphql-tools/links": {
       "version": "6.2.4",
       "resolved": "https://registry.npmjs.org/@graphql-tools/links/-/links-6.2.4.tgz",
@@ -1371,107 +1330,6 @@
             "mime-types": "^2.1.12"
           }
         },
-        "tslib": {
-          "version": "2.0.3",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.0.3.tgz",
-          "integrity": "sha512-uZtkfKblCEQtZKBF6EBXVZeQNl82yqtDQdv+eck8u7tdPxjLu2/lp5/uPW+um2tpuxINHWy3GhiccY7QgEaVHQ==",
-          "dev": true
-        }
-      }
-    },
-    "@graphql-tools/merge": {
-      "version": "6.2.2",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/merge/-/merge-6.2.2.tgz",
-      "integrity": "sha512-2YyErSvq4hn5mjE6qJ/0Q8r3WU9JB3+obv2xyvb+oW+E/T1iYRJGxSFldi6lqO5IADZz8QASLJeSpRBw40gpBg==",
-      "dev": true,
-      "requires": {
-        "@graphql-tools/schema": "6.2.2",
-        "@graphql-tools/utils": "6.2.2",
-        "tslib": "~2.0.1"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "2.0.3",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.0.3.tgz",
-          "integrity": "sha512-uZtkfKblCEQtZKBF6EBXVZeQNl82yqtDQdv+eck8u7tdPxjLu2/lp5/uPW+um2tpuxINHWy3GhiccY7QgEaVHQ==",
-          "dev": true
-        }
-      }
-    },
-    "@graphql-tools/schema": {
-      "version": "6.2.2",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/schema/-/schema-6.2.2.tgz",
-      "integrity": "sha512-KITlyr//1oKyxIOlGvNZDl4c6bLj2Gc+3eJXyUKWfSmgsmAZPudpQNa/8VbiVujpm7UaX0cyM3FdeCaxWFeBgg==",
-      "dev": true,
-      "requires": {
-        "@graphql-tools/utils": "6.2.2",
-        "tslib": "~2.0.1"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "2.0.3",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.0.3.tgz",
-          "integrity": "sha512-uZtkfKblCEQtZKBF6EBXVZeQNl82yqtDQdv+eck8u7tdPxjLu2/lp5/uPW+um2tpuxINHWy3GhiccY7QgEaVHQ==",
-          "dev": true
-        }
-      }
-    },
-    "@graphql-tools/stitch": {
-      "version": "6.2.2",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/stitch/-/stitch-6.2.2.tgz",
-      "integrity": "sha512-VysuOBik1ICqsgV3VGXysJfdUl4/ro95rsnREma9BJP3oNqriPd6v8JhrnZqP2LbfzF7G2xndRoSRAQgYOzsUQ==",
-      "dev": true,
-      "requires": {
-        "@graphql-tools/batch-delegate": "6.2.2",
-        "@graphql-tools/delegate": "6.2.2",
-        "@graphql-tools/merge": "6.2.2",
-        "@graphql-tools/schema": "6.2.2",
-        "@graphql-tools/utils": "6.2.2",
-        "@graphql-tools/wrap": "6.2.2",
-        "is-promise": "4.0.0",
-        "tslib": "~2.0.1"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "2.0.3",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.0.3.tgz",
-          "integrity": "sha512-uZtkfKblCEQtZKBF6EBXVZeQNl82yqtDQdv+eck8u7tdPxjLu2/lp5/uPW+um2tpuxINHWy3GhiccY7QgEaVHQ==",
-          "dev": true
-        }
-      }
-    },
-    "@graphql-tools/utils": {
-      "version": "6.2.2",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-6.2.2.tgz",
-      "integrity": "sha512-a0SSYF76dnKHs8te4Igfnrrq1VOO4sFG8yx3ehO7464eGUfUUYo2QmNRjhxny2HRMvqzX40xuQikyg6LBXDNLQ==",
-      "dev": true,
-      "requires": {
-        "@ardatan/aggregate-error": "0.0.6",
-        "camel-case": "4.1.1",
-        "tslib": "~2.0.1"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "2.0.3",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.0.3.tgz",
-          "integrity": "sha512-uZtkfKblCEQtZKBF6EBXVZeQNl82yqtDQdv+eck8u7tdPxjLu2/lp5/uPW+um2tpuxINHWy3GhiccY7QgEaVHQ==",
-          "dev": true
-        }
-      }
-    },
-    "@graphql-tools/wrap": {
-      "version": "6.2.2",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/wrap/-/wrap-6.2.2.tgz",
-      "integrity": "sha512-FjCE+NvMwcCiAlt9EAw9uDi2zblE4Z5CEkY+z4NRO1AmCB5THoWJKG+csPh8tGuU80mAJI51Wy9FQGyUo/EU0g==",
-      "dev": true,
-      "requires": {
-        "@graphql-tools/delegate": "6.2.2",
-        "@graphql-tools/schema": "6.2.2",
-        "@graphql-tools/utils": "6.2.2",
-        "is-promise": "4.0.0",
-        "tslib": "~2.0.1"
-      },
-      "dependencies": {
         "tslib": {
           "version": "2.0.3",
           "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.0.3.tgz",
@@ -1715,64 +1573,11 @@
         }
       }
     },
-    "@parse/fs-files-adapter": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@parse/fs-files-adapter/-/fs-files-adapter-1.0.1.tgz",
-      "integrity": "sha1-do94QIPo+Wc+9GPhmaG+X4N7QWU=",
-      "dev": true
-    },
     "@parse/minami": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/@parse/minami/-/minami-1.0.0.tgz",
       "integrity": "sha512-Rw+p0WdOOypFPVJsmhyiI+Q056ZxdP2iAtObnU1DZrsvKZTf5x0B/0SjIt0hUgWp+COjqi/p17VdBU9IAD/NJg==",
       "dev": true
-    },
-    "@parse/node-apn": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/@parse/node-apn/-/node-apn-3.2.0.tgz",
-      "integrity": "sha512-Xa2paSzLY18k0ekvVAa9YbwwxGjzFnnAu7fqwlrFhaWCv1IaQ9u7r/TGuLml1zWbvhFTdy4XXB4soDS1pek3uA==",
-      "dev": true,
-      "requires": {
-        "debug": "3.1.0",
-        "jsonwebtoken": "8.1.0",
-        "node-forge": "0.10.0",
-        "verror": "1.10.0"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
-          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
-          "dev": true,
-          "requires": {
-            "ms": "2.0.0"
-          }
-        },
-        "jsonwebtoken": {
-          "version": "8.1.0",
-          "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-8.1.0.tgz",
-          "integrity": "sha1-xjl80uX9WD1lwAeoPce7eOaYK4M=",
-          "dev": true,
-          "requires": {
-            "jws": "^3.1.4",
-            "lodash.includes": "^4.3.0",
-            "lodash.isboolean": "^3.0.3",
-            "lodash.isinteger": "^4.0.4",
-            "lodash.isnumber": "^3.0.3",
-            "lodash.isplainobject": "^4.0.6",
-            "lodash.isstring": "^4.0.1",
-            "lodash.once": "^4.0.0",
-            "ms": "^2.0.0",
-            "xtend": "^4.0.1"
-          }
-        },
-        "ms": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
-          "dev": true
-        }
-      }
     },
     "@parse/node-gcm": {
       "version": "1.0.2",
@@ -1836,104 +1641,6 @@
           "requires": {
             "psl": "^1.1.24",
             "punycode": "^1.4.1"
-          }
-        }
-      }
-    },
-    "@parse/push-adapter": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/@parse/push-adapter/-/push-adapter-3.3.0.tgz",
-      "integrity": "sha512-PQlgP5ydplSZlC2jCx79j/5A8FVD1i7yl3796RL/zC4dj9TZ4Hocc/IVjru4aFHB129zwXQeyJBmtByySP95uw==",
-      "dev": true,
-      "requires": {
-        "@parse/node-apn": "3.2.0",
-        "@parse/node-gcm": "1.0.2",
-        "npmlog": "4.0.2",
-        "parse": "2.16.0"
-      },
-      "dependencies": {
-        "parse": {
-          "version": "2.16.0",
-          "resolved": "https://registry.npmjs.org/parse/-/parse-2.16.0.tgz",
-          "integrity": "sha512-MJRGCYZGawOs9FOn/i/ag7IFF9NHe5OG+XvNta45pSMzre6nvqUqcvQpTDj0tC+h0C4eMuLoI39SQ07PIwnRTw==",
-          "dev": true,
-          "requires": {
-            "@babel/runtime": "7.11.2",
-            "@babel/runtime-corejs3": "7.11.2",
-            "crypto-js": "4.0.0",
-            "react-native-crypto-js": "1.0.0",
-            "uuid": "3.4.0",
-            "ws": "7.3.1",
-            "xmlhttprequest": "1.8.0"
-          },
-          "dependencies": {
-            "@babel/runtime": {
-              "version": "7.11.2",
-              "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.11.2.tgz",
-              "integrity": "sha512-TeWkU52so0mPtDcaCTxNBI/IHiz0pZgr8VEFqXFtZWpYD08ZB6FaSwVAS8MKRQAP3bYKiVjwysOJgMFY28o6Tw==",
-              "dev": true,
-              "requires": {
-                "regenerator-runtime": "^0.13.4"
-              }
-            },
-            "@babel/runtime-corejs3": {
-              "version": "7.11.2",
-              "resolved": "https://registry.npmjs.org/@babel/runtime-corejs3/-/runtime-corejs3-7.11.2.tgz",
-              "integrity": "sha512-qh5IR+8VgFz83VBa6OkaET6uN/mJOhHONuy3m1sgF0CV6mXdPSEBdA7e1eUbVvyNtANjMbg22JUv71BaDXLY6A==",
-              "dev": true,
-              "requires": {
-                "core-js-pure": "^3.0.0",
-                "regenerator-runtime": "^0.13.4"
-              }
-            }
-          }
-        }
-      }
-    },
-    "@parse/s3-files-adapter": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/@parse/s3-files-adapter/-/s3-files-adapter-1.5.0.tgz",
-      "integrity": "sha512-dF4IkGgP2o1iiuTsrHz2Y4hASE/QMMXIcOLf0hxA1e1fBYQ1oLphquoaFldO0Li0wUIE0zg5vuIAkp1M4ODqjQ==",
-      "dev": true,
-      "requires": {
-        "aws-sdk": "2.761.0",
-        "parse": "2.16.0"
-      },
-      "dependencies": {
-        "parse": {
-          "version": "2.16.0",
-          "resolved": "https://registry.npmjs.org/parse/-/parse-2.16.0.tgz",
-          "integrity": "sha512-MJRGCYZGawOs9FOn/i/ag7IFF9NHe5OG+XvNta45pSMzre6nvqUqcvQpTDj0tC+h0C4eMuLoI39SQ07PIwnRTw==",
-          "dev": true,
-          "requires": {
-            "@babel/runtime": "7.11.2",
-            "@babel/runtime-corejs3": "7.11.2",
-            "crypto-js": "4.0.0",
-            "react-native-crypto-js": "1.0.0",
-            "uuid": "3.4.0",
-            "ws": "7.3.1",
-            "xmlhttprequest": "1.8.0"
-          },
-          "dependencies": {
-            "@babel/runtime": {
-              "version": "7.11.2",
-              "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.11.2.tgz",
-              "integrity": "sha512-TeWkU52so0mPtDcaCTxNBI/IHiz0pZgr8VEFqXFtZWpYD08ZB6FaSwVAS8MKRQAP3bYKiVjwysOJgMFY28o6Tw==",
-              "dev": true,
-              "requires": {
-                "regenerator-runtime": "^0.13.4"
-              }
-            },
-            "@babel/runtime-corejs3": {
-              "version": "7.11.2",
-              "resolved": "https://registry.npmjs.org/@babel/runtime-corejs3/-/runtime-corejs3-7.11.2.tgz",
-              "integrity": "sha512-qh5IR+8VgFz83VBa6OkaET6uN/mJOhHONuy3m1sgF0CV6mXdPSEBdA7e1eUbVvyNtANjMbg22JUv71BaDXLY6A==",
-              "dev": true,
-              "requires": {
-                "core-js-pure": "^3.0.0",
-                "regenerator-runtime": "^0.13.4"
-              }
-            }
           }
         }
       }
@@ -2102,15 +1809,6 @@
         "@types/express": "*",
         "@types/keygrip": "*",
         "@types/node": "*"
-      }
-    },
-    "@types/cors": {
-      "version": "2.8.8",
-      "resolved": "https://registry.npmjs.org/@types/cors/-/cors-2.8.8.tgz",
-      "integrity": "sha512-fO3gf3DxU2Trcbr75O7obVndW/X5k8rJNZkLXlQWStTHhP71PkRqjwPIEI0yMnJdg9R9OasjU+Bsr+Hr1xy/0w==",
-      "dev": true,
-      "requires": {
-        "@types/express": "*"
       }
     },
     "@types/express": {
@@ -2553,15 +2251,6 @@
         "apollo-server-env": "^2.4.5"
       }
     },
-    "apollo-engine-reporting-protobuf": {
-      "version": "0.5.2",
-      "resolved": "https://registry.npmjs.org/apollo-engine-reporting-protobuf/-/apollo-engine-reporting-protobuf-0.5.2.tgz",
-      "integrity": "sha512-4wm9FR3B7UvJxcK/69rOiS5CAJPEYKufeRWb257ZLfX7NGFTMqvbc1hu4q8Ch7swB26rTpkzfsftLED9DqH9qg==",
-      "dev": true,
-      "requires": {
-        "@apollo/protobufjs": "^1.0.3"
-      }
-    },
     "apollo-env": {
       "version": "0.6.5",
       "resolved": "https://registry.npmjs.org/apollo-env/-/apollo-env-0.6.5.tgz",
@@ -2723,30 +2412,6 @@
       "integrity": "sha512-FeGxW3Batn6sUtX3OVVUm7o56EgjxDlmgpTLNyWcLb0j6P8mw9oLNyAm3B+deHA4KNdNHO5BmHS2g1SJYjqPCQ==",
       "dev": true
     },
-    "apollo-server-express": {
-      "version": "2.17.0",
-      "resolved": "https://registry.npmjs.org/apollo-server-express/-/apollo-server-express-2.17.0.tgz",
-      "integrity": "sha512-PonpWOuM1DH3Cz0bu56Tusr3GXOnectC6AD/gy2GXK0v84E7tKTuxEY3SgsgxhvfvvhfwJbXTyIogL/wezqnCw==",
-      "dev": true,
-      "requires": {
-        "@apollographql/graphql-playground-html": "1.6.26",
-        "@types/accepts": "^1.3.5",
-        "@types/body-parser": "1.19.0",
-        "@types/cors": "^2.8.4",
-        "@types/express": "4.17.7",
-        "accepts": "^1.3.5",
-        "apollo-server-core": "^2.17.0",
-        "apollo-server-types": "^0.5.1",
-        "body-parser": "^1.18.3",
-        "cors": "^2.8.4",
-        "express": "^4.17.1",
-        "graphql-subscriptions": "^1.0.0",
-        "graphql-tools": "^4.0.0",
-        "parseurl": "^1.3.2",
-        "subscriptions-transport-ws": "^0.9.16",
-        "type-is": "^1.6.16"
-      }
-    },
     "apollo-server-plugin-base": {
       "version": "0.10.1",
       "resolved": "https://registry.npmjs.org/apollo-server-plugin-base/-/apollo-server-plugin-base-0.10.1.tgz",
@@ -2767,17 +2432,6 @@
             "apollo-server-env": "^2.4.5"
           }
         }
-      }
-    },
-    "apollo-server-types": {
-      "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/apollo-server-types/-/apollo-server-types-0.5.1.tgz",
-      "integrity": "sha512-my2cPw+DAb2qVnIuBcsRKGyS28uIc2vjFxa1NpRoJZe9gK0BWUBk7wzXnIzWy3HZ5Er11e/40MPTUesNfMYNVA==",
-      "dev": true,
-      "requires": {
-        "apollo-engine-reporting-protobuf": "^0.5.2",
-        "apollo-server-caching": "^0.5.2",
-        "apollo-server-env": "^2.4.5"
       }
     },
     "apollo-tracing": {
@@ -4592,7 +4246,8 @@
     "crypto-js": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/crypto-js/-/crypto-js-4.0.0.tgz",
-      "integrity": "sha512-bzHZN8Pn+gS7DQA6n+iUmBfl0hO5DJq++QP3U6uTucDtk/0iGpXd/Gg7CGR0p8tJhofJyaKoWBuJI4eAO00BBg=="
+      "integrity": "sha512-bzHZN8Pn+gS7DQA6n+iUmBfl0hO5DJq++QP3U6uTucDtk/0iGpXd/Gg7CGR0p8tJhofJyaKoWBuJI4eAO00BBg==",
+      "optional": true
     },
     "cssfilter": {
       "version": "0.0.10",
@@ -6183,6 +5838,11 @@
       "resolved": "https://registry.npmjs.org/flatted/-/flatted-2.0.2.tgz",
       "integrity": "sha512-r5wGx7YeOwNWNlCA0wQ86zKyDLMQr+/RB8xy74M4hTphfmjlijTSSXGuH8rnvKZnfT9i+75zmd8jcKdMR4O6jA==",
       "dev": true
+    },
+    "flow": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/flow/-/flow-0.2.3.tgz",
+      "integrity": "sha1-+Npl76JJEn7Jk3aiiJZXKpeV0a8="
     },
     "flush-write-stream": {
       "version": "1.1.1",
@@ -8871,21 +8531,6 @@
         "safe-buffer": "^5.0.1"
       }
     },
-    "jwks-rsa": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/jwks-rsa/-/jwks-rsa-1.9.0.tgz",
-      "integrity": "sha512-UPCfQQg0s2kF2Ju6UFJrQH73f7MaVN/hKBnYBYOp+X9KN4y6TLChhLtaXS5nRKbZqshwVdrZ9OY63m/Q9CLqcg==",
-      "dev": true,
-      "requires": {
-        "@types/express-jwt": "0.0.42",
-        "axios": "^0.19.2",
-        "debug": "^4.1.0",
-        "jsonwebtoken": "^8.5.1",
-        "limiter": "^1.1.5",
-        "lru-memoizer": "^2.1.2",
-        "ms": "^2.1.2"
-      }
-    },
     "jws": {
       "version": "3.2.2",
       "resolved": "https://registry.npmjs.org/jws/-/jws-3.2.2.tgz",
@@ -8968,22 +8613,6 @@
       "dev": true,
       "requires": {
         "assert-plus": "^1.0.0"
-      }
-    },
-    "ldapjs": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/ldapjs/-/ldapjs-2.1.1.tgz",
-      "integrity": "sha512-XzF2BEGeM/nenYDAJvkDMYovZ07fIGalrYD+suprSqUWPCWpoa+a4vWl5g8o/En85m6NHWBpirDFNClWLAd77w==",
-      "dev": true,
-      "requires": {
-        "abstract-logging": "^2.0.0",
-        "asn1": "^0.2.4",
-        "assert-plus": "^1.0.0",
-        "backoff": "^2.5.0",
-        "ldap-filter": "^0.3.3",
-        "once": "^1.4.0",
-        "vasync": "^2.2.0",
-        "verror": "^1.8.1"
       }
     },
     "lead": {
@@ -9836,18 +9465,6 @@
         "path-key": "^2.0.0"
       }
     },
-    "npmlog": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.0.2.tgz",
-      "integrity": "sha1-0DlQ4OeM4VJ7om0qdZLpNIrD518=",
-      "dev": true,
-      "requires": {
-        "are-we-there-yet": "~1.1.2",
-        "console-control-strings": "~1.1.0",
-        "gauge": "~2.7.1",
-        "set-blocking": "~2.0.0"
-      }
-    },
     "number-is-nan": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
@@ -10299,48 +9916,6 @@
         "path-platform": "~0.11.15"
       }
     },
-    "parse": {
-      "version": "2.15.0",
-      "resolved": "https://registry.npmjs.org/parse/-/parse-2.15.0.tgz",
-      "integrity": "sha512-Aupg+qd6I4X5uTacpsxROg5GlhkVn2+qOHtyOhlGj/Woi75c5cPD8kn7qhhLKcVVpe2L+HoJ+yGkMdI8IjKBKA==",
-      "dev": true,
-      "requires": {
-        "@babel/runtime": "7.10.3",
-        "@babel/runtime-corejs3": "7.10.3",
-        "crypto-js": "4.0.0",
-        "react-native-crypto-js": "1.0.0",
-        "uuid": "3.4.0",
-        "ws": "7.3.0",
-        "xmlhttprequest": "1.8.0"
-      },
-      "dependencies": {
-        "@babel/runtime": {
-          "version": "7.10.3",
-          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.10.3.tgz",
-          "integrity": "sha512-RzGO0RLSdokm9Ipe/YD+7ww8X2Ro79qiXZF3HU9ljrM+qnJmH1Vqth+hbiQZy761LnMJTMitHDuKVYTk3k4dLw==",
-          "dev": true,
-          "requires": {
-            "regenerator-runtime": "^0.13.4"
-          }
-        },
-        "@babel/runtime-corejs3": {
-          "version": "7.10.3",
-          "resolved": "https://registry.npmjs.org/@babel/runtime-corejs3/-/runtime-corejs3-7.10.3.tgz",
-          "integrity": "sha512-HA7RPj5xvJxQl429r5Cxr2trJwOfPjKiqhCXcdQPSqO2G0RHPZpXu4fkYmBaTKCp2c/jRaMK9GB/lN+7zvvFPw==",
-          "dev": true,
-          "requires": {
-            "core-js-pure": "^3.0.0",
-            "regenerator-runtime": "^0.13.4"
-          }
-        },
-        "ws": {
-          "version": "7.3.0",
-          "resolved": "https://registry.npmjs.org/ws/-/ws-7.3.0.tgz",
-          "integrity": "sha512-iFtXzngZVXPGgpTlP1rBqsUK82p9tKqsWRPg5L56egiljujJT3vGAYnHANvFxBieXrTFavhzhxW52jnaWV+w2w==",
-          "dev": true
-        }
-      }
-    },
     "parse-asn1": {
       "version": "5.1.6",
       "resolved": "https://registry.npmjs.org/parse-asn1/-/parse-asn1-5.1.6.tgz",
@@ -10422,15 +9997,15 @@
       "dev": true,
       "requires": {
         "@apollographql/graphql-playground-html": "1.6.26",
-        "@graphql-tools/links": "^6.2.4",
-        "@graphql-tools/stitch": "6.2.2",
-        "@graphql-tools/utils": "6.2.2",
+        "@graphql-tools/links": "6.2.4",
+        "@graphql-tools/stitch": "6.2.4",
+        "@graphql-tools/utils": "6.2.4",
         "@node-rs/bcrypt": "0.4.1",
-        "@parse/fs-files-adapter": "1.0.1",
-        "@parse/push-adapter": "3.3.0",
-        "@parse/s3-files-adapter": "1.5.0",
+        "@parse/fs-files-adapter": "1.2.0",
+        "@parse/push-adapter": "3.4.0",
+        "@parse/s3-files-adapter": "1.6.0",
         "@parse/simple-mailgun-adapter": "1.1.0",
-        "apollo-server-express": "2.17.0",
+        "apollo-server-express": "2.18.2",
         "bcryptjs": "2.4.3",
         "body-parser": "1.19.0",
         "commander": "5.1.0",
@@ -10444,30 +10019,437 @@
         "graphql-upload": "11.0.0",
         "intersect": "1.0.1",
         "jsonwebtoken": "8.5.1",
-        "jwks-rsa": "1.9.0",
-        "ldapjs": "2.1.1",
+        "jwks-rsa": "1.10.1",
+        "ldapjs": "2.2.0",
         "lodash": "4.17.20",
         "lru-cache": "5.1.1",
         "mime": "2.4.6",
         "mongodb": "3.6.2",
-        "parse": "2.15.0",
-        "pg-promise": "10.6.1",
+        "parse": "2.17.0",
+        "pg-promise": "10.7.0",
         "pluralize": "8.0.0",
         "redis": "3.0.2",
         "semver": "7.3.2",
         "subscriptions-transport-ws": "0.9.18",
         "tv4": "1.3.0",
-        "uuid": "8.3.0",
+        "uuid": "8.3.1",
         "winston": "3.3.3",
         "winston-daily-rotate-file": "4.5.0",
         "ws": "7.3.1"
       },
       "dependencies": {
+        "@babel/runtime": {
+          "version": "7.11.2",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.11.2.tgz",
+          "integrity": "sha512-TeWkU52so0mPtDcaCTxNBI/IHiz0pZgr8VEFqXFtZWpYD08ZB6FaSwVAS8MKRQAP3bYKiVjwysOJgMFY28o6Tw==",
+          "dev": true,
+          "requires": {
+            "regenerator-runtime": "^0.13.4"
+          }
+        },
+        "@babel/runtime-corejs3": {
+          "version": "7.11.2",
+          "resolved": "https://registry.npmjs.org/@babel/runtime-corejs3/-/runtime-corejs3-7.11.2.tgz",
+          "integrity": "sha512-qh5IR+8VgFz83VBa6OkaET6uN/mJOhHONuy3m1sgF0CV6mXdPSEBdA7e1eUbVvyNtANjMbg22JUv71BaDXLY6A==",
+          "dev": true,
+          "requires": {
+            "core-js-pure": "^3.0.0",
+            "regenerator-runtime": "^0.13.4"
+          }
+        },
+        "@graphql-tools/batch-delegate": {
+          "version": "6.2.6",
+          "resolved": "https://registry.npmjs.org/@graphql-tools/batch-delegate/-/batch-delegate-6.2.6.tgz",
+          "integrity": "sha512-QUoE9pQtkdNPFdJHSnBhZtUfr3M7pIRoXoMR+TG7DK2Y62ISKbT/bKtZEUU1/2v5uqd5WVIvw9dF8gHDSJAsSA==",
+          "dev": true,
+          "requires": {
+            "@graphql-tools/delegate": "^6.2.4",
+            "dataloader": "2.0.0",
+            "tslib": "~2.0.1"
+          }
+        },
+        "@graphql-tools/delegate": {
+          "version": "6.2.4",
+          "resolved": "https://registry.npmjs.org/@graphql-tools/delegate/-/delegate-6.2.4.tgz",
+          "integrity": "sha512-mXe6DfoWmq49kPcDrpKHgC2DSWcD5q0YCaHHoXYPAOlnLH8VMTY8BxcE8y/Do2eyg+GLcwAcrpffVszWMwqw0w==",
+          "dev": true,
+          "requires": {
+            "@ardatan/aggregate-error": "0.0.6",
+            "@graphql-tools/schema": "^6.2.4",
+            "@graphql-tools/utils": "^6.2.4",
+            "dataloader": "2.0.0",
+            "is-promise": "4.0.0",
+            "tslib": "~2.0.1"
+          }
+        },
+        "@graphql-tools/merge": {
+          "version": "6.2.5",
+          "resolved": "https://registry.npmjs.org/@graphql-tools/merge/-/merge-6.2.5.tgz",
+          "integrity": "sha512-T2UEm7L5MeS1ggbGKBkdV9kTqLqSHQM13RrjPzIAYzkFL/mK837sf+oq8h2+R8B+senuHX8akUhMTcU85kcMvw==",
+          "dev": true,
+          "requires": {
+            "@graphql-tools/schema": "^7.0.0",
+            "@graphql-tools/utils": "^7.0.0",
+            "tslib": "~2.0.1"
+          },
+          "dependencies": {
+            "@graphql-tools/schema": {
+              "version": "7.0.0",
+              "resolved": "https://registry.npmjs.org/@graphql-tools/schema/-/schema-7.0.0.tgz",
+              "integrity": "sha512-yDKgoT2+Uf3cdLYmiFB9lRIGsB6lZhILtCXHgZigYgURExrEPmfj3ZyszfEpPKYcPmKaO9FI4coDhIN0Toxl3w==",
+              "dev": true,
+              "requires": {
+                "@graphql-tools/utils": "^7.0.0",
+                "tslib": "~2.0.1"
+              }
+            },
+            "@graphql-tools/utils": {
+              "version": "7.0.2",
+              "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-7.0.2.tgz",
+              "integrity": "sha512-VQQ7krHeoXO0FS3qbWsb/vZb8c8oyiCYPIH4RSgeK9SKOUpatWYt3DW4jmLmyHZLVVMk0yjUbsOhKTBEMejKSA==",
+              "dev": true,
+              "requires": {
+                "@ardatan/aggregate-error": "0.0.6",
+                "camel-case": "4.1.1",
+                "tslib": "~2.0.1"
+              }
+            }
+          }
+        },
+        "@graphql-tools/schema": {
+          "version": "6.2.4",
+          "resolved": "https://registry.npmjs.org/@graphql-tools/schema/-/schema-6.2.4.tgz",
+          "integrity": "sha512-rh+14lSY1q8IPbEv2J9x8UBFJ5NrDX9W5asXEUlPp+7vraLp/Tiox4GXdgyA92JhwpYco3nTf5Bo2JDMt1KnAQ==",
+          "dev": true,
+          "requires": {
+            "@graphql-tools/utils": "^6.2.4",
+            "tslib": "~2.0.1"
+          }
+        },
+        "@graphql-tools/stitch": {
+          "version": "6.2.4",
+          "resolved": "https://registry.npmjs.org/@graphql-tools/stitch/-/stitch-6.2.4.tgz",
+          "integrity": "sha512-0C7PNkS7v7iAc001m7c1LPm5FUB0/DYw+s3OyCii6YYYHY8NwdI0roeOyeDGFJkFubWBQfjc3hoSyueKtU73mw==",
+          "dev": true,
+          "requires": {
+            "@graphql-tools/batch-delegate": "^6.2.4",
+            "@graphql-tools/delegate": "^6.2.4",
+            "@graphql-tools/merge": "^6.2.4",
+            "@graphql-tools/schema": "^6.2.4",
+            "@graphql-tools/utils": "^6.2.4",
+            "@graphql-tools/wrap": "^6.2.4",
+            "is-promise": "4.0.0",
+            "tslib": "~2.0.1"
+          }
+        },
+        "@graphql-tools/utils": {
+          "version": "6.2.4",
+          "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-6.2.4.tgz",
+          "integrity": "sha512-ybgZ9EIJE3JMOtTrTd2VcIpTXtDrn2q6eiYkeYMKRVh3K41+LZa6YnR2zKERTXqTWqhobROwLt4BZbw2O3Aeeg==",
+          "dev": true,
+          "requires": {
+            "@ardatan/aggregate-error": "0.0.6",
+            "camel-case": "4.1.1",
+            "tslib": "~2.0.1"
+          }
+        },
+        "@graphql-tools/wrap": {
+          "version": "6.2.4",
+          "resolved": "https://registry.npmjs.org/@graphql-tools/wrap/-/wrap-6.2.4.tgz",
+          "integrity": "sha512-cyQgpybolF9DjL2QNOvTS1WDCT/epgYoiA8/8b3nwv5xmMBQ6/6nYnZwityCZ7njb7MMyk7HBEDNNlP9qNJDcA==",
+          "dev": true,
+          "requires": {
+            "@graphql-tools/delegate": "^6.2.4",
+            "@graphql-tools/schema": "^6.2.4",
+            "@graphql-tools/utils": "^6.2.4",
+            "is-promise": "4.0.0",
+            "tslib": "~2.0.1"
+          }
+        },
+        "@parse/fs-files-adapter": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/@parse/fs-files-adapter/-/fs-files-adapter-1.2.0.tgz",
+          "integrity": "sha512-kr7Ti2eYOm14p05S86yriJdMtawL6qln3Dn5eekrwY14ih4jrjH/E+QlEpBUSBzN64fluFxciFOyjdbwDGWsGw==",
+          "dev": true
+        },
+        "@parse/node-apn": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/@parse/node-apn/-/node-apn-4.0.0.tgz",
+          "integrity": "sha512-/Zhz7+AfwuMeBn9kpENF5qbWDG1+0xLBOlAb7O34BhR9R5BSjAKkMxqWmTz3R3nvlsod4XrZ8NuRMUOXVrCCFQ==",
+          "dev": true,
+          "requires": {
+            "debug": "3.1.0",
+            "jsonwebtoken": "8.1.0",
+            "node-forge": "0.10.0",
+            "verror": "1.10.0"
+          },
+          "dependencies": {
+            "jsonwebtoken": {
+              "version": "8.1.0",
+              "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-8.1.0.tgz",
+              "integrity": "sha1-xjl80uX9WD1lwAeoPce7eOaYK4M=",
+              "dev": true,
+              "requires": {
+                "jws": "^3.1.4",
+                "lodash.includes": "^4.3.0",
+                "lodash.isboolean": "^3.0.3",
+                "lodash.isinteger": "^4.0.4",
+                "lodash.isnumber": "^3.0.3",
+                "lodash.isplainobject": "^4.0.6",
+                "lodash.isstring": "^4.0.1",
+                "lodash.once": "^4.0.0",
+                "ms": "^2.0.0",
+                "xtend": "^4.0.1"
+              }
+            }
+          }
+        },
+        "@parse/push-adapter": {
+          "version": "3.4.0",
+          "resolved": "https://registry.npmjs.org/@parse/push-adapter/-/push-adapter-3.4.0.tgz",
+          "integrity": "sha512-ZYf6DKQHpUoi806SIDiuVhstL3BRQC4brcCyTnoLih/u08Cg60Pbkz2B95JU+6xMcM211A2AvPDudEmsMahq7w==",
+          "dev": true,
+          "requires": {
+            "@parse/node-apn": "4.0.0",
+            "@parse/node-gcm": "1.0.2",
+            "npmlog": "4.1.2",
+            "parse": "2.17.0"
+          }
+        },
+        "@parse/s3-files-adapter": {
+          "version": "1.6.0",
+          "resolved": "https://registry.npmjs.org/@parse/s3-files-adapter/-/s3-files-adapter-1.6.0.tgz",
+          "integrity": "sha512-t/91hlZ4+GIA68zmJIX9lkIAxPZVRJROPYWGGyxE9CLGsSvBr/eaIHs6LnKyM012lBHzwJwoLxMkN4RvJADgbg==",
+          "dev": true,
+          "requires": {
+            "aws-sdk": "2.761.0",
+            "parse": "2.17.0"
+          }
+        },
+        "@types/cors": {
+          "version": "2.8.7",
+          "resolved": "https://registry.npmjs.org/@types/cors/-/cors-2.8.7.tgz",
+          "integrity": "sha512-sOdDRU3oRS7LBNTIqwDkPJyq0lpHYcbMTt0TrjzsXbk/e37hcLTH6eZX7CdbDeN0yJJvzw9hFBZkbtCSbk/jAQ==",
+          "dev": true,
+          "requires": {
+            "@types/express": "*"
+          }
+        },
+        "@types/express-serve-static-core": {
+          "version": "4.17.9",
+          "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.17.9.tgz",
+          "integrity": "sha512-DG0BYg6yO+ePW+XoDENYz8zhNGC3jDDEpComMYn7WJc4mY1Us8Rw9ax2YhJXxpyk2SF47PQAoQ0YyVT1a0bEkA==",
+          "dev": true,
+          "requires": {
+            "@types/node": "*",
+            "@types/qs": "*",
+            "@types/range-parser": "*"
+          }
+        },
+        "apollo-reporting-protobuf": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/apollo-reporting-protobuf/-/apollo-reporting-protobuf-0.6.1.tgz",
+          "integrity": "sha512-qr4DheFP154PGZsd93SSIS9RkqHnR5b6vT+eCloWjy3UIpY+yZ3cVLlttlIjYvOG4xTJ25XEwcHiAExatQo/7g==",
+          "dev": true,
+          "requires": {
+            "@apollo/protobufjs": "^1.0.3"
+          }
+        },
+        "apollo-server-express": {
+          "version": "2.18.2",
+          "resolved": "https://registry.npmjs.org/apollo-server-express/-/apollo-server-express-2.18.2.tgz",
+          "integrity": "sha512-9P5YOSE2amcNdkXqxqU3oulp+lpwoIBdwS2vOP69kl6ix+n7vEWHde4ulHwwl4xLdtZ88yyxgdKJEIkhaepiNw==",
+          "dev": true,
+          "requires": {
+            "@apollographql/graphql-playground-html": "1.6.26",
+            "@types/accepts": "^1.3.5",
+            "@types/body-parser": "1.19.0",
+            "@types/cors": "2.8.7",
+            "@types/express": "4.17.7",
+            "@types/express-serve-static-core": "4.17.9",
+            "accepts": "^1.3.5",
+            "apollo-server-core": "^2.18.2",
+            "apollo-server-types": "^0.6.0",
+            "body-parser": "^1.18.3",
+            "cors": "^2.8.4",
+            "express": "^4.17.1",
+            "graphql-subscriptions": "^1.0.0",
+            "graphql-tools": "^4.0.0",
+            "parseurl": "^1.3.2",
+            "subscriptions-transport-ws": "^0.9.16",
+            "type-is": "^1.6.16"
+          }
+        },
+        "apollo-server-types": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/apollo-server-types/-/apollo-server-types-0.6.1.tgz",
+          "integrity": "sha512-IEQ37aYvMLiTUzsySVLOSuvvhxuyYdhI05f3cnH6u2aN1HgGp7vX6bg+U3Ue8wbHfdcifcGIk5UEU+Q+QO6InA==",
+          "dev": true,
+          "requires": {
+            "apollo-reporting-protobuf": "^0.6.1",
+            "apollo-server-caching": "^0.5.2",
+            "apollo-server-env": "^2.4.5"
+          }
+        },
+        "debug": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "https-proxy-agent": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.0.tgz",
+          "integrity": "sha512-EkYm5BcKUGiduxzSt3Eppko+PiNWNEpa4ySk9vTC6wDsQJW9rHSa+UhGNJoRYp7bz6Ht1eaRIa6QaJqO5rCFbA==",
+          "dev": true,
+          "requires": {
+            "agent-base": "6",
+            "debug": "4"
+          },
+          "dependencies": {
+            "debug": {
+              "version": "4.2.0",
+              "resolved": "https://registry.npmjs.org/debug/-/debug-4.2.0.tgz",
+              "integrity": "sha512-IX2ncY78vDTjZMFUdmsvIRFY2Cf4FnD0wRs+nQwJU8Lu99/tPFdb0VybiiMTPe3I6rQmwsqQqRBvxU+bZ/I8sg==",
+              "dev": true,
+              "requires": {
+                "ms": "2.1.2"
+              }
+            },
+            "ms": {
+              "version": "2.1.2",
+              "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+              "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+              "dev": true
+            }
+          }
+        },
+        "jwks-rsa": {
+          "version": "1.10.1",
+          "resolved": "https://registry.npmjs.org/jwks-rsa/-/jwks-rsa-1.10.1.tgz",
+          "integrity": "sha512-UmjOsATVu7eQr17wbBCS+BSoz5LFtl57PtNXHbHFeT1WKomHykCHtn7c8inWVI7tpnsy6CZ1KOMJTgipFwXPig==",
+          "dev": true,
+          "requires": {
+            "@types/express-jwt": "0.0.42",
+            "axios": "^0.19.2",
+            "debug": "^4.1.0",
+            "http-proxy-agent": "^4.0.1",
+            "https-proxy-agent": "^5.0.0",
+            "jsonwebtoken": "^8.5.1",
+            "limiter": "^1.1.5",
+            "lru-memoizer": "^2.1.2",
+            "ms": "^2.1.2"
+          },
+          "dependencies": {
+            "debug": {
+              "version": "4.2.0",
+              "resolved": "https://registry.npmjs.org/debug/-/debug-4.2.0.tgz",
+              "integrity": "sha512-IX2ncY78vDTjZMFUdmsvIRFY2Cf4FnD0wRs+nQwJU8Lu99/tPFdb0VybiiMTPe3I6rQmwsqQqRBvxU+bZ/I8sg==",
+              "dev": true,
+              "requires": {
+                "ms": "2.1.2"
+              }
+            },
+            "ms": {
+              "version": "2.1.2",
+              "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+              "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+              "dev": true
+            }
+          }
+        },
+        "ldapjs": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/ldapjs/-/ldapjs-2.2.0.tgz",
+          "integrity": "sha512-9+ekbj97nxRYQMRgEm/HYFhFLWSRKah2PnReUfhfM5f62XBeUSFolB+AQ2Jij5tqowpksTnrdNCZLP6C+V3uag==",
+          "dev": true,
+          "requires": {
+            "abstract-logging": "^2.0.0",
+            "asn1": "^0.2.4",
+            "assert-plus": "^1.0.0",
+            "backoff": "^2.5.0",
+            "ldap-filter": "^0.3.3",
+            "once": "^1.4.0",
+            "vasync": "^2.2.0",
+            "verror": "^1.8.1"
+          }
+        },
         "mime": {
           "version": "2.4.6",
           "resolved": "https://registry.npmjs.org/mime/-/mime-2.4.6.tgz",
           "integrity": "sha512-RZKhC3EmpBchfTGBVb8fb+RL2cWyw/32lshnsETttkBAyAUXSGHxbEJWWRXc751DrIxG1q04b8QwMbAwkRPpUA==",
           "dev": true
+        },
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+          "dev": true
+        },
+        "npmlog": {
+          "version": "4.1.2",
+          "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.2.tgz",
+          "integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
+          "dev": true,
+          "requires": {
+            "are-we-there-yet": "~1.1.2",
+            "console-control-strings": "~1.1.0",
+            "gauge": "~2.7.3",
+            "set-blocking": "~2.0.0"
+          }
+        },
+        "parse": {
+          "version": "2.17.0",
+          "resolved": "https://registry.npmjs.org/parse/-/parse-2.17.0.tgz",
+          "integrity": "sha512-1hWoMNW39LH5YV3xCds9LyD8SsKD6FUwlD1Kn8ZlXNosg6WgF+s3ZSQUzT5AJ/9YPUoC/y1PoCO79FumrBYftA==",
+          "dev": true,
+          "requires": {
+            "@babel/runtime": "7.11.2",
+            "@babel/runtime-corejs3": "7.11.2",
+            "crypto-js": "4.0.0",
+            "react-native-crypto-js": "1.0.0",
+            "uuid": "3.4.0",
+            "ws": "7.3.1",
+            "xmlhttprequest": "1.8.0"
+          },
+          "dependencies": {
+            "uuid": {
+              "version": "3.4.0",
+              "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
+              "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
+              "dev": true
+            }
+          }
+        },
+        "pg": {
+          "version": "8.4.0",
+          "resolved": "https://registry.npmjs.org/pg/-/pg-8.4.0.tgz",
+          "integrity": "sha512-01LcNrAf+mBI46c78mE86I5o5KkOM942lLiSBdiCfgHTR+oUNIjh1fKClWeoPNHJz2oXe/VUSqtk1vwAQYwWEg==",
+          "dev": true,
+          "requires": {
+            "buffer-writer": "2.0.0",
+            "packet-reader": "1.0.0",
+            "pg-connection-string": "^2.4.0",
+            "pg-pool": "^3.2.1",
+            "pg-protocol": "^1.3.0",
+            "pg-types": "^2.1.0",
+            "pgpass": "1.x"
+          }
+        },
+        "pg-promise": {
+          "version": "10.7.0",
+          "resolved": "https://registry.npmjs.org/pg-promise/-/pg-promise-10.7.0.tgz",
+          "integrity": "sha512-jQui6HvPUpvnFGDo8hxJ1/4KamqRGjYan7+QApp+dA7hOv5GIJP+IRZayYqsX6+ktHqUFqxvn3se+Bd4WW/vmw==",
+          "dev": true,
+          "requires": {
+            "assert-options": "0.6.2",
+            "pg": "8.4.0",
+            "pg-minify": "1.6.1",
+            "spex": "3.0.2"
+          }
         },
         "semver": {
           "version": "7.3.2",
@@ -10475,10 +10457,16 @@
           "integrity": "sha512-OrOb32TeeambH6UrhtShmF7CRDqhL6/5XpPNp2DuRH6+9QLw/orhp72j87v8Qa1ScDkvrrBNpZcDejAirJmfXQ==",
           "dev": true
         },
+        "tslib": {
+          "version": "2.0.3",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.0.3.tgz",
+          "integrity": "sha512-uZtkfKblCEQtZKBF6EBXVZeQNl82yqtDQdv+eck8u7tdPxjLu2/lp5/uPW+um2tpuxINHWy3GhiccY7QgEaVHQ==",
+          "dev": true
+        },
         "uuid": {
-          "version": "8.3.0",
-          "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.0.tgz",
-          "integrity": "sha512-fX6Z5o4m6XsXBdli9g7DtWgAx+osMsRRZFKma1mIUsLCz6vRvv+pz5VNbyu9UEDzpMWulZfvpgb/cmDXVulYFQ==",
+          "version": "8.3.1",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.1.tgz",
+          "integrity": "sha512-FOmRr+FmWEIG8uhZv6C2bTgEVXsHk08kE7mPlrBbEe+c3r9pjceVPgupIfNIhc4yx55H69OXANrUaSuu9eInKg==",
           "dev": true
         }
       }
@@ -10619,30 +10607,6 @@
       "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns=",
       "dev": true
     },
-    "pg": {
-      "version": "8.3.3",
-      "resolved": "https://registry.npmjs.org/pg/-/pg-8.3.3.tgz",
-      "integrity": "sha512-wmUyoQM/Xzmo62wgOdQAn5tl7u+IA1ZYK7qbuppi+3E+Gj4hlUxVHjInulieWrd0SfHi/ADriTb5ILJ/lsJrSg==",
-      "dev": true,
-      "requires": {
-        "buffer-writer": "2.0.0",
-        "packet-reader": "1.0.0",
-        "pg-connection-string": "^2.3.0",
-        "pg-pool": "^3.2.1",
-        "pg-protocol": "^1.2.5",
-        "pg-types": "^2.1.0",
-        "pgpass": "1.x",
-        "semver": "4.3.2"
-      },
-      "dependencies": {
-        "semver": {
-          "version": "4.3.2",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-4.3.2.tgz",
-          "integrity": "sha1-x6BxWKgL7dBSNVt3DYLWZA+AO+c=",
-          "dev": true
-        }
-      }
-    },
     "pg-connection-string": {
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/pg-connection-string/-/pg-connection-string-2.4.0.tgz",
@@ -10666,18 +10630,6 @@
       "resolved": "https://registry.npmjs.org/pg-pool/-/pg-pool-3.2.1.tgz",
       "integrity": "sha512-BQDPWUeKenVrMMDN9opfns/kZo4lxmSWhIqo+cSAF7+lfi9ZclQbr9vfnlNaPr8wYF3UYjm5X0yPAhbcgqNOdA==",
       "dev": true
-    },
-    "pg-promise": {
-      "version": "10.6.1",
-      "resolved": "https://registry.npmjs.org/pg-promise/-/pg-promise-10.6.1.tgz",
-      "integrity": "sha512-Ahde0/04RmEPwryMcDV8ya4XXjfNWD44EuckgFPFQOIX/3smZS2ygeSXPEy4DmDxoSkSF6Y6vK8Bc4fN+bYMxg==",
-      "dev": true,
-      "requires": {
-        "assert-options": "0.6.2",
-        "pg": "8.3.3",
-        "pg-minify": "1.6.1",
-        "spex": "3.0.2"
-      }
     },
     "pg-protocol": {
       "version": "1.3.0",

--- a/package.json
+++ b/package.json
@@ -29,8 +29,9 @@
     "react-native": false
   },
   "dependencies": {
-    "@babel/runtime-corejs3": "7.12.1",
     "@babel/runtime": "7.12.1",
+    "@babel/runtime-corejs3": "7.12.1",
+    "flow": "^0.2.3",
     "react-native-crypto-js": "1.0.0",
     "uuid": "3.4.0",
     "ws": "7.3.1",

--- a/src/__tests__/encode-test.js
+++ b/src/__tests__/encode-test.js
@@ -17,7 +17,6 @@ const mockObject = function(className) {
 };
 mockObject.registerSubclass = function() {};
 mockObject.prototype = {
-  id : 'objId123',
   _getServerData() {
     return this._serverData;
   },
@@ -118,6 +117,7 @@ describe('encode', () => {
 
   it('encodes ParseObjects', () => {
     const obj = new ParseObject('Item');
+    obj.id = 'objId123';
     obj._serverData = {};
     expect(encode(obj)).toEqual('POINTER');
 

--- a/src/__tests__/encode-test.js
+++ b/src/__tests__/encode-test.js
@@ -263,4 +263,15 @@ describe('encode', () => {
       str: 'abc'
     });
   });
+
+  it('should throw an error when recursion is detected in unsaved objects', (done) => {
+    const parent = new ParseObject('Parent');
+    const child = new ParseObject('Child');
+    parent._serverData = {};
+    child._serverData = {};
+    parent.attributes = { child : child};
+    child.attributes  = {parent : parent};
+    expect(function() {encode(parent)}).toThrow("Circular recursion is not allowed on temporary Objects.");
+    done();
+  });
 });

--- a/src/__tests__/encode-test.js
+++ b/src/__tests__/encode-test.js
@@ -186,7 +186,7 @@ describe('encode', () => {
       date: {
         __type: 'Date',
         iso: '2015-02-01T00:00:00.000Z'
-      }    
+      }
     });
 
     const subobj = new ParseObject('Subitem')
@@ -198,8 +198,8 @@ describe('encode', () => {
 
     obj.attributes = {
       item : subobj
-    };  
-   
+    };
+
     expect(encode(obj)).toEqual({
       __type: 'Object',
       className: 'Item',
@@ -209,10 +209,10 @@ describe('encode', () => {
         str:'substring'
       }
     });
-    
+
     obj.attributes = {
       items : [subobj, subobj]
-    };  
+    };
     expect(encode(obj)).toEqual({
       __type: 'Object',
       className: 'Item',

--- a/src/encode.js
+++ b/src/encode.js
@@ -32,6 +32,9 @@ function encode(value: mixed, disallowObjects: boolean, forcePointers: boolean, 
       if (offline && value._getId().startsWith('local')) {
         return value.toOfflinePointer();
       }
+      if (value.id === undefined){
+        return value._toFullJSON();
+      }
       return value.toPointer();
     }
     seen = seen.concat(seenEntry);

--- a/src/encode.js
+++ b/src/encode.js
@@ -32,9 +32,18 @@ function encode(value: mixed, disallowObjects: boolean, forcePointers: boolean, 
       if (offline && value._getId().startsWith('local')) {
         return value.toOfflinePointer();
       }
-      if (value.id === undefined){
-        return value._toFullJSON();
+
+      if (value.id === undefined) {
+        if (value._temp) {
+          throw new Error("Circular recursion is not allowed on temporary Objects.");
+        }
+        if (seen.includes(value)) {
+          value._temp = true;
+        }
+        seen = seen.concat(seenEntry);
+        return value._toFullJSON(seen, offline);
       }
+
       return value.toPointer();
     }
     seen = seen.concat(seenEntry);


### PR DESCRIPTION
Converts the ParseObject `_toFullJson` when no `id` is set. So you are able to send unsaved ParseObjects to the client to unify the communication when you retrieved the data previously from third party and are not allowed to save the data in your Parse-DB.

see https://github.com/parse-community/parse-server/issues/7004 for the complete discussion.