### PR TITLE
Add Server Health Check

### DIFF
--- a/src/Parse.js
+++ b/src/Parse.js
@@ -81,6 +81,16 @@ const Parse = {
   },
 
   /**
+   * Returns information regarding the current server's health
+   *
+   * @returns {Promise}
+   * @static
+   */
+  getServerHealth() {
+    return CoreManager.getRESTController().request('GET', 'health');
+  },
+
+  /**
    * @member {string} Parse.applicationId
    * @static
    */
@@ -228,9 +238,6 @@ Parse.LiveQuery = require('./ParseLiveQuery').default;
 Parse.LiveQueryClient = require('./LiveQueryClient').default;
 Parse.IndexedDB = require('./IndexedDBStorageController');
 
-Parse.getServerHealth = function () {
-  return CoreManager.getRESTController().request('GET', 'health');
-};
 Parse._request = function (...args) {
   return CoreManager.getRESTController().request.apply(null, args);
 };

--- a/src/Parse.js
+++ b/src/Parse.js
@@ -228,6 +228,9 @@ Parse.LiveQuery = require('./ParseLiveQuery').default;
 Parse.LiveQueryClient = require('./LiveQueryClient').default;
 Parse.IndexedDB = require('./IndexedDBStorageController');
 
+Parse.getServerHealth = function () {
+  return CoreManager.getRESTController().request('GET', 'health');
+};
 Parse._request = function (...args) {
   return CoreManager.getRESTController().request.apply(null, args);
 };

--- a/src/__tests__/Parse-test.js
+++ b/src/__tests__/Parse-test.js
@@ -161,6 +161,18 @@ describe('Parse module', () => {
     CoreManager.set('REQUEST_BATCH_SIZE', 20);
   });
 
+  it('getServerHealth', () => {
+    const controller = {
+      request: jest.fn(),
+      ajax: jest.fn(),
+    };
+    CoreManager.setRESTController(controller);
+    Parse.getServerHealth();
+    const [method, path] = controller.request.mock.calls[0];
+    expect(method).toBe('GET');
+    expect(path).toBe('health');
+  });
+
   it('_request', () => {
     const controller = {
       request: jest.fn(),


### PR DESCRIPTION
Adds `Parse.getServerHealth` as a quick way to check on the server health without having to make an arbitrary request to a functional endpoint, and without needing keys.

Similar to the PHP SDK
https://github.com/parse-community/parse-php-sdk/pull/366