### PR TITLE
feat: add error code for email already verified

### DIFF
--- a/src/ParseError.js
+++ b/src/ParseError.js
@@ -434,6 +434,14 @@ ParseError.EMAIL_MISSING = 204;
 ParseError.EMAIL_NOT_FOUND = 205;
 
 /**
+ * Error code indicating that the email has already been verified and can not be verified again.
+ *
+ * @property {number} EMAIL_ALREADY_VERIFIED
+ * @static
+ */
+ ParseError.EMAIL_ALREADY_VERIFIED = 212;
+
+/**
  * Error code indicating that a user object without a valid session could
  * not be altered.
  *


### PR DESCRIPTION
See[ parse-community/parse-server##7740](https://github.com/parse-community/parse-server/issues/7740)

### New Pull Request Checklist
<!--
    Check every following box [x] before submitting your PR.
    Click the "Preview" tab for better readability.
    Thanks for contributing to Parse Platform!
-->

- [x] I am not disclosing a [vulnerability](https://github.com/parse-community/parse-server/blob/master/SECURITY.md).
- [x] I am creating this PR in reference to an [issue](https://github.com/parse-community/parse-server/issues/7740).

### Issue Description
<!-- Add a brief description of the issue this PR solves. -->
This PR adds a new error code when users requestEmailVerification for verified email, now the parse server sends the OTHER_CAUSE error code and it needs a better error code instead of -1 and should have a message instead of stack property.


Related issue:
[ parse-community/parse-server##7740](https://github.com/parse-community/parse-server/issues/7740)