### PR TITLE
fix: Pending updates to nested field causes `ParseObject.toJSON()` to return incorrect object

### DIFF
--- a/integration/test/ParseObjectTest.js
+++ b/integration/test/ParseObjectTest.js
@@ -292,6 +292,18 @@ describe('Parse Object', () => {
     assert.strictEqual(result.get('a').b.c.d, 2);
   });
 
+  it('can set nested fields without repeating pending operations on toJSON (regression test for #1452)', async () => {
+    const a = new Parse.Object('MyObject');
+    a.set('obj', {});
+    await a.save();
+    a.set('obj.a', 0);
+    const json = a.toJSON();
+    expect(json.obj).toEqual({ a: 0 });
+    expect(new Set(Object.keys(json))).toEqual(
+      new Set(['objectId', 'createdAt', 'updatedAt', 'obj'])
+    );
+  });
+
   it('can increment nested field and retain full object', async () => {
     const obj = new Parse.Object('TestIncrementObject');
     obj.set('objectField', { number: 5, letter: 'a' });

--- a/src/ParseObject.js
+++ b/src/ParseObject.js
@@ -470,10 +470,6 @@ class ParseObject {
         json[attr] = encode(attrs[attr], false, false, seen, offline);
       }
     }
-    const pending = this._getPendingOps();
-    for (const attr in pending[0]) {
-      json[attr] = pending[0][attr].toJSON(offline);
-    }
 
     if (this.id) {
       json.objectId = this.id;

--- a/src/__tests__/ParseObject-test.js
+++ b/src/__tests__/ParseObject-test.js
@@ -667,6 +667,14 @@ describe('ParseObject', () => {
       'objectField.number': 20,
       otherField: { hello: 'world' },
     });
+    expect(o.toJSON()).toEqual({
+      objectField: {
+        number: 20,
+        letter: 'a',
+      },
+      otherField: { hello: 'world' },
+      objectId: 'setNested',
+    });
   });
 
   it('can set multiple nested fields (regression test for #1450)', () => {


### PR DESCRIPTION
### New Pull Request Checklist
<!--
    Check every following box [x] before submitting your PR.
    Click the "Preview" tab for better readability.
    Thanks for contributing to Parse Platform!
-->

- [x] I am not disclosing a [vulnerability](https://github.com/parse-community/parse-server/blob/master/SECURITY.md).
- [x] I am creating this PR in reference to an [issue](https://github.com/parse-community/Parse-SDK-JS/issues?q=is%3Aissue).

### Issue Description
Fix #1452

Related issue: #1452

### Approach
<!-- Add a description of the approach in this PR. -->
`ParseObject.toJSON()` no longer applies pending operations a second time. `attributes` takes care of them already.

### TODOs before merging
<!--
    Add TODOs that need to be completed before merging this PR.
    Delete TODOs that do not apply to this PR.
-->

- [x] Add tests
- [ ] Add entry to changelog
- [ ] Add changes to documentation (guides, repository pages, in-code descriptions)