### PR TITLE
fix: Multiple object updates of nested keys overwrite each other

### DIFF
--- a/src/ObjectStateMutations.js
+++ b/src/ObjectStateMutations.js
@@ -120,14 +120,14 @@ export function estimateAttributes(
         if (attr.includes('.')) {
           // convert a.b.c into { a: { b: { c: value } } }
           const fields = attr.split('.');
-          const first = fields[0];
           const last = fields[fields.length - 1];
-          if (data[first] === serverData[first]) data[first] = { ...serverData[first] }; // Do a deep copy
-          let object = { ...data };
+          let object = data;
           for (let i = 0; i < fields.length - 1; i++) {
             const key = fields[i];
             if (!(key in object)) {
               object[key] = {};
+            } else {
+              object[key] = { ...object[key] };
             }
             object = object[key];
           }

--- a/src/ObjectStateMutations.js
+++ b/src/ObjectStateMutations.js
@@ -122,7 +122,7 @@ export function estimateAttributes(
           const fields = attr.split('.');
           const first = fields[0];
           const last = fields[fields.length - 1];
-          data[first] = { ...serverData[first] };
+          if (data[first] === serverData[first]) data[first] = { ...serverData[first] }; // Do a deep copy
           let object = { ...data };
           for (let i = 0; i < fields.length - 1; i++) {
             const key = fields[i];

--- a/src/__tests__/ParseObject-test.js
+++ b/src/__tests__/ParseObject-test.js
@@ -676,23 +676,55 @@ describe('ParseObject', () => {
       objectField: {
         number: 5,
         letter: 'a',
+        nested: {
+          number: 0,
+          letter: 'b',
+        },
       },
     });
 
     expect(o.attributes).toEqual({
-      objectField: { number: 5, letter: 'a' },
+      objectField: { number: 5, letter: 'a', nested: { number: 0, letter: 'b' } },
     });
     o.set('objectField.number', 20);
     o.set('objectField.letter', 'b');
+    o.set('objectField.nested.number', 1);
+    o.set('objectField.nested.letter', 'c');
 
     expect(o.attributes).toEqual({
-      objectField: { number: 20, letter: 'b' },
+      objectField: { number: 20, letter: 'b', nested: { number: 1, letter: 'c' } },
     });
     expect(o.op('objectField.number') instanceof SetOp).toBe(true);
-    expect(o.dirtyKeys()).toEqual(['objectField.number', 'objectField.letter', 'objectField']);
+    expect(o.dirtyKeys()).toEqual([
+      'objectField.number',
+      'objectField.letter',
+      'objectField.nested.number',
+      'objectField.nested.letter',
+      'objectField',
+    ]);
     expect(o._getSaveJSON()).toEqual({
       'objectField.number': 20,
       'objectField.letter': 'b',
+      'objectField.nested.number': 1,
+      'objectField.nested.letter': 'c',
+    });
+
+    o.revert('objectField.nested.number');
+    o.revert('objectField.nested.letter');
+    expect(o._getSaveJSON()).toEqual({
+      'objectField.number': 20,
+      'objectField.letter': 'b',
+    });
+    expect(o.attributes).toEqual({
+      objectField: { number: 20, letter: 'b', nested: { number: 0, letter: 'b' } },
+    });
+
+    // Also test setting new root fields using the dot notation
+    o.set('objectField2.number', 0);
+    expect(o._getSaveJSON()).toEqual({
+      'objectField.number': 20,
+      'objectField.letter': 'b',
+      'objectField2.number': 0,
     });
   });
 

--- a/src/__tests__/ParseObject-test.js
+++ b/src/__tests__/ParseObject-test.js
@@ -726,6 +726,10 @@ describe('ParseObject', () => {
       'objectField.letter': 'b',
       'objectField2.number': 0,
     });
+    expect(o.attributes).toEqual({
+      objectField: { number: 20, letter: 'b', nested: { number: 0, letter: 'b' } },
+      objectField2: { number: 0 },
+    });
   });
 
   it('can increment a nested field', () => {

--- a/src/__tests__/ParseObject-test.js
+++ b/src/__tests__/ParseObject-test.js
@@ -669,6 +669,33 @@ describe('ParseObject', () => {
     });
   });
 
+  it('can set multiple nested fields (regression test for #1450)', () => {
+    const o = new ParseObject('Person');
+    o._finishFetch({
+      objectId: 'setNested2_1450',
+      objectField: {
+        number: 5,
+        letter: 'a',
+      },
+    });
+
+    expect(o.attributes).toEqual({
+      objectField: { number: 5, letter: 'a' },
+    });
+    o.set('objectField.number', 20);
+    o.set('objectField.letter', 'b');
+
+    expect(o.attributes).toEqual({
+      objectField: { number: 20, letter: 'b' },
+    });
+    expect(o.op('objectField.number') instanceof SetOp).toBe(true);
+    expect(o.dirtyKeys()).toEqual(['objectField.number', 'objectField.letter', 'objectField']);
+    expect(o._getSaveJSON()).toEqual({
+      'objectField.number': 20,
+      'objectField.letter': 'b',
+    });
+  });
+
   it('can increment a nested field', () => {
     const o = new ParseObject('Person');
     o._finishFetch({


### PR DESCRIPTION
### New Pull Request Checklist
<!--
    Check every following box [x] before submitting your PR.
    Click the "Preview" tab for better readability.
    Thanks for contributing to Parse Platform!
-->

- [x] I am not disclosing a [vulnerability](https://github.com/parse-community/parse-server/blob/master/SECURITY.md).
- [x] I am creating this PR in reference to an [issue](https://github.com/parse-community/Parse-SDK-JS/issues?q=is%3Aissue).

### Issue Description
<!-- Add a brief description of the issue this PR solves. -->
See #1450 

Closes: #1450
Closes: https://github.com/parse-community/Parse-SDK-JS/issues/1365

### Approach
<!-- Add a description of the approach in this PR. -->
estimateAttributes uses a more robust deep-cloning logic to carry out operations performed on nested fields.

### TODOs before merging
<!--
    Add TODOs that need to be completed before merging this PR.
    Delete TODOs that do not apply to this PR.
-->

- [x] Add tests
- [ ] Add entry to changelog
- [ ] Add changes to documentation (guides, repository pages, in-code descriptions)