### PR TITLE
fix(LiveQuery): Allow connect with null fields

### DIFF
--- a/integration/test/ParseLiveQueryTest.js
+++ b/integration/test/ParseLiveQueryTest.js
@@ -58,6 +58,32 @@ describe('Parse LiveQuery', () => {
     await object.save();
   });
 
+  it('can subscribe to query with null connect fields', async done => {
+    const client = new Parse.LiveQueryClient({
+      applicationId: 'integration',
+      serverURL: 'ws://localhost:1337',
+      javascriptKey: null,
+      masterKey: null,
+      sessionToken: null,
+      installationId: null,
+    });
+    client.open();
+    const object = new TestObject();
+    await object.save();
+
+    const query = new Parse.Query(TestObject);
+    query.equalTo('objectId', object.id);
+    const subscription = await client.subscribe(query);
+    subscription.on('update', async object => {
+      assert.equal(object.get('foo'), 'bar');
+      client.close();
+      done();
+    });
+    await subscription.subscribePromise;
+    object.set({ foo: 'bar' });
+    await object.save();
+  });
+
   it('can subscribe to multiple queries', async () => {
     const objectA = new TestObject();
     const objectB = new TestObject();

--- a/src/LiveQueryClient.js
+++ b/src/LiveQueryClient.js
@@ -160,10 +160,10 @@ class LiveQueryClient extends EventEmitter {
     this.requestId = 1;
     this.serverURL = serverURL;
     this.applicationId = applicationId;
-    this.javascriptKey = javascriptKey;
-    this.masterKey = masterKey;
+    this.javascriptKey = javascriptKey || undefined;
+    this.masterKey = masterKey || undefined;
     this.sessionToken = sessionToken || undefined;
-    this.installationId = installationId;
+    this.installationId = installationId || undefined;
     this.additionalProperties = true;
     this.connectPromise = resolvingPromise();
     this.subscriptions = new Map();


### PR DESCRIPTION
Fixes issue where optional field if null won't connect to the LiveQueryServer.

Fixes: https://github.com/parse-community/parse-server/pull/7099

See [LiveQuery Protocol Specification](https://github.com/parse-community/parse-server/wiki/Parse-LiveQuery-Protocol-Specification)