### PR TITLE
Add useMasterKey option to Parse.File.destroy()

### DIFF
--- a/src/ParseFile.js
+++ b/src/ParseFile.js
@@ -323,14 +323,23 @@ class ParseFile {
    * Deletes the file from the Parse cloud.
    * In Cloud Code and Node only with Master Key.
    *
+   * @param {object} options
+   *  * Valid options are:<ul>
+   *   <li>useMasterKey: In Cloud Code and Node only, causes the Master Key to
+   *     be used for this request.
+   * <pre>
    * @returns {Promise} Promise that is resolved when the delete finishes.
    */
-  destroy() {
+  destroy(options?: FullOptions = {}) {
     if (!this._name) {
       throw new ParseError(ParseError.FILE_DELETE_UNNAMED_ERROR, 'Cannot delete an unnamed file.');
     }
+    const destroyOptions = { useMasterKey: true };
+    if (options.hasOwnProperty('useMasterKey')) {
+      destroyOptions.useMasterKey = options.useMasterKey;
+    }
     const controller = CoreManager.getFileController();
-    return controller.deleteFile(this._name).then(() => {
+    return controller.deleteFile(this._name, destroyOptions).then(() => {
       this._data = null;
       this._requestTask = null;
       return this;
@@ -540,11 +549,13 @@ const DefaultController = {
     });
   },
 
-  deleteFile: function (name) {
+  deleteFile: function (name: string, options?: FullOptions) {
     const headers = {
       'X-Parse-Application-ID': CoreManager.get('APPLICATION_ID'),
-      'X-Parse-Master-Key': CoreManager.get('MASTER_KEY'),
     };
+    if (options.useMasterKey) {
+      headers['X-Parse-Master-Key'] = CoreManager.get('MASTER_KEY');
+    }
     let url = CoreManager.get('SERVER_URL');
     if (url[url.length - 1] !== '/') {
       url += '/';

--- a/src/__tests__/ParseFile-test.js
+++ b/src/__tests__/ParseFile-test.js
@@ -821,16 +821,31 @@ describe('FileController', () => {
     }
   });
 
+  it('should delete file with masterKey', async () => {
+    const file = new ParseFile('filename', [1, 2, 3]);
+    const ajax = jest.fn().mockResolvedValueOnce({ foo: 'bar' });
+    CoreManager.setRESTController({ ajax, request: () => {} });
+    CoreManager.set('MASTER_KEY', 'masterKey');
+    const result = await file.destroy({ useMasterKey: true });
+    expect(result).toEqual(file);
+    expect(ajax).toHaveBeenCalledWith('DELETE', 'https://api.parse.com/1/files/filename', '', {
+      'X-Parse-Application-ID': null,
+      'X-Parse-Master-Key': 'masterKey',
+    });
+    CoreManager.set('MASTER_KEY', null);
+  });
+
   it('should delete file', async () => {
     const file = new ParseFile('filename', [1, 2, 3]);
     const ajax = jest.fn().mockResolvedValueOnce({ foo: 'bar' });
     CoreManager.setRESTController({ ajax, request: () => {} });
-    const result = await file.destroy();
+    CoreManager.set('MASTER_KEY', 'masterKey');
+    const result = await file.destroy({ useMasterKey: false });
     expect(result).toEqual(file);
     expect(ajax).toHaveBeenCalledWith('DELETE', 'https://api.parse.com/1/files/filename', '', {
       'X-Parse-Application-ID': null,
-      'X-Parse-Master-Key': null,
     });
+    CoreManager.set('MASTER_KEY', null);
   });
 
   it('should handle delete file error', async () => {


### PR DESCRIPTION
Closes: https://github.com/parse-community/Parse-SDK-JS/issues/1272