### PR TITLE
feat: Add option to return raw json from queries

### DIFF
--- a/integration/test/ParseQueryTest.js
+++ b/integration/test/ParseQueryTest.js
@@ -48,6 +48,30 @@ describe('Parse Query', () => {
       .catch(done.fail);
   });
 
+  it('can return raw json from queries', async () => {
+    const object = new TestObject({ foo: 'bar' });
+    await object.save();
+
+    const query = new Parse.Query(TestObject);
+    const results = await query.find({ json: true });
+    assert.strictEqual(results[0] instanceof Parse.Object, false);
+    assert.strictEqual(results[0].foo, 'bar');
+    assert.strictEqual(results[0].className, 'TestObject');
+    assert.strictEqual(results[0].objectId, object.id);
+
+    let result = await query.first({ json: true });
+    assert.strictEqual(result instanceof Parse.Object, false);
+    assert.strictEqual(result.foo, 'bar');
+    assert.strictEqual(result.className, 'TestObject');
+    assert.strictEqual(result.objectId, object.id);
+
+    result = await query.get(object.id, { json: true });
+    assert.strictEqual(result instanceof Parse.Object, false);
+    assert.strictEqual(result.foo, 'bar');
+    assert.strictEqual(result.className, 'TestObject');
+    assert.strictEqual(result.objectId, object.id);
+  });
+
   it('can do query with count', async () => {
     const items = [];
     for (let i = 0; i < 4; i++) {

--- a/src/ParseQuery.js
+++ b/src/ParseQuery.js
@@ -601,6 +601,7 @@ class ParseQuery {
    *   <li>sessionToken: A valid session token, used for making a request on
    *       behalf of a specific user.
    *   <li>context: A dictionary that is accessible in Cloud Code `beforeFind` trigger.
+   *   <li>json: Return raw json without converting to Parse.Object
    * </ul>
    *
    * @returns {Promise} A promise that is resolved with the result when
@@ -618,6 +619,9 @@ class ParseQuery {
     }
     if (options && options.hasOwnProperty('context') && typeof options.context === 'object') {
       firstOptions.context = options.context;
+    }
+    if (options && options.hasOwnProperty('json')) {
+      firstOptions.json = options.json;
     }
 
     return this.first(firstOptions).then(response => {
@@ -640,6 +644,7 @@ class ParseQuery {
    *   <li>sessionToken: A valid session token, used for making a request on
    *       behalf of a specific user.
    *   <li>context: A dictionary that is accessible in Cloud Code `beforeFind` trigger.
+   *   <li>json: Return raw json without converting to Parse.Object
    * </ul>
    *
    * @returns {Promise} A promise that is resolved with the results when
@@ -686,8 +691,11 @@ class ParseQuery {
         if (select) {
           handleSelectResult(data, select);
         }
-
-        return ParseObject.fromJSON(data, !select);
+        if (options.json) {
+          return data;
+        } else {
+          return ParseObject.fromJSON(data, !select);
+        }
       });
 
       const count = response.count;
@@ -849,6 +857,7 @@ class ParseQuery {
    *   <li>sessionToken: A valid session token, used for making a request on
    *       behalf of a specific user.
    *   <li>context: A dictionary that is accessible in Cloud Code `beforeFind` trigger.
+   *   <li>json: Return raw json without converting to Parse.Object
    * </ul>
    *
    * @returns {Promise} A promise that is resolved with the object when
@@ -900,8 +909,11 @@ class ParseQuery {
       if (select) {
         handleSelectResult(objects[0], select);
       }
-
-      return ParseObject.fromJSON(objects[0], !select);
+      if (options.json) {
+        return objects[0];
+      } else {
+        return ParseObject.fromJSON(objects[0], !select);
+      }
     });
   }
 

--- a/src/__tests__/ParseQuery-test.js
+++ b/src/__tests__/ParseQuery-test.js
@@ -1341,6 +1341,43 @@ describe('ParseQuery', () => {
     });
   });
 
+  it('can return raw json from query', async () => {
+    CoreManager.setQueryController({
+      aggregate() {},
+      find() {
+        return Promise.resolve({
+          results: [
+            {
+              objectId: 'I1',
+              size: 'small',
+              name: 'Product 3',
+            },
+          ],
+        });
+      },
+    });
+
+    const q = new ParseQuery('Item');
+    q.equalTo('size', 'small');
+    const results = await q.find({ json: true });
+    expect(results[0].objectId).toBe('I1');
+    expect(results[0].size).toBe('small');
+    expect(results[0].name).toEqual('Product 3');
+    expect(results[0].className).toEqual('Item');
+
+    let result = await q.first({ json: true });
+    expect(result.objectId).toBe('I1');
+    expect(result.size).toBe('small');
+    expect(result.name).toEqual('Product 3');
+    expect(result.className).toEqual('Item');
+
+    result = await q.get(result.objectId, { json: true });
+    expect(result.objectId).toBe('I1');
+    expect(result.size).toBe('small');
+    expect(result.name).toEqual('Product 3');
+    expect(result.className).toEqual('Item');
+  });
+
   it('will error when getting a nonexistent object', done => {
     CoreManager.setQueryController({
       aggregate() {},
@@ -3260,7 +3297,12 @@ describe('ParseQuery LocalDatastore', () => {
       updatedAt: new Date('2018-08-12T00:00:00.000Z'),
     };
 
-    mockLocalDatastore._serializeObjectsFromPinName.mockImplementation(() => [obj1, obj3, obj2, obj4]);
+    mockLocalDatastore._serializeObjectsFromPinName.mockImplementation(() => [
+      obj1,
+      obj3,
+      obj2,
+      obj4,
+    ]);
 
     mockLocalDatastore.checkIfEnabled.mockImplementation(() => true);
 


### PR DESCRIPTION
Mimics [options](https://github.com/parse-community/parse-php-sdk/pull/423) in PHP SDK.

Works for get, find and first queries.