### PR TITLE
docs: update equals method in ParseACL

### DIFF
--- a/src/ParseACL.js
+++ b/src/ParseACL.js
@@ -80,7 +80,7 @@ class ParseACL {
   /**
    * Returns whether this ACL is equal to another object
    *
-   * @param other The other object to compare to
+   * @param {ParseACL} other The other object's ACL to compare to
    * @returns {boolean}
    */
   equals(other: ParseACL): boolean {


### PR DESCRIPTION
Original description didn't have type expression for a argument. 

before

```
@param other The other object to compare to
```

after

```
@param {ParseACL} other The other object's ACL to compare to
```