### PR TITLE
Allow fromJSON to set keys to dirty

### DIFF
--- a/integration/test/ParseObjectTest.js
+++ b/integration/test/ParseObjectTest.js
@@ -2012,6 +2012,7 @@ describe('Parse Object', () => {
     const fetched = await query.get(user.id);
     assert.equal(fetched.isDataAvailable(), true);
   });
+
   it('from json save data', async () => {
     const json = {
       className: 'TestObject',

--- a/integration/test/ParseObjectTest.js
+++ b/integration/test/ParseObjectTest.js
@@ -2012,4 +2012,32 @@ describe('Parse Object', () => {
     const fetched = await query.get(user.id);
     assert.equal(fetched.isDataAvailable(), true);
   });
+  it('from json save data', async () => {
+    const json = {
+      className: 'TestObject',
+      date: new Date(),
+      array: [],
+      object: {},
+      string: '',
+    };
+    const obj = Parse.Object.fromJSON(json, false, true);
+    expect(obj.get('date')).toBeDefined();
+    expect(obj.get('date')).toBeInstanceOf(Date);
+    expect(obj.get('array')).toBeDefined();
+    expect(obj.get('array')).toBeInstanceOf(Array);
+    expect(obj.get('object')).toBeDefined();
+    expect(obj.get('object')).toBeInstanceOf(Object);
+    expect(obj.get('string')).toBeDefined();
+    expect(obj.get('string')).toBeInstanceOf(String);
+    await obj.save();
+    await obj.fetch();
+    expect(obj.get('date')).toBeDefined();
+    expect(obj.get('date')).toBeInstanceOf(Date);
+    expect(obj.get('array')).toBeDefined();
+    expect(obj.get('array')).toBeInstanceOf(Array);
+    expect(obj.get('object')).toBeDefined();
+    expect(obj.get('object')).toBeInstanceOf(Object);
+    expect(obj.get('string')).toBeDefined();
+    expect(obj.get('string')).toBeInstanceOf(String);
+  });
 });

--- a/src/ParseObject.js
+++ b/src/ParseObject.js
@@ -1766,6 +1766,7 @@ class ParseObject {
     for (const attr in json) {
       if (attr !== 'className' && attr !== '__type') {
         otherAttributes[attr] = json[attr];
+        if (dirty) {
           o.set(attr, json[attr])
         }
       }

--- a/src/ParseObject.js
+++ b/src/ParseObject.js
@@ -1838,7 +1838,7 @@ class ParseObject {
       if (attr !== 'className' && attr !== '__type') {
         otherAttributes[attr] = json[attr];
         if (dirty) {
-          o.set(attr, json[attr])
+          o.set(attr, json[attr]);
         }
       }
     }

--- a/src/ParseObject.js
+++ b/src/ParseObject.js
@@ -1752,10 +1752,11 @@ class ParseObject {
    * @param {object} json The JSON map of the Object's data
    * @param {boolean} override In single instance mode, all old server data
    *   is overwritten if this is set to true
+   * @param {boolean} dirty Whether the Parse.Object should set JSON keys to dirty
    * @static
    * @returns {Parse.Object} A Parse.Object reference
    */
-  static fromJSON(json: any, override?: boolean) {
+  static fromJSON(json: any, override?: boolean, dirty?: boolean) {
     if (!json.className) {
       throw new Error('Cannot create an object without a className');
     }
@@ -1765,6 +1766,8 @@ class ParseObject {
     for (const attr in json) {
       if (attr !== 'className' && attr !== '__type') {
         otherAttributes[attr] = json[attr];
+          o.set(attr, json[attr])
+        }
       }
     }
     if (override) {

--- a/src/__tests__/ParseObject-test.js
+++ b/src/__tests__/ParseObject-test.js
@@ -1243,7 +1243,6 @@ describe('ParseObject', () => {
     expect(o.op('count')).toBe(undefined);
   });
 
-
   it('can revert a specific field in unsaved ops', () => {
     const o = ParseObject.fromJSON({
       className: 'Item',

--- a/src/__tests__/ParseObject-test.js
+++ b/src/__tests__/ParseObject-test.js
@@ -255,11 +255,13 @@ describe('ParseObject', () => {
   });
 
   it('can be inflated from server JSON', () => {
+    const date = new Date();
     const json = {
       className: 'Item',
       createdAt: '2013-12-14T04:51:19Z',
       objectId: 'I1',
       size: 'medium',
+      date: date
     };
     const o = ParseObject.fromJSON(json);
     expect(o.className).toBe('Item');
@@ -268,8 +270,10 @@ describe('ParseObject', () => {
       size: 'medium',
       createdAt: new Date(Date.UTC(2013, 11, 14, 4, 51, 19)),
       updatedAt: new Date(Date.UTC(2013, 11, 14, 4, 51, 19)),
+      date
     });
     expect(o.dirty()).toBe(false);
+    expect(o.get('date')).toBeInstanceOf(Date);
   });
 
   it('can override old data when inflating from the server', () => {
@@ -1239,6 +1243,7 @@ describe('ParseObject', () => {
     expect(o.op('count')).toBe(undefined);
   });
 
+  
   it('can revert a specific field in unsaved ops', () => {
     const o = ParseObject.fromJSON({
       className: 'Item',

--- a/src/__tests__/ParseObject-test.js
+++ b/src/__tests__/ParseObject-test.js
@@ -276,6 +276,50 @@ describe('ParseObject', () => {
     expect(o.get('date')).toBeInstanceOf(Date);
   });
 
+  it('can be inflated from server JSON', () => {
+    const date = new Date();
+    const json = {
+      className: 'Item',
+      createdAt: '2013-12-14T04:51:19Z',
+      objectId: 'I1',
+      size: 'medium',
+      date: date
+    };
+    const o = ParseObject.fromJSON(json);
+    expect(o.className).toBe('Item');
+    expect(o.id).toBe('I1');
+    expect(o.attributes).toEqual({
+      size: 'medium',
+      createdAt: new Date(Date.UTC(2013, 11, 14, 4, 51, 19)),
+      updatedAt: new Date(Date.UTC(2013, 11, 14, 4, 51, 19)),
+      date
+    });
+    expect(o.dirty()).toBe(false);
+    expect(o.get('date')).toBeInstanceOf(Date);
+  });
+
+  it('can be dirty with fromJSON', () => {
+    const date = new Date();
+    const json = {
+      className: 'Item',
+      createdAt: '2013-12-14T04:51:19Z',
+      objectId: 'I1',
+      size: 'medium',
+      date: date
+    };
+    const o = ParseObject.fromJSON(json, false, true);
+    expect(o.className).toBe('Item');
+    expect(o.id).toBe('I1');
+    expect(o.attributes).toEqual({
+      size: 'medium',
+      createdAt: new Date(Date.UTC(2013, 11, 14, 4, 51, 19)),
+      updatedAt: new Date(Date.UTC(2013, 11, 14, 4, 51, 19)),
+      date
+    });
+    expect(o.dirty()).toBe(true);
+    expect(o.dirtyKeys()).toEqual([ 'size', 'date' ]);
+  });
+
   it('can override old data when inflating from the server', () => {
     const o = ParseObject.fromJSON({
       className: 'Item',

--- a/src/__tests__/ParseObject-test.js
+++ b/src/__tests__/ParseObject-test.js
@@ -276,28 +276,6 @@ describe('ParseObject', () => {
     expect(o.get('date')).toBeInstanceOf(Date);
   });
 
-  it('can be inflated from server JSON', () => {
-    const date = new Date();
-    const json = {
-      className: 'Item',
-      createdAt: '2013-12-14T04:51:19Z',
-      objectId: 'I1',
-      size: 'medium',
-      date: date
-    };
-    const o = ParseObject.fromJSON(json);
-    expect(o.className).toBe('Item');
-    expect(o.id).toBe('I1');
-    expect(o.attributes).toEqual({
-      size: 'medium',
-      createdAt: new Date(Date.UTC(2013, 11, 14, 4, 51, 19)),
-      updatedAt: new Date(Date.UTC(2013, 11, 14, 4, 51, 19)),
-      date
-    });
-    expect(o.dirty()).toBe(false);
-    expect(o.get('date')).toBeInstanceOf(Date);
-  });
-
   it('can be dirty with fromJSON', () => {
     const date = new Date();
     const json = {

--- a/src/__tests__/ParseObject-test.js
+++ b/src/__tests__/ParseObject-test.js
@@ -262,7 +262,7 @@ describe('ParseObject', () => {
       createdAt: '2013-12-14T04:51:19Z',
       objectId: 'I1',
       size: 'medium',
-      date: date
+      date: date,
     };
     const o = ParseObject.fromJSON(json);
     expect(o.className).toBe('Item');
@@ -271,7 +271,7 @@ describe('ParseObject', () => {
       size: 'medium',
       createdAt: new Date(Date.UTC(2013, 11, 14, 4, 51, 19)),
       updatedAt: new Date(Date.UTC(2013, 11, 14, 4, 51, 19)),
-      date
+      date,
     });
     expect(o.dirty()).toBe(false);
     expect(o.get('date')).toBeInstanceOf(Date);
@@ -284,7 +284,7 @@ describe('ParseObject', () => {
       createdAt: '2013-12-14T04:51:19Z',
       objectId: 'I1',
       size: 'medium',
-      date: date
+      date: date,
     };
     const o = ParseObject.fromJSON(json, false, true);
     expect(o.className).toBe('Item');
@@ -293,10 +293,10 @@ describe('ParseObject', () => {
       size: 'medium',
       createdAt: new Date(Date.UTC(2013, 11, 14, 4, 51, 19)),
       updatedAt: new Date(Date.UTC(2013, 11, 14, 4, 51, 19)),
-      date
+      date,
     });
     expect(o.dirty()).toBe(true);
-    expect(o.dirtyKeys()).toEqual([ 'size', 'date' ]);
+    expect(o.dirtyKeys()).toEqual(['size', 'date']);
   });
 
   it('can override old data when inflating from the server', () => {

--- a/src/__tests__/ParseObject-test.js
+++ b/src/__tests__/ParseObject-test.js
@@ -1243,7 +1243,7 @@ describe('ParseObject', () => {
     expect(o.op('count')).toBe(undefined);
   });
 
-  
+
   it('can revert a specific field in unsaved ops', () => {
     const o = ParseObject.fromJSON({
       className: 'Item',

--- a/src/__tests__/ParseQuery-test.js
+++ b/src/__tests__/ParseQuery-test.js
@@ -3251,7 +3251,16 @@ describe('ParseQuery LocalDatastore', () => {
       updatedAt: new Date('2018-08-12T00:00:00.000Z'),
     };
 
-    mockLocalDatastore._serializeObjectsFromPinName.mockImplementation(() => [obj1, obj3, obj2]);
+    const obj4 = {
+      className: 'Item',
+      objectId: 'objectId3',
+      password: 123,
+      number: 4,
+      createdAt: new Date('2018-08-12T00:00:00.000Z'),
+      updatedAt: new Date('2018-08-12T00:00:00.000Z'),
+    };
+
+    mockLocalDatastore._serializeObjectsFromPinName.mockImplementation(() => [obj1, obj3, obj2, obj4]);
 
     mockLocalDatastore.checkIfEnabled.mockImplementation(() => true);
 
@@ -3262,22 +3271,16 @@ describe('ParseQuery LocalDatastore', () => {
     expect(results[0].get('number')).toEqual(2);
     expect(results[1].get('number')).toEqual(3);
     expect(results[2].get('number')).toEqual(4);
+    expect(results[3].get('number')).toEqual(4);
 
     q = new ParseQuery('Item');
     q.descending('number');
     q.fromLocalDatastore();
     results = await q.find();
     expect(results[0].get('number')).toEqual(4);
-    expect(results[1].get('number')).toEqual(3);
-    expect(results[2].get('number')).toEqual(2);
-
-    q = new ParseQuery('Item');
-    q.descending('number');
-    q.fromLocalDatastore();
-    results = await q.find();
-    expect(results[0].get('number')).toEqual(4);
-    expect(results[1].get('number')).toEqual(3);
-    expect(results[2].get('number')).toEqual(2);
+    expect(results[1].get('number')).toEqual(4);
+    expect(results[2].get('number')).toEqual(3);
+    expect(results[3].get('number')).toEqual(2);
 
     q = new ParseQuery('Item');
     q.ascending('_created_at');

--- a/src/__tests__/ParseQuery-test.js
+++ b/src/__tests__/ParseQuery-test.js
@@ -3251,7 +3251,7 @@ describe('ParseQuery LocalDatastore', () => {
       updatedAt: new Date('2018-08-12T00:00:00.000Z'),
     };
 
-    mockLocalDatastore._serializeObjectsFromPinName.mockImplementation(() => [obj1, obj2, obj3]);
+    mockLocalDatastore._serializeObjectsFromPinName.mockImplementation(() => [obj1, obj3, obj2]);
 
     mockLocalDatastore.checkIfEnabled.mockImplementation(() => true);
 
@@ -3280,7 +3280,7 @@ describe('ParseQuery LocalDatastore', () => {
     expect(results[2].get('number')).toEqual(2);
 
     q = new ParseQuery('Item');
-    q.descending('_created_at');
+    q.ascending('_created_at');
     q.fromLocalDatastore();
     results = await q.find();
     expect(results[0].get('number')).toEqual(2);
@@ -3288,7 +3288,7 @@ describe('ParseQuery LocalDatastore', () => {
     expect(results[2].get('number')).toEqual(4);
 
     q = new ParseQuery('Item');
-    q.descending('_updated_at');
+    q.ascending('_updated_at');
     q.fromLocalDatastore();
     results = await q.find();
     expect(results[0].get('number')).toEqual(2);

--- a/src/__tests__/ParseQuery-test.js
+++ b/src/__tests__/ParseQuery-test.js
@@ -3260,7 +3260,12 @@ describe('ParseQuery LocalDatastore', () => {
       updatedAt: new Date('2018-08-12T00:00:00.000Z'),
     };
 
-    mockLocalDatastore._serializeObjectsFromPinName.mockImplementation(() => [obj1, obj3, obj2, obj4]);
+    mockLocalDatastore._serializeObjectsFromPinName.mockImplementation(() => [
+      obj1,
+      obj3,
+      obj2,
+      obj4,
+    ]);
 
     mockLocalDatastore.checkIfEnabled.mockImplementation(() => true);
 

--- a/src/__tests__/ParseQuery-test.js
+++ b/src/__tests__/ParseQuery-test.js
@@ -3253,7 +3253,7 @@ describe('ParseQuery LocalDatastore', () => {
 
     const obj4 = {
       className: 'Item',
-      objectId: 'objectId3',
+      objectId: 'objectId4',
       password: 123,
       number: 4,
       createdAt: new Date('2018-08-12T00:00:00.000Z'),

--- a/src/decode.js
+++ b/src/decode.js
@@ -17,7 +17,7 @@ import { opFromJSON } from './ParseOp';
 import ParseRelation from './ParseRelation';
 
 export default function decode(value: any): any {
-  if (value === null || typeof value !== 'object') {
+  if (value === null || typeof value !== 'object' || value instanceof Date) {
     return value;
   }
   if (Array.isArray(value)) {


### PR DESCRIPTION
Currently, there is no way to save fields to a Parse.Object using `fromJSON`, as `dirtyKeys` doesn't get set.

This can be confusing as at first glance, you would expect the keys to be set as they are defined. However, after the object is fetched, the keys will be null.

```
it('from json save data', async (done) => {
    const json = {
      className : 'TestObject',
      date: new Date(),
      array: [],
      object: {},
      string: ''
    }
    const obj = Parse.Object.fromJSON(json);
    expect(obj.get('date')).toBeDefined()
    expect(obj.get('date')).toBeInstanceOf(Date);
    expect(obj.get('array')).toBeDefined()
    expect(obj.get('array')).toBeInstanceOf(Array);
    expect(obj.get('object')).toBeDefined()
    expect(obj.get('object')).toBeInstanceOf(Object);
    expect(obj.get('string')).toBeDefined()
    expect(obj.get('string')).toBeInstanceOf(String);
    await obj.save();
    // all keys are defined


    await obj.fetch();
    // only created at and updated at are defined
    expect(obj.get('date')).toBeDefined()
    expect(obj.get('date')).toBeInstanceOf(Date);
    expect(obj.get('array')).toBeDefined()
    expect(obj.get('array')).toBeInstanceOf(Array);
    expect(obj.get('object')).toBeDefined()
    expect(obj.get('object')).toBeInstanceOf(Object);
    expect(obj.get('string')).toBeDefined()
    expect(obj.get('string')).toBeInstanceOf(String);
    done();
  });
```

This PR allows a 3rd parameter to `fromJSON`, where you can specify whether the keys should be set to dirty.

```js
    const json = {
      className : 'TestObject',
      date: new Date(),
      array: [],
      object: {},
      string: ''
    }
    const obj = Parse.Object.fromJSON(json, false, true);
    // now keys will be dirty
```

Properly closes #161 and #482