### PR TITLE
new: className in subclass constructor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### master
 [Full Changelog](https://github.com/parse-community/Parse-SDK-JS/compare/3.1.0...master)
+- Add className argument to Parse Object subclass constructor ([#1315](https://github.com/parse-community/Parse-SDK-JS/pull/1315))
 
 ## 3.1.0
 [Full Changelog](https://github.com/parse-community/Parse-SDK-JS/compare/3.0.0...3.1.0)

--- a/integration/test/ParseSubclassTest.js
+++ b/integration/test/ParseSubclassTest.js
@@ -193,6 +193,7 @@ describe('Parse Object Subclasses', () => {
     const wartortle = new Wartortle();
     assert(wartortle.water);
   });
+
   it('registerSubclass with unknown className', async () => {
     let outerClassName = '';
     class TestObject extends Parse.Object {

--- a/integration/test/ParseSubclassTest.js
+++ b/integration/test/ParseSubclassTest.js
@@ -193,4 +193,21 @@ describe('Parse Object Subclasses', () => {
     const wartortle = new Wartortle();
     assert(wartortle.water);
   });
+  it('registerSubclass with unknown className', async () => {
+    let outerClassName = '';
+    class TestObject extends Parse.Object {
+      constructor(className) {
+        super(className);
+        outerClassName = className;
+      }
+    }
+    Parse.Object.registerSubclass('TestObject', TestObject);
+    const o = new Parse.Object('TestObject');
+    await o.save();
+    const query = new Parse.Query('TestObject');
+    const first = await query.first();
+    expect(first instanceof TestObject).toBe(true);
+    expect(first.className).toBe('TestObject');
+    expect(outerClassName).toBe('TestObject');
+  });
 });

--- a/src/ParseObject.js
+++ b/src/ParseObject.js
@@ -931,9 +931,6 @@ class ParseObject {
    */
   clone(): any {
     const clone = new this.constructor(this.className);
-    if (!clone.className) {
-      clone.className = this.className;
-    }
     let attributes = this.attributes;
     if (typeof this.constructor.readOnlyAttributes === 'function') {
       const readonly = this.constructor.readOnlyAttributes() || [];
@@ -960,9 +957,6 @@ class ParseObject {
    */
   newInstance(): any {
     const clone = new this.constructor(this.className);
-    if (!clone.className) {
-      clone.className = this.className;
-    }
     clone.id = this.id;
     if (singleInstance) {
       // Just return an object with the right id

--- a/src/ParseObject.js
+++ b/src/ParseObject.js
@@ -930,7 +930,7 @@ class ParseObject {
    * @returns {Parse.Object}
    */
   clone(): any {
-    const clone = new this.constructor();
+    const clone = new this.constructor(this.className);
     if (!clone.className) {
       clone.className = this.className;
     }
@@ -959,7 +959,7 @@ class ParseObject {
    * @returns {Parse.Object}
    */
   newInstance(): any {
-    const clone = new this.constructor();
+    const clone = new this.constructor(this.className);
     if (!clone.className) {
       clone.className = this.className;
     }
@@ -1831,7 +1831,7 @@ class ParseObject {
       throw new Error('Cannot create an object without a className');
     }
     const constructor = classMap[json.className];
-    const o = constructor ? new constructor() : new ParseObject(json.className);
+    const o = constructor ? new constructor(json.className) : new ParseObject(json.className);
     const otherAttributes = {};
     for (const attr in json) {
       if (attr !== 'className' && attr !== '__type') {

--- a/src/__tests__/ParseObject-test.js
+++ b/src/__tests__/ParseObject-test.js
@@ -3425,6 +3425,7 @@ describe('ParseObject Subclasses', () => {
       'You must register the subclass constructor. Did you attempt to register an instance of the subclass?'
     );
   });
+
   it('can use on ParseObject subclass for multiple Parse.Object class names', () => {
     class MyParseObjects extends ParseObject {
       constructor(className) {

--- a/src/__tests__/ParseObject-test.js
+++ b/src/__tests__/ParseObject-test.js
@@ -3425,6 +3425,19 @@ describe('ParseObject Subclasses', () => {
       'You must register the subclass constructor. Did you attempt to register an instance of the subclass?'
     );
   });
+  it('registerSubclass with unknown className', () => {
+    let outerClassName = '';
+    class TestObject extends ParseObject {
+      constructor(className) {
+        super(className);
+        outerClassName = className;
+      }
+    }
+    ParseObject.registerSubclass('TestObject', TestObject);
+    const o = new TestObject('TestObject');
+    expect(o.className).toBe('TestObject');
+    expect(outerClassName).toBe('TestObject');
+  });
 
   it('can inflate subclasses from server JSON', () => {
     const json = {

--- a/src/__tests__/ParseObject-test.js
+++ b/src/__tests__/ParseObject-test.js
@@ -3425,18 +3425,21 @@ describe('ParseObject Subclasses', () => {
       'You must register the subclass constructor. Did you attempt to register an instance of the subclass?'
     );
   });
-  it('registerSubclass with unknown className', () => {
-    let outerClassName = '';
-    class TestObject extends ParseObject {
+  it('can use on ParseObject subclass for multiple Parse.Object class names', () => {
+    class MyParseObjects extends ParseObject {
       constructor(className) {
         super(className);
-        outerClassName = className;
       }
     }
-    ParseObject.registerSubclass('TestObject', TestObject);
-    const o = new TestObject('TestObject');
-    expect(o.className).toBe('TestObject');
-    expect(outerClassName).toBe('TestObject');
+    ParseObject.registerSubclass('TestObject', MyParseObjects);
+    ParseObject.registerSubclass('TestObject1', MyParseObjects);
+    ParseObject.registerSubclass('TestObject2', MyParseObjects);
+    const obj = new MyParseObjects('TestObject');
+    expect(obj.className).toBe('TestObject');
+    const obj1 = new MyParseObjects('TestObject1');
+    expect(obj1.className).toBe('TestObject1');
+    const obj2 = new MyParseObjects('TestObject2');
+    expect(obj2.className).toBe('TestObject2');
   });
 
   it('can inflate subclasses from server JSON', () => {


### PR DESCRIPTION
Hi,

Let's say you want to create a global function `getName` on all your Parse.Objects. Let's say you have 4 different classes. Here's how you'd have to do that now:

```javascript
class ClassOne extends Parse.Object {
  constructor() {
    super('ClassOne');
  }
  getDetails() {
    return `${this.get('title')} ${this.get('description')}`;
  }
}
class ClassTwo extends Parse.Object {
  constructor() {
    super('ClassTwo');
  }
  getDetails() {
    return `${this.get('title')} ${this.get('description')}`;
  }
}
class ClassThree extends Parse.Object {
  constructor() {
    super('ClassThree');
  }
  getDetails() {
    return `${this.get('title')} ${this.get('description')}`;
  }
}
Parse.Object.registerSubclass('ClassOne', ClassOne);
Parse.Object.registerSubclass('ClassTwo', ClassTwo);
Parse.Object.registerSubclass('ClassThree', ClassThree);
```

Now, obviously this doesn't apply to all use cases, but this allows a `registeredSubclass` to have multiple class names, meaning that you can create one overhead class for multiple Parse Objects.

```javascript
class ParseHelper extends Parse.Object {
  constructor(className) {
    super(className);
  }
  getDetails() {
    return `${this.get('title')} ${this.get('description')}`;
  }
}
const classNames = ['ClassOne', 'ClassTwo', 'ClassThree'];
for (const className of classNames) {
  Parse.Object.registerSubclass(className, ParseHelper);
}
```