### PR TITLE
Combine equalTo clause with other clauses

### DIFF
--- a/src/__tests__/ParseQuery-test.js
+++ b/src/__tests__/ParseQuery-test.js
@@ -807,6 +807,21 @@ describe('ParseQuery', () => {
     });
   });
 
+  it('can combine equalTo clause with any other clause', () => {
+    const q = new ParseQuery('Item');
+    q.equalTo('inStock', null);
+    q.exists('inStock');
+
+    expect(q.toJSON()).toEqual({
+      where: {
+        inStock: {
+          $eq: null,
+          $exists: true,
+        },
+      },
+    });
+  });
+
   it('can specify ordering', () => {
     const q = new ParseQuery('Item');
     q.greaterThan('inStock', 0).ascending('createdAt');


### PR DESCRIPTION
https://github.com/parse-community/Parse-SDK-JS/issues/1372

have added only a failing test case.