### PR TITLE
fromJSON: Return date if value is a date 

### DIFF
--- a/src/__tests__/ParseObject-test.js
+++ b/src/__tests__/ParseObject-test.js
@@ -1243,7 +1243,6 @@ describe('ParseObject', () => {
     expect(o.op('count')).toBe(undefined);
   });
 
-
   it('can revert a specific field in unsaved ops', () => {
     const o = ParseObject.fromJSON({
       className: 'Item',

--- a/src/__tests__/ParseObject-test.js
+++ b/src/__tests__/ParseObject-test.js
@@ -255,11 +255,13 @@ describe('ParseObject', () => {
   });
 
   it('can be inflated from server JSON', () => {
+    const date = new Date();
     const json = {
       className: 'Item',
       createdAt: '2013-12-14T04:51:19Z',
       objectId: 'I1',
       size: 'medium',
+      date: date
     };
     const o = ParseObject.fromJSON(json);
     expect(o.className).toBe('Item');
@@ -268,8 +270,10 @@ describe('ParseObject', () => {
       size: 'medium',
       createdAt: new Date(Date.UTC(2013, 11, 14, 4, 51, 19)),
       updatedAt: new Date(Date.UTC(2013, 11, 14, 4, 51, 19)),
+      date
     });
     expect(o.dirty()).toBe(false);
+    expect(o.get('date')).toBeInstanceOf(Date);
   });
 
   it('can override old data when inflating from the server', () => {
@@ -1239,6 +1243,7 @@ describe('ParseObject', () => {
     expect(o.op('count')).toBe(undefined);
   });
 
+  
   it('can revert a specific field in unsaved ops', () => {
     const o = ParseObject.fromJSON({
       className: 'Item',

--- a/src/__tests__/ParseObject-test.js
+++ b/src/__tests__/ParseObject-test.js
@@ -1243,7 +1243,7 @@ describe('ParseObject', () => {
     expect(o.op('count')).toBe(undefined);
   });
 
-  
+
   it('can revert a specific field in unsaved ops', () => {
     const o = ParseObject.fromJSON({
       className: 'Item',

--- a/src/__tests__/ParseQuery-test.js
+++ b/src/__tests__/ParseQuery-test.js
@@ -3251,7 +3251,16 @@ describe('ParseQuery LocalDatastore', () => {
       updatedAt: new Date('2018-08-12T00:00:00.000Z'),
     };
 
-    mockLocalDatastore._serializeObjectsFromPinName.mockImplementation(() => [obj1, obj3, obj2]);
+    const obj4 = {
+      className: 'Item',
+      objectId: 'objectId3',
+      password: 123,
+      number: 4,
+      createdAt: new Date('2018-08-12T00:00:00.000Z'),
+      updatedAt: new Date('2018-08-12T00:00:00.000Z'),
+    };
+
+    mockLocalDatastore._serializeObjectsFromPinName.mockImplementation(() => [obj1, obj3, obj2, obj4]);
 
     mockLocalDatastore.checkIfEnabled.mockImplementation(() => true);
 
@@ -3262,22 +3271,16 @@ describe('ParseQuery LocalDatastore', () => {
     expect(results[0].get('number')).toEqual(2);
     expect(results[1].get('number')).toEqual(3);
     expect(results[2].get('number')).toEqual(4);
+    expect(results[3].get('number')).toEqual(4);
 
     q = new ParseQuery('Item');
     q.descending('number');
     q.fromLocalDatastore();
     results = await q.find();
     expect(results[0].get('number')).toEqual(4);
-    expect(results[1].get('number')).toEqual(3);
-    expect(results[2].get('number')).toEqual(2);
-
-    q = new ParseQuery('Item');
-    q.descending('number');
-    q.fromLocalDatastore();
-    results = await q.find();
-    expect(results[0].get('number')).toEqual(4);
-    expect(results[1].get('number')).toEqual(3);
-    expect(results[2].get('number')).toEqual(2);
+    expect(results[1].get('number')).toEqual(4);
+    expect(results[2].get('number')).toEqual(3);
+    expect(results[3].get('number')).toEqual(2);
 
     q = new ParseQuery('Item');
     q.ascending('_created_at');

--- a/src/__tests__/ParseQuery-test.js
+++ b/src/__tests__/ParseQuery-test.js
@@ -3251,7 +3251,7 @@ describe('ParseQuery LocalDatastore', () => {
       updatedAt: new Date('2018-08-12T00:00:00.000Z'),
     };
 
-    mockLocalDatastore._serializeObjectsFromPinName.mockImplementation(() => [obj1, obj2, obj3]);
+    mockLocalDatastore._serializeObjectsFromPinName.mockImplementation(() => [obj1, obj3, obj2]);
 
     mockLocalDatastore.checkIfEnabled.mockImplementation(() => true);
 
@@ -3280,7 +3280,7 @@ describe('ParseQuery LocalDatastore', () => {
     expect(results[2].get('number')).toEqual(2);
 
     q = new ParseQuery('Item');
-    q.descending('_created_at');
+    q.ascending('_created_at');
     q.fromLocalDatastore();
     results = await q.find();
     expect(results[0].get('number')).toEqual(2);
@@ -3288,7 +3288,7 @@ describe('ParseQuery LocalDatastore', () => {
     expect(results[2].get('number')).toEqual(4);
 
     q = new ParseQuery('Item');
-    q.descending('_updated_at');
+    q.ascending('_updated_at');
     q.fromLocalDatastore();
     results = await q.find();
     expect(results[0].get('number')).toEqual(2);

--- a/src/__tests__/ParseQuery-test.js
+++ b/src/__tests__/ParseQuery-test.js
@@ -3253,7 +3253,7 @@ describe('ParseQuery LocalDatastore', () => {
 
     const obj4 = {
       className: 'Item',
-      objectId: 'objectId3',
+      objectId: 'objectId4',
       password: 123,
       number: 4,
       createdAt: new Date('2018-08-12T00:00:00.000Z'),

--- a/src/decode.js
+++ b/src/decode.js
@@ -17,7 +17,7 @@ import { opFromJSON } from './ParseOp';
 import ParseRelation from './ParseRelation';
 
 export default function decode(value: any): any {
-  if (value === null || typeof value !== 'object') {
+  if (value === null || typeof value !== 'object' || value instanceof Date) {
     return value;
   }
   if (Array.isArray(value)) {


### PR DESCRIPTION
Not sure how often this error would occur, but if you try to create a `ParseObject` with `fromJSON` with a Date, the date field is returned as `{}`

[Related](https://github.com/parse-community/parse-server/issues/7082)


Evidently, this bug also affects the localDataStore tests as:

descending date order should be larger (newer) to smaller (older)

Obj1: createdAt: new Date('2018-08-10T00:00:00.000Z'),
Obj2: createdAt: new Date('2018-08-11T00:00:00.000Z'),
Obj3: createdAt: new Date('2018-08-12T00:00:00.000Z'),

So, this test:

```
    q = new ParseQuery('Item');
    q.descending('_created_at');
    q.fromLocalDatastore();
    results = await q.find();
```

Should return Obj3, Obj2, Obj1. Instead, it returns Obj1, Obj2, then Obj3.

If this doesn't make sense, if you change the order that the objects are loaded [here](https://github.com/parse-community/Parse-SDK-JS/blob/d40f1505a29ae0080d6094f5557f4f372f14a428/src/__tests__/ParseQuery-test.js#L3254) (e.g to Obj2, Obj3, Obj1), the tests will fail on the current master.

