### PR TITLE
Add npm version ci check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,16 @@ on:
     branches:
       - '**'
 jobs:
+  check-lock-file-version:
+    name: NPM Lock File Version
+    timeout-minutes: 5
+    runs-on: ubuntu-18.04
+    steps:
+      - uses: actions/checkout@v2
+      - name: Check NPM lock file version
+        uses: mansona/npm-lockfile-version@v1
+        with:
+          version: 1
   build:
     runs-on: ubuntu-18.04
     timeout-minutes: 30


### PR DESCRIPTION
Adds a CI check that requires `package-lock.json` to be generated with npm <7.

Building with npm 7 causes errors that are difficult to interpret.
The discussion in https://github.com/parse-community/Parse-SDK-JS/pull/1344 shows that without a clear error message, contributors and reviewers unnecessarily spend more time to trace the issue back to npm 7.

This is analogous to https://github.com/parse-community/parse-server/pull/7333.
