### PR TITLE
Remove deletion of Anonymous User on logout

### DIFF
--- a/src/AnonymousUtils.js
+++ b/src/AnonymousUtils.js
@@ -89,6 +89,18 @@ const AnonymousUtils = {
     return user.linkWith(provider.getAuthType(), provider.getAuthData(), options);
   },
 
+  /**
+   * Returns true if Authentication Provider has been registered for use.
+   *
+   * @function isRegistered
+   * @name Parse.AnonymousUtils.isRegistered
+   * @returns {boolean}
+   * @static
+   */
+  isRegistered(): boolean {
+    return registered;
+  },
+
   _getAuthProvider() {
     const provider = {
       restoreAuthentication() {

--- a/src/ParseUser.js
+++ b/src/ParseUser.js
@@ -9,7 +9,6 @@
  * @flow
  */
 
-import AnonymousUtils from './AnonymousUtils';
 import CoreManager from './CoreManager';
 import isRevocableSession from './isRevocableSession';
 import ParseError from './ParseError';
@@ -337,8 +336,7 @@ class ParseUser extends ParseObject {
    * @param {string} username
    */
   setUsername(username: string) {
-    // Strip anonymity, even we do not support anonymous user in js SDK, we may
-    // encounter anonymous user created by android/iOS in cloud code.
+    // Strip anonymity
     const authData = this.get('authData');
     if (authData && typeof authData === 'object' && authData.hasOwnProperty('anonymous')) {
       // We need to set anonymous to null instead of deleting it in order to remove it from Parse.
@@ -960,13 +958,7 @@ const DefaultController = {
     return Storage.removeItemAsync(path);
   },
 
-  async setCurrentUser(user) {
-    const currentUser = await this.currentUserAsync();
-    if (currentUser && !user.equals(currentUser) && AnonymousUtils.isLinked(currentUser)) {
-      await currentUser.destroy({
-        sessionToken: currentUser.getSessionToken(),
-      });
-    }
+  setCurrentUser(user) {
     currentUserCache = user;
     user._cleanupAuthData();
     user._synchronizeAllAuthData();
@@ -1134,7 +1126,7 @@ const DefaultController = {
     });
   },
 
-  logOut(options: RequestOptions): Promise<ParseUser> {
+  async logOut(options: RequestOptions): Promise<ParseUser> {
     const RESTController = CoreManager.getRESTController();
     if (options.sessionToken) {
       return RESTController.request('POST', 'logout', {}, options);
@@ -1143,18 +1135,11 @@ const DefaultController = {
       const path = Storage.generatePath(CURRENT_USER_KEY);
       let promise = Storage.removeItemAsync(path);
       if (currentUser !== null) {
-        const isAnonymous = AnonymousUtils.isLinked(currentUser);
         const currentSession = currentUser.getSessionToken();
         if (currentSession && isRevocableSession(currentSession)) {
-          promise = promise
-            .then(() => {
-              if (isAnonymous) {
-                return currentUser.destroy({ sessionToken: currentSession });
-              }
-            })
-            .then(() => {
-              return RESTController.request('POST', 'logout', {}, { sessionToken: currentSession });
-            });
+          promise = promise.then(() => {
+            return RESTController.request('POST', 'logout', {}, { sessionToken: currentSession });
+          });
         }
         currentUser._logOutWithAll();
         currentUser._finishFetch({ sessionToken: undefined });

--- a/src/ParseUser.js
+++ b/src/ParseUser.js
@@ -1126,7 +1126,7 @@ const DefaultController = {
     });
   },
 
-  async logOut(options: RequestOptions): Promise<ParseUser> {
+  logOut(options: RequestOptions): Promise<ParseUser> {
     const RESTController = CoreManager.getRESTController();
     if (options.sessionToken) {
       return RESTController.request('POST', 'logout', {}, options);

--- a/src/__tests__/ParseUser-test.js
+++ b/src/__tests__/ParseUser-test.js
@@ -1066,6 +1066,8 @@ describe('ParseUser', () => {
 
   it('can sync anonymous user with current user', async () => {
     const provider = AnonymousUtils._getAuthProvider();
+    expect(AnonymousUtils.isRegistered()).toBe(true);
+
     jest.spyOn(provider, 'restoreAuthentication');
 
     const object = new ParseUser();
@@ -1086,7 +1088,7 @@ describe('ParseUser', () => {
     spy.mockRestore();
   });
 
-  it('can destroy anonymous user on logout', async () => {
+  it('can logout anonymous user', async () => {
     ParseUser.enableUnsafeCurrentUser();
     ParseUser._clearCache();
     CoreManager.setRESTController({
@@ -1111,7 +1113,7 @@ describe('ParseUser', () => {
     ParseUser._setCurrentUserCache(user);
 
     await ParseUser.logOut();
-    expect(user.destroy).toHaveBeenCalledTimes(1);
+    expect(ParseUser.current()).toBe(null);
   });
 
   it('can unlink', async () => {
@@ -1138,7 +1140,7 @@ describe('ParseUser', () => {
     expect(user.linkWith).toHaveBeenCalledTimes(1);
   });
 
-  it('can destroy anonymous user when login new user', async () => {
+  it('can logout anonymous user when login new user', async () => {
     ParseUser.enableUnsafeCurrentUser();
     ParseUser._clearCache();
     CoreManager.setRESTController({
@@ -1176,7 +1178,7 @@ describe('ParseUser', () => {
       ajax() {},
     });
     await ParseUser.logIn('username', 'password');
-    expect(user.destroy).toHaveBeenCalledTimes(1);
+    expect(ParseUser.current().id).not.toBe(user.id);
   });
 
   it('strip anonymity when we set username', () => {


### PR DESCRIPTION
Based on conversation [here](https://community.parseplatform.org/t/anonymous-user-destroyed-on-logout/1425/6)

* Remove deletion on logout
* Remove deletion on setCurrentUser
* Exposes registered on AnonymousUtils