### PR TITLE
Allow nested increment on undefined fields

### DIFF
--- a/integration/test/ParseObjectTest.js
+++ b/integration/test/ParseObjectTest.js
@@ -414,16 +414,6 @@ describe('Parse Object', () => {
     assert.equal(result.get('objectField').unknown, 20);
   });
 
-  it('ignore set nested fields on new object', async () => {
-    const obj = new TestObject();
-    obj.set('objectField.number', 5);
-    assert.deepEqual(obj._getPendingOps()[0], {});
-    assert.equal(obj.get('objectField'), undefined);
-
-    await obj.save();
-    assert.equal(obj.get('objectField'), undefined);
-  });
-
   it('can set nested fields two levels', async () => {
     const obj = new TestObject({ objectField: { foo: { bar: 5 } } });
     assert.equal(obj.get('objectField').foo.bar, 5);

--- a/src/ParseObject.js
+++ b/src/ParseObject.js
@@ -741,15 +741,6 @@ class ParseObject {
 
     const currentAttributes = this.attributes;
 
-    // Only set nested fields if exists
-    const serverData = this._getServerData();
-    if (typeof key === 'string' && key.includes('.')) {
-      const field = key.split('.')[0];
-      if (!serverData[field]) {
-        return this;
-      }
-    }
-
     // Calculate new values
     const newValues = {};
     for (const attr in newOps) {

--- a/src/__tests__/ParseObject-test.js
+++ b/src/__tests__/ParseObject-test.js
@@ -699,16 +699,6 @@ describe('ParseObject', () => {
     expect(o.get('objectField').letter).toEqual('a');
   });
 
-  it('ignore set nested field on new object', () => {
-    const o = new ParseObject('Person');
-    o.set('objectField.number', 20);
-
-    expect(o.attributes).toEqual({});
-    expect(o.op('objectField.number') instanceof SetOp).toBe(false);
-    expect(o.dirtyKeys()).toEqual([]);
-    expect(o._getSaveJSON()).toEqual({});
-  });
-
   it('can add elements to an array field', () => {
     const o = new ParseObject('Schedule');
     o.add('available', 'Monday');


### PR DESCRIPTION
Calling increment on a field that doesn't exists (serverData stored in object state) gets ignored.
```
const obj = new TestObject();
obj.increment('a.b.c.d'); // ignored
await obj.save();
```
I believe this was ignored because the server doesn't support it and throws the following error
```
Unhandled promise rejection: TypeError: Cannot read property 'split' of undefined
```
