### PR TITLE
fix: bump crypto js

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,13 @@
 # Parse-SDK-JS
 
 ### master
-[Full Changelog](https://github.com/parse-community/Parse-SDK-JS/compare/3.3.0...master)
+[Full Changelog](https://github.com/parse-community/Parse-SDK-JS/compare/3.3.1...master)
+
+## 3.3.1
+[Full Changelog](https://github.com/parse-community/Parse-SDK-JS/compare/3.3.0...3.3.1)
+
+**Fixes**
+- Upgraded crypto-js dependency for compatibility with webpack in Parse Dashboard
 
 ## 3.3.0
 [Full Changelog](https://github.com/parse-community/Parse-SDK-JS/compare/3.2.0...3.3.0)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "parse",
-  "version": "3.3.0",
+  "version": "3.3.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -2046,6 +2046,15 @@
             "uuid": "3.4.0",
             "ws": "7.3.1",
             "xmlhttprequest": "1.8.0"
+          },
+          "dependencies": {
+            "crypto-js": {
+              "version": "4.0.0",
+              "resolved": "https://registry.npmjs.org/crypto-js/-/crypto-js-4.0.0.tgz",
+              "integrity": "sha512-bzHZN8Pn+gS7DQA6n+iUmBfl0hO5DJq++QP3U6uTucDtk/0iGpXd/Gg7CGR0p8tJhofJyaKoWBuJI4eAO00BBg==",
+              "dev": true,
+              "optional": true
+            }
           }
         },
         "ws": {
@@ -4584,9 +4593,9 @@
       }
     },
     "crypto-js": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/crypto-js/-/crypto-js-4.0.0.tgz",
-      "integrity": "sha512-bzHZN8Pn+gS7DQA6n+iUmBfl0hO5DJq++QP3U6uTucDtk/0iGpXd/Gg7CGR0p8tJhofJyaKoWBuJI4eAO00BBg==",
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/crypto-js/-/crypto-js-4.1.1.tgz",
+      "integrity": "sha512-o2JlM7ydqd3Qk9CA0L4NL6mTzU2sdx96a+oOfPu8Mkl/PK51vSyoi8/rQ8NknZtk44vq15lmhAj9CIAGwgeWKw==",
       "optional": true
     },
     "cssfilter": {
@@ -10799,14 +10808,14 @@
       "from": "github:parse-community/parse-server#master",
       "dev": true,
       "requires": {
-        "@apollographql/graphql-playground-html": "1.6.27",
+        "@apollographql/graphql-playground-html": "1.6.29",
         "@graphql-tools/links": "6.2.5",
         "@graphql-tools/stitch": "6.2.4",
         "@graphql-tools/utils": "6.2.4",
         "@node-rs/bcrypt": "1.1.0",
         "@parse/fs-files-adapter": "1.2.0",
-        "@parse/push-adapter": "3.4.0",
-        "apollo-server-express": "2.25.1",
+        "@parse/push-adapter": "3.4.1",
+        "apollo-server-express": "2.25.2",
         "bcryptjs": "2.4.3",
         "body-parser": "1.19.0",
         "commander": "5.1.0",
@@ -10814,23 +10823,23 @@
         "deepcopy": "2.1.0",
         "express": "4.17.1",
         "follow-redirects": "1.14.1",
-        "graphql": "15.5.0",
+        "graphql": "15.5.2",
         "graphql-list-fields": "2.0.2",
-        "graphql-relay": "0.7.0",
-        "graphql-tag": "2.12.4",
+        "graphql-relay": "0.8.0",
+        "graphql-tag": "2.12.5",
         "graphql-upload": "11.0.0",
         "intersect": "1.0.1",
         "jsonwebtoken": "8.5.1",
         "jwks-rsa": "1.12.3",
-        "ldapjs": "2.3.0",
+        "ldapjs": "2.3.1",
         "lodash": "4.17.21",
         "lru-cache": "5.1.1",
         "mime": "2.5.2",
-        "mongodb": "3.6.9",
+        "mongodb": "3.6.11",
         "mustache": "4.2.0",
-        "parse": "3.2.0",
+        "parse": "3.3.0",
         "pg-monitor": "1.4.1",
-        "pg-promise": "10.10.2",
+        "pg-promise": "10.11.0",
         "pluralize": "8.0.0",
         "redis": "3.1.2",
         "semver": "7.3.4",
@@ -10839,7 +10848,7 @@
         "uuid": "8.3.2",
         "winston": "3.3.3",
         "winston-daily-rotate-file": "4.5.5",
-        "ws": "7.4.6"
+        "ws": "8.2.1"
       },
       "dependencies": {
         "@babel/runtime": {
@@ -11153,6 +11162,13 @@
             "xmlhttprequest": "1.8.0"
           },
           "dependencies": {
+            "crypto-js": {
+              "version": "4.0.0",
+              "resolved": "https://registry.npmjs.org/crypto-js/-/crypto-js-4.0.0.tgz",
+              "integrity": "sha512-bzHZN8Pn+gS7DQA6n+iUmBfl0hO5DJq++QP3U6uTucDtk/0iGpXd/Gg7CGR0p8tJhofJyaKoWBuJI4eAO00BBg==",
+              "dev": true,
+              "optional": true
+            },
             "uuid": {
               "version": "3.4.0",
               "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",

--- a/package.json
+++ b/package.json
@@ -81,7 +81,7 @@
     "vinyl-source-stream": "2.0.0"
   },
   "optionalDependencies": {
-    "crypto-js": "4.0.0"
+    "crypto-js": "4.1.1"
   },
   "scripts": {
     "build": "node build_releases.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "parse",
-  "version": "3.3.0",
+  "version": "3.3.1",
   "description": "The Parse JavaScript SDK",
   "homepage": "https://parseplatform.org/",
   "keywords": [


### PR DESCRIPTION
### New Pull Request Checklist
<!--
    Check every following box [x] before submitting your PR.
    Click the "Preview" tab for better readability.
    Thanks for contributing to Parse Platform!
-->

- [x] I am not disclosing a [vulnerability](https://github.com/parse-community/parse-server/blob/master/SECURITY.md).
- [x] I am creating this PR in reference to an [issue](https://github.com/parse-community/Parse-SDK-JS/issues?q=is%3Aissue).

### Issue Description
crypto-js 4.0.0 requires manual polyfill when used with webpack 5 in Parse Dashboard, see https://github.com/brix/crypto-js/pull/364.

Related issue: https://github.com/parse-community/parse-dashboard/pull/1807#issuecomment-926921625

### Approach
Bump crypto-js to 4.1.1, which should fix the issue.

### TODOs before merging
<!--
    Add TODOs that need to be completed before merging this PR.
    Delete TODOs that do not apply to this PR.
-->

- [x] Add entry to changelog