### PR TITLE
fix(EventuallyQueue): Poll against /health endpoint

### DIFF
--- a/src/EventuallyQueue.js
+++ b/src/EventuallyQueue.js
@@ -308,12 +308,14 @@ const EventuallyQueue = {
     }
     polling = setInterval(() => {
       const RESTController = CoreManager.getRESTController();
-      RESTController.ajax('GET', CoreManager.get('SERVER_URL')).catch(error => {
-        if (error !== 'Unable to connect to the Parse API') {
+      RESTController.request('GET', 'health/')
+        .then(() => {
           this.stopPoll();
           return this.sendQueue();
-        }
-      });
+        })
+        .catch(() => {
+          // 'Unable to connect to the Parse API' keep polling
+        });
     }, ms);
   },
 

--- a/src/EventuallyQueue.js
+++ b/src/EventuallyQueue.js
@@ -308,14 +308,14 @@ const EventuallyQueue = {
     }
     polling = setInterval(() => {
       const RESTController = CoreManager.getRESTController();
-      RESTController.request('GET', 'health/')
-        .then(() => {
-          this.stopPoll();
-          return this.sendQueue();
+      RESTController.request('GET', 'health')
+        .then(({ status }) => {
+          if (status === 'ok') {
+            this.stopPoll();
+            return this.sendQueue();
+          }
         })
-        .catch(() => {
-          // 'Unable to connect to the Parse API' keep polling
-        });
+        .catch(e => e);
     }, ms);
   },
 

--- a/src/__tests__/EventuallyQueue-test.js
+++ b/src/__tests__/EventuallyQueue-test.js
@@ -406,7 +406,7 @@ describe('EventuallyQueue', () => {
 
   it('can poll server', async () => {
     jest.spyOn(EventuallyQueue, 'sendQueue').mockImplementationOnce(() => {});
-    RESTController._setXHR(mockXHR([{ status: 200, response: {} }]));
+    RESTController._setXHR(mockXHR([{ status: 200, response: { status: 'ok' } }]));
     EventuallyQueue.poll();
     expect(EventuallyQueue.isPolling()).toBe(true);
     jest.runOnlyPendingTimers();

--- a/src/__tests__/EventuallyQueue-test.js
+++ b/src/__tests__/EventuallyQueue-test.js
@@ -52,6 +52,12 @@ const RESTController = require('../RESTController');
 const Storage = require('../Storage');
 const mockXHR = require('./test_helpers/mockXHR');
 
+CoreManager.setInstallationController({
+  currentInstallationId() {
+    return Promise.resolve('iid');
+  },
+});
+
 function flushPromises() {
   return new Promise(resolve => setImmediate(resolve));
 }
@@ -400,7 +406,7 @@ describe('EventuallyQueue', () => {
 
   it('can poll server', async () => {
     jest.spyOn(EventuallyQueue, 'sendQueue').mockImplementationOnce(() => {});
-    RESTController._setXHR(mockXHR([{ status: 107, response: { error: 'ok' } }]));
+    RESTController._setXHR(mockXHR([{ status: 200, response: {} }]));
     EventuallyQueue.poll();
     expect(EventuallyQueue.isPolling()).toBe(true);
     jest.runOnlyPendingTimers();


### PR DESCRIPTION
The `/health` endpoint has been supported on the server since 2.2.5.
This fixes an issue where a `403` would let us know that server was online.