### PR TITLE
Support PushStatus on Parse.Push

### DIFF
--- a/integration/test/ParsePushTest.js
+++ b/integration/test/ParsePushTest.js
@@ -1,0 +1,15 @@
+'use strict';
+
+const Parse = require('../../node');
+
+describe('Parse Push', () => {
+  it('can get pushStatusId', async () => {
+    const payload = {
+      data: { alert: 'We return status!' },
+      where: { deviceType: { $eq: 'random' } },
+    };
+    const pushStatusId = await Parse.Push.send(payload, { useMasterKey: true });
+    const pushStatus = await Parse.Push.getPushStatus(pushStatusId, { useMasterKey: true });
+    expect(pushStatus.id).toBe(pushStatusId);
+  });
+});

--- a/integration/test/helper.js
+++ b/integration/test/helper.js
@@ -36,6 +36,12 @@ const defaultConfiguration = {
   },
   verbose: false,
   silent: true,
+  push: {
+    android: {
+      senderId: 'yolo',
+      apiKey: 'yolo',
+    },
+  },
   idempotencyOptions: {
     paths: ['functions/CloudFunctionIdempotency', 'jobs/CloudJob1', 'classes/IdempotentTest'],
     ttl: 120,

--- a/src/Push.js
+++ b/src/Push.js
@@ -13,6 +13,7 @@ import CoreManager from './CoreManager';
 import ParseQuery from './ParseQuery';
 
 import type { WhereClause } from './ParseQuery';
+import type { FullOptions } from './RESTController';
 
 export type PushData = {
   where?: WhereClause | ParseQuery,
@@ -37,7 +38,7 @@ export type PushData = {
  *
  * @function send
  * @name Parse.Push.send
- * @param {object} data -  The data of the push notification.  Valid fields
+ * @param {object} data -  The data of the push notification. Valid fields
  * are:
  *   <ol>
  *     <li>channels - An Array of channels to push to.</li>
@@ -49,10 +50,15 @@ export type PushData = {
  *         a set of installations to push to.</li>
  *     <li>data - The data to send as part of the push.</li>
  *   <ol>
+ * @param {object} options Valid options
+ * are:<ul>
+ *   <li>useMasterKey: In Cloud Code and Node only, causes the Master Key to
+ *     be used for this request.
+ * </ul>
  * @returns {Promise} A promise that is fulfilled when the push request
  *     completes.
  */
-export function send(data: PushData): Promise {
+export function send(data: PushData, options?: FullOptions = {}): Promise {
   if (data.where && data.where instanceof ParseQuery) {
     data.where = data.where.toJSON().where;
   }
@@ -69,14 +75,39 @@ export function send(data: PushData): Promise {
     throw new Error('expiration_time and expiration_interval cannot both be set.');
   }
 
-  return CoreManager.getPushController().send(data);
+  const pushOptions = { useMasterKey: true };
+  if (options.hasOwnProperty('useMasterKey')) {
+    pushOptions.useMasterKey = options.useMasterKey;
+  }
+
+  return CoreManager.getPushController().send(data, pushOptions);
+}
+
+/**
+ * Gets push status by Id
+ *
+ * @function getPushStatus
+ * @name Parse.Push.getPushStatus
+ * @param {string} pushStatusId The Id of Push Status.
+ * @param {object} options Valid options
+ * are:<ul>
+ *   <li>useMasterKey: In Cloud Code and Node only, causes the Master Key to
+ *     be used for this request.
+ * </ul>
+ * @returns {Parse.Object} Status of Push.
+ */
+export function getPushStatus(pushStatusId: string, options?: FullOptions = {}): Promise<string> {
+  const pushOptions = { useMasterKey: true };
+  if (options.hasOwnProperty('useMasterKey')) {
+    pushOptions.useMasterKey = options.useMasterKey;
+  }
+  const query = new ParseQuery('_PushStatus');
+  return query.get(pushStatusId, pushOptions);
 }
 
 const DefaultController = {
-  send(data: PushData) {
-    return CoreManager.getRESTController().request('POST', 'push', data, {
-      useMasterKey: true,
-    });
+  send(data: PushData, options?: FullOptions) {
+    return CoreManager.getRESTController().request('POST', 'push', data, options);
   },
 };
 

--- a/src/RESTController.js
+++ b/src/RESTController.js
@@ -122,6 +122,9 @@ const RESTController = {
               if ((xhr.getAllResponseHeaders() || '').includes('x-parse-job-status-id: ')) {
                 response = xhr.getResponseHeader('x-parse-job-status-id');
               }
+              if ((xhr.getAllResponseHeaders() || '').includes('x-parse-push-status-id: ')) {
+                response = xhr.getResponseHeader('x-parse-push-status-id');
+              }
             }
           } catch (e) {
             promise.reject(e.toString());

--- a/src/__tests__/Cloud-test.js
+++ b/src/__tests__/Cloud-test.js
@@ -14,9 +14,11 @@ jest.dontMock('../encode');
 jest.dontMock('../ParseError');
 jest.dontMock('../ParseObject');
 jest.dontMock('../ParseQuery');
+jest.dontMock('../Push');
 
 const Cloud = require('../Cloud');
 const CoreManager = require('../CoreManager');
+const Push = require('../Push');
 
 const defaultController = CoreManager.getCloudController();
 
@@ -303,5 +305,49 @@ describe('CloudController', () => {
       },
     });
     expect(options.useMasterKey).toBe(true);
+  });
+
+  it('can get push status', async () => {
+    const request = jest.fn();
+    request.mockReturnValue(
+      Promise.resolve({
+        results: [{ className: '_PushStatus', objectId: 'pushId1234' }],
+      })
+    );
+    CoreManager.setRESTController({ request: request, ajax: jest.fn() });
+
+    await Push.getPushStatus('pushId1234');
+    const [method, path, data, options] = request.mock.calls[0];
+    expect(method).toBe('GET');
+    expect(path).toBe('classes/_PushStatus');
+    expect(data).toEqual({
+      limit: 1,
+      where: {
+        objectId: 'pushId1234',
+      },
+    });
+    expect(options.useMasterKey).toBe(true);
+  });
+
+  it('can get push status with masterKey', async () => {
+    const request = jest.fn();
+    request.mockReturnValue(
+      Promise.resolve({
+        results: [{ className: '_PushStatus', objectId: 'pushId1234' }],
+      })
+    );
+    CoreManager.setRESTController({ request: request, ajax: jest.fn() });
+
+    await Push.getPushStatus('pushId1234', { useMasterKey: false });
+    const [method, path, data, options] = request.mock.calls[0];
+    expect(method).toBe('GET');
+    expect(path).toBe('classes/_PushStatus');
+    expect(data).toEqual({
+      limit: 1,
+      where: {
+        objectId: 'pushId1234',
+      },
+    });
+    expect(options.useMasterKey).toBe(false);
   });
 });

--- a/src/__tests__/RESTController-test.js
+++ b/src/__tests__/RESTController-test.js
@@ -242,6 +242,29 @@ describe('RESTController', () => {
     expect(response).toBe(1234);
   });
 
+  it('handles x-parse-push-status-id header', async () => {
+    const XHR = function () {};
+    XHR.prototype = {
+      open: function () {},
+      setRequestHeader: function () {},
+      getResponseHeader: function () {
+        return 1234;
+      },
+      send: function () {
+        this.status = 200;
+        this.responseText = '{}';
+        this.readyState = 4;
+        this.onreadystatechange();
+      },
+      getAllResponseHeaders: function () {
+        return 'x-parse-push-status-id: 1234';
+      },
+    };
+    RESTController._setXHR(XHR);
+    const response = await RESTController.request('POST', 'push', {}, {});
+    expect(response).toBe(1234);
+  });
+
   it('handles invalid header', async () => {
     const XHR = function () {};
     XHR.prototype = {


### PR DESCRIPTION
Similar to how jobStatus is handled.

* Parse.Push.send now returns the pushStatusId
* Add useMasterKey to Parse.Push.send
* Add new Parse.Push.getPushStatus
* Add new Push Integration tests.

```
const pushStatusId = await Parse.Push.send(payload);
const pushStatus = await Parse.Push.getPushStatus(pushStatusId);
```
This is currently a breaking change. Parse.Push.send returned `{ result: true }` before.