### PR TITLE
feat(Query): Add Parse.Query.from

### DIFF
--- a/src/ParseQuery.js
+++ b/src/ParseQuery.js
@@ -580,15 +580,10 @@ class ParseQuery {
    * Static method to create Parse.Query instance
    *
    * @param {string} className
-   * @param {object} eq key / value object for query.equalTo()
    * @returns {Parse.Query} new created query
    */
-  static from(className: string, eq: { [key: string]: any }): ParseQuery {
-    const query = new ParseQuery(className);
-    if (eq) {
-      query.equalTo(eq);
-    }
-    return query;
+  static from(className: string): ParseQuery {
+    return new ParseQuery(className);
   }
 
   /**

--- a/src/ParseQuery.js
+++ b/src/ParseQuery.js
@@ -577,6 +577,16 @@ class ParseQuery {
   }
 
   /**
+   * Static method to create Parse.Query instance
+   *
+   * @param {string} className
+   * @returns {Parse.Query} new created query
+   */
+  static from(className: string): ParseQuery {
+    return new ParseQuery(className);
+  }
+
+  /**
    * Static method to restore Parse.Query by json representation
    * Internally calling Parse.Query.withJSON
    *

--- a/src/ParseQuery.js
+++ b/src/ParseQuery.js
@@ -579,11 +579,11 @@ class ParseQuery {
   /**
    * Static method to create Parse.Query instance
    *
-   * @param {string} className
-   * @returns {Parse.Query} new created query
+   * @param {(string | Parse.Object)} objectClass An instance of a subclass of Parse.Object, or a Parse className string.
+   * @returns {Parse.Query} Newly created query
    */
-  static from(className: string): ParseQuery {
-    return new ParseQuery(className);
+  static from(objectClass: string | ParseObject): ParseQuery {
+    return new ParseQuery(objectClass);
   }
 
   /**

--- a/src/ParseQuery.js
+++ b/src/ParseQuery.js
@@ -580,10 +580,15 @@ class ParseQuery {
    * Static method to create Parse.Query instance
    *
    * @param {string} className
+   * @param {object} eq key / value object for query.equalTo()
    * @returns {Parse.Query} new created query
    */
-  static from(className: string): ParseQuery {
-    return new ParseQuery(className);
+  static from(className: string, eq: { [key: string]: any }): ParseQuery {
+    const query = new ParseQuery(className);
+    if (eq) {
+      query.equalTo(eq);
+    }
+    return query;
   }
 
   /**

--- a/src/__tests__/ParseQuery-test.js
+++ b/src/__tests__/ParseQuery-test.js
@@ -2503,6 +2503,14 @@ describe('ParseQuery', () => {
       );
   });
 
+  it('create query instance from className', () => {
+    const q = ParseQuery.from('Item');
+    expect(q.className).toBe('Item');
+    expect(q.toJSON()).toEqual({
+      where: {},
+    });
+  });
+
   it('restores queries from json representation', () => {
     const q = new ParseQuery('Item');
 

--- a/src/__tests__/ParseQuery-test.js
+++ b/src/__tests__/ParseQuery-test.js
@@ -2504,10 +2504,18 @@ describe('ParseQuery', () => {
   });
 
   it('create query instance from className', () => {
-    const q = ParseQuery.from('Item');
+    let q = ParseQuery.from('Item');
     expect(q.className).toBe('Item');
     expect(q.toJSON()).toEqual({
       where: {},
+    });
+
+    q = ParseQuery.from('Item', { hello: 'world' });
+    expect(q.className).toBe('Item');
+    expect(q.toJSON()).toEqual({
+      where: {
+        hello: 'world',
+      },
     });
   });
 

--- a/src/__tests__/ParseQuery-test.js
+++ b/src/__tests__/ParseQuery-test.js
@@ -2504,18 +2504,10 @@ describe('ParseQuery', () => {
   });
 
   it('create query instance from className', () => {
-    let q = ParseQuery.from('Item');
+    const q = ParseQuery.from('Item');
     expect(q.className).toBe('Item');
     expect(q.toJSON()).toEqual({
       where: {},
-    });
-
-    q = ParseQuery.from('Item', { hello: 'world' });
-    expect(q.className).toBe('Item');
-    expect(q.toJSON()).toEqual({
-      where: {
-        hello: 'world',
-      },
     });
   });
 


### PR DESCRIPTION
ref: https://github.com/parse-community/Parse-SDK-JS/issues/1348

The goal of this PR is to make the Query API more readable and similar to use. This PR introduces `Parse.Query.from` which returns a Query instance without requiring the use of `new`.

Before
```
const data = await new Parse.Query('Blog').find();
```

After
```
const { Query } = require('parse');
const data = await Query.from('Blog').find();
```


