### PR TITLE
fix: user object may contain already deleted fields

### DIFF
--- a/src/Cloud.js
+++ b/src/Cloud.js
@@ -121,6 +121,7 @@ const DefaultController = {
       if (typeof res === 'object' && Object.keys(res).length > 0 && !res.hasOwnProperty('result')) {
         throw new ParseError(ParseError.INVALID_JSON, 'The server returned an invalid response.');
       }
+      ParseObject._clearAllState();
       const decoded = decode(res);
       if (decoded && decoded.hasOwnProperty('result')) {
         return Promise.resolve(decoded.result);

--- a/src/Cloud.js
+++ b/src/Cloud.js
@@ -121,7 +121,6 @@ const DefaultController = {
       if (typeof res === 'object' && Object.keys(res).length > 0 && !res.hasOwnProperty('result')) {
         throw new ParseError(ParseError.INVALID_JSON, 'The server returned an invalid response.');
       }
-      ParseObject._clearAllState();
       const decoded = decode(res);
       if (decoded && decoded.hasOwnProperty('result')) {
         return Promise.resolve(decoded.result);

--- a/src/ParseObject.js
+++ b/src/ParseObject.js
@@ -347,9 +347,12 @@ class ParseObject {
     };
   }
 
-  _finishFetch(serverData: AttributeMap) {
+  _finishFetch(serverData: AttributeMap, override?: boolean) {
     if (!this.id && serverData.objectId) {
       this.id = serverData.objectId;
+    }
+    if (override) {
+      this._clearServerData();
     }
     const stateController = CoreManager.getObjectStateController();
     stateController.initializeState(this._getStateIdentifier());

--- a/src/ParseUser.js
+++ b/src/ParseUser.js
@@ -1088,6 +1088,7 @@ const DefaultController = {
         stateController.setPendingOp(user._getStateIdentifier(), 'username', undefined);
         stateController.setPendingOp(user._getStateIdentifier(), 'password', undefined);
         response.password = undefined;
+        user._clearServerData();
         user._finishFetch(response);
         if (!canUseCurrentUser) {
           // We can't set the current user, so just return the one we logged in

--- a/src/ParseUser.js
+++ b/src/ParseUser.js
@@ -1088,8 +1088,7 @@ const DefaultController = {
         stateController.setPendingOp(user._getStateIdentifier(), 'username', undefined);
         stateController.setPendingOp(user._getStateIdentifier(), 'password', undefined);
         response.password = undefined;
-        user._clearServerData();
-        user._finishFetch(response);
+        user._finishFetch(response, true);
         if (!canUseCurrentUser) {
           // We can't set the current user, so just return the one we logged in
           return Promise.resolve(user);

--- a/src/__tests__/ParseUser-test.js
+++ b/src/__tests__/ParseUser-test.js
@@ -992,7 +992,7 @@ describe('ParseUser', () => {
     expect(user2.isCurrent()).toBe(true);
     expect(user2.id).toBe('uid2');
     expect(user2.get('username')).toBe('username');
-    expect(user2.get('fieldToBeDeleted')).toBe(undefined); // Failing test
+    expect(user2.get('fieldToBeDeleted')).toBe(undefined); // Failing test PR #1442
   });
 
   it('can retreive a user with sessionToken (me)', async () => {

--- a/src/decode.js
+++ b/src/decode.js
@@ -34,7 +34,7 @@ export default function decode(value: any): any {
     return ParseObject.fromJSON(value);
   }
   if (value.__type === 'Object' && value.className) {
-    return ParseObject.fromJSON(value);
+    return ParseObject.fromJSON(value, true);
   }
   if (value.__type === 'Relation') {
     // The parent and key fields will be populated by the parent


### PR DESCRIPTION
### New Pull Request Checklist
<!--
    Check every following box [x] before submitting your PR.
    Click the "Preview" tab for better readability.
    Thanks for contributing to Parse Platform!
-->

- [x] I am not disclosing a [vulnerability](https://github.com/parse-community/parse-server/blob/master/SECURITY.md).
- [x] I am creating this PR in reference to an [issue](https://github.com/parse-community/Parse-SDK-JS/issues?q=is%3Aissue).

### Issue Description
As discussed in #1347, the return from `Parse.User.logIn` can include fields that no longer exist on the user, even if the network response from parse-server does not include the removed fields. There is also an issue with the return from `Parse.Cloud.run`.

Related issue: #1347

### Approach
This PR is a work in progress, initially containing only a failing test for the `Parse.User.logIn` case. If the failing test is confirmed to represent the issue well, a failing test for `Parse.Cloud.run` can also be added.

No solution for the `Parse.User.logIn` case has yet been proposed.
The [proposed solution](https://github.com/parse-community/Parse-SDK-JS/issues/1347#issuecomment-819539080) for the `Parse.Cloud.run` case is to update one of the cases in `decode.js` to call `ParseObject.fromJSON(value, true)` instead of `ParseObject.fromJSON(value)`.

### TODOs before merging
<!--
    Add TODOs that need to be completed before merging this PR.
    Delete TODOs that do not apply to this PR.
-->
- [x] Add failing test for `Parse.Cloud.run` case
- [x] Add failing test for `Parse.User.logIn` case
- [ ] Fix `Parse.Cloud.run` case
- [ ] Fix `Parse.User.logIn` case
- [ ] Add entry to changelog