### PR TITLE
feat: add Parse.Object.saveAllSettled to support more robust saving of multiple Parse Objects

### DIFF
--- a/src/ParseObject.js
+++ b/src/ParseObject.js
@@ -1801,7 +1801,7 @@ class ParseObject {
 
   /**
    * Saves the given list of Parse.Object.
-   * Will keep trying to save all items lists, even if ecountering errors, up to options.retyMax (default 3).
+   * Will keep trying to save all items lists, even if encountering errors, up to options.retryMax (default 3).
    *
    * <pre>
    * Parse.Object.saveAllSettled([object1, object2, ...], options)

--- a/src/ParseObject.js
+++ b/src/ParseObject.js
@@ -1809,6 +1809,11 @@ class ParseObject {
    * // All the objects were saved.
    * }, (error) => {
    * // An error occurred while saving one of the objects.
+   *  error will contain:
+   * <ul>
+   * <li>message: error message
+   * <li>statuses: list of statuses { status : fulfilled | rejected, reason : <error message, if rejected>, fulfilled : <value of saved object, if saved ok>} corresponding to list
+   * </ul>
    * });
    * </pre>
    *

--- a/src/ParseObject.js
+++ b/src/ParseObject.js
@@ -1801,7 +1801,8 @@ class ParseObject {
 
   /**
    * Saves the given list of Parse.Object.
-   * Will keep trying to save all items lists, even if encountering errors, up to options.retryMax (default 3).
+   * Will keep trying to save all items lists, even if encountering errors, 
+   * up to options.retryMax (default 3).
    *
    * <pre>
    * Parse.Object.saveAllSettled([object1, object2, ...], options)
@@ -1812,7 +1813,9 @@ class ParseObject {
    *  error will contain:
    * <ul>
    * <li>message: error message
-   * <li>statuses: list of statuses { status : fulfilled | rejected, reason : <error message, if rejected>, fulfilled : <value of saved object, if saved ok>} corresponding to list
+   * <li>statuses: list of statuses { status : fulfilled | rejected, 
+   *                                  reason : <error message, if rejected>, 
+   *                                  fulfilled : <value of saved object, if saved ok>} 
    * </ul>
    * });
    * </pre>

--- a/src/ParseObject.js
+++ b/src/ParseObject.js
@@ -1884,7 +1884,7 @@ class ParseObject {
           } else {
             //hit the limit - reject
             reject({
-              message: 'Time Out. Saved ' + successCount + ' of ' + items.length + ' items.',
+              message: 'Time Out. Saved ' + successCount + ' of ' + list.length + ' items.',
               statuses: statuses
             });
           }


### PR DESCRIPTION
### New Pull Request Checklist
<!--
    Check every following box [x] before submitting your PR.
    Click the "Preview" tab for better readability.
    Thanks for contributing to Parse Platform!
-->

- [x] I am not disclosing a [vulnerability](https://github.com/parse-community/parse-server/blob/master/SECURITY.md).
- [x] I am creating this PR in reference to an [issue](https://github.com/parse-community/Parse-SDK-JS/issues?q=is%3Aissue).

### Issue Description
<!-- Add a brief description of the issue this PR solves. -->

Related issue:  #494 #799 #1433 and [this StackOverflow issue](https://stackoverflow.com/questions/34951768/parseobject-saveall-sometimes-results-in-duplicate-objects-being-created)

`Parse.Object.saveAll` can create data consistency issues. Because `saveAll` (which uses the `/batch` endpoint) will reject if *any* of the save items in the list fails, you can end up with 19 saved objects and 1 unsaved object. If the cause of the failure was a network delay, then the `saveAll` will automatically retry, with *all* 20 objects again - which leads to duplicated objects on the server.

 

### Approach

`Parse.Object.saveAllSettled` fixes this problem, by using the [Promise.allSettled](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise/allSettled) method and individual, staggered `object. save()` calls - which waits for the saving of all the objects in the list to resolve or reject, then only tries to resave any objects that didn't successfully save the first time.

### TODOs before merging
<!--
    Add TODOs that need to be completed before merging this PR.
    Delete TODOs that do not apply to this PR.
-->

- [ ] Add tests
- [x] Add entry to changelog
- [ ] ?support passing of context?
