### PR TITLE
doc improvement

### DIFF
--- a/src/ParseObject.js
+++ b/src/ParseObject.js
@@ -1261,7 +1261,7 @@ class ParseObject {
    * });</pre>
    * 
    * Example 2: <pre>
-   * player.save("name", "Jake Cutter");</pre>
+   * gameTurn.save("player", "Jake Cutter");</pre>
    *
    * @param {string | object | null} [arg1]
    * Valid options are:<ul>

--- a/src/ParseObject.js
+++ b/src/ParseObject.js
@@ -1246,9 +1246,11 @@ class ParseObject {
    * or<pre>
    * object.save(attrs, options);</pre>
    * or<pre>
+   * object.save(key, value);</pre>
+   * or<pre>
    * object.save(key, value, options);</pre>
    *
-   * For example, <pre>
+   * Example 1: <pre>
    * gameTurn.save({
    * player: "Jake Cutter",
    * diceRoll: 2
@@ -1257,6 +1259,9 @@ class ParseObject {
    * }, function(error) {
    * // The save failed.  Error is an instance of Parse.Error.
    * });</pre>
+   * 
+   * Example 2: <pre>
+   * player.save("name", "Jake Cutter");</pre>
    *
    * @param {string | object | null} [arg1]
    * Valid options are:<ul>

--- a/src/ParseObject.js
+++ b/src/ParseObject.js
@@ -1259,7 +1259,7 @@ class ParseObject {
    * }, function(error) {
    * // The save failed.  Error is an instance of Parse.Error.
    * });</pre>
-   * 
+   *
    * Example 2: <pre>
    * gameTurn.save("player", "Jake Cutter");</pre>
    *


### PR DESCRIPTION
added an example in the Parse.Object docs to show usage of saving a single attribute on a parse object. Users may use this in typescript class extensions of Parse.Object as a class attribute mutator.