### PR TITLE
Added an error code for geospatial index failures

### DIFF
--- a/src/ParseError.js
+++ b/src/ParseError.js
@@ -378,6 +378,14 @@ ParseError.DUPLICATE_REQUEST = 159;
 ParseError.INVALID_EVENT_NAME = 160;
 
 /**
+ * Error code indicating that a field had an invalid value.
+ *
+ * @property {number} INVALID_VALUE
+ * @static
+ */
+ParseError.INVALID_VALUE = 162;
+
+/**
  * Error code indicating that the username is missing or empty.
  *
  * @property {number} USERNAME_MISSING


### PR DESCRIPTION
See parse-community/parse-server#7331

This PR adds a new error code for geospatial index failures. MongoDB returns the error codes 16755/16756 if one tries to create an object on a collection with a geospatial index (such as `2dsphere`) but MongoDB fails to index the object, perhaps because the geojson is invalid or the index does not support the given geometry.