### PR TITLE
test: fix expired twitter auth token

### DIFF
--- a/integration/test/ParseUserTest.js
+++ b/integration/test/ParseUserTest.js
@@ -959,7 +959,7 @@ describe('Parse User', () => {
     user.setPassword(uuidv4());
     await user.signUp();
 
-    await user.linkWith('twitter', { twitterAuthData });
+    await user.linkWith('twitter', { authData: twitterAuthData });
     expect(user.get('authData').twitter.id).toBe(twitterAuthData.id);
     expect(user._isLinked('twitter')).toBe(true);
 
@@ -975,7 +975,7 @@ describe('Parse User', () => {
     user.setPassword(uuidv4());
     await user.signUp();
 
-    await user.linkWith('twitter', { twitterAuthData });
+    await user.linkWith('twitter', { authData: twitterAuthData });
     await Parse.FacebookUtils.link(user);
 
     expect(Parse.FacebookUtils.isLinked(user)).toBe(true);

--- a/integration/test/ParseUserTest.js
+++ b/integration/test/ParseUserTest.js
@@ -3,6 +3,7 @@
 const assert = require('assert');
 const Parse = require('../../node');
 const uuidv4 = require('uuid/v4');
+const { twitterAuthData } = require('./helper');
 
 class CustomUser extends Parse.User {
   constructor(attributes) {
@@ -952,30 +953,14 @@ describe('Parse User', () => {
   });
 
   it('can link with twitter', async () => {
-    /*
-      To generate the auth data below, the Twitter app "GitHub CI Test App" has
-      been created, managed by the @ParsePlatform Twitter account. In case this
-      test starts to fail because the token has become invalid, generate a new
-      token according to the OAuth process described in the Twitter docs[1].
-
-      [1] https://developer.twitter.com/en/docs/authentication/oauth-1-0a/obtaining-user-access-tokens
-    */
-    const authData = {
-      id: 1506726799266430985,
-      consumer_key: 'jeQw6luN2PEWREtoFDb0FdGYf',
-      consumer_secret: 'VSFENh1X5UC4MLEuduHLtJDnf8Ydsh5KuSR4zZQufFCAGNtzcs',
-      auth_token: '1506726799266430985-NKM9tqVbPXMnLhHTLYB98SNGtxxi6v',
-      auth_token_secret: 'JpDVIINbqV5TK0th9nKiS1IVokZfjRj06FrXxCrkggF07',
-    };
     Parse.User.enableUnsafeCurrentUser();
     const user = new Parse.User();
     user.setUsername(uuidv4());
     user.setPassword(uuidv4());
     await user.signUp();
 
-    await user.linkWith('twitter', { authData });
-
-    expect(user.get('authData').twitter.id).toBe(authData.id);
+    await user.linkWith('twitter', { twitterAuthData });
+    expect(user.get('authData').twitter.id).toBe(twitterAuthData.id);
     expect(user._isLinked('twitter')).toBe(true);
 
     await user._unlinkFrom('twitter');
@@ -985,25 +970,18 @@ describe('Parse User', () => {
   it('can link with twitter and facebook', async () => {
     Parse.User.enableUnsafeCurrentUser();
     Parse.FacebookUtils.init();
-    const authData = {
-      id: 1506726799266430985,
-      consumer_key: 'jeQw6luN2PEWREtoFDb0FdGYf',
-      consumer_secret: 'VSFENh1X5UC4MLEuduHLtJDnf8Ydsh5KuSR4zZQufFCAGNtzcs',
-      auth_token: '1506726799266430985-NKM9tqVbPXMnLhHTLYB98SNGtxxi6v',
-      auth_token_secret: 'JpDVIINbqV5TK0th9nKiS1IVokZfjRj06FrXxCrkggF07',
-    };
     const user = new Parse.User();
     user.setUsername(uuidv4());
     user.setPassword(uuidv4());
     await user.signUp();
 
-    await user.linkWith('twitter', { authData });
+    await user.linkWith('twitter', { twitterAuthData });
     await Parse.FacebookUtils.link(user);
 
     expect(Parse.FacebookUtils.isLinked(user)).toBe(true);
     expect(user._isLinked('twitter')).toBe(true);
 
-    expect(user.get('authData').twitter.id).toBe(authData.id);
+    expect(user.get('authData').twitter.id).toBe(twitterAuthData.id);
     expect(user.get('authData').facebook.id).toBe('test');
   });
 

--- a/integration/test/ParseUserTest.js
+++ b/integration/test/ParseUserTest.js
@@ -952,14 +952,22 @@ describe('Parse User', () => {
   });
 
   it('can link with twitter', async () => {
-    Parse.User.enableUnsafeCurrentUser();
+    /*
+      To generate the auth data below, the Twitter app "GitHub CI Test App" has
+      been created, managed by the @ParsePlatform Twitter account. In case this
+      test starts to fail because the token has become invalid, generate a new
+      token according to the OAuth process described in the Twitter docs[1].
+
+      [1] https://developer.twitter.com/en/docs/authentication/oauth-1-0a/obtaining-user-access-tokens
+    */
     const authData = {
-      id: 227463280,
-      consumer_key: '5QiVwxr8FQHbo5CMw46Z0jquF',
-      consumer_secret: 'p05FDlIRAnOtqJtjIt0xcw390jCcjj56QMdE9B52iVgOEb7LuK',
-      auth_token: '227463280-lngpMGXdnG36JiuzGfAYbKcZUPwjmcIV2NqL9hWc',
-      auth_token_secret: 'G1tl1R0gaYKTyxw0uYJDKRoVhM16ifyLeMwIaKlFtPkQr',
+      id: 1506726799266430985,
+      consumer_key: 'jeQw6luN2PEWREtoFDb0FdGYf',
+      consumer_secret: 'VSFENh1X5UC4MLEuduHLtJDnf8Ydsh5KuSR4zZQufFCAGNtzcs',
+      auth_token: '1506726799266430985-NKM9tqVbPXMnLhHTLYB98SNGtxxi6v',
+      auth_token_secret: 'JpDVIINbqV5TK0th9nKiS1IVokZfjRj06FrXxCrkggF07',
     };
+    Parse.User.enableUnsafeCurrentUser();
     const user = new Parse.User();
     user.setUsername(uuidv4());
     user.setPassword(uuidv4());
@@ -978,11 +986,11 @@ describe('Parse User', () => {
     Parse.User.enableUnsafeCurrentUser();
     Parse.FacebookUtils.init();
     const authData = {
-      id: 227463280,
-      consumer_key: '5QiVwxr8FQHbo5CMw46Z0jquF',
-      consumer_secret: 'p05FDlIRAnOtqJtjIt0xcw390jCcjj56QMdE9B52iVgOEb7LuK',
-      auth_token: '227463280-lngpMGXdnG36JiuzGfAYbKcZUPwjmcIV2NqL9hWc',
-      auth_token_secret: 'G1tl1R0gaYKTyxw0uYJDKRoVhM16ifyLeMwIaKlFtPkQr',
+      id: 1506726799266430985,
+      consumer_key: 'jeQw6luN2PEWREtoFDb0FdGYf',
+      consumer_secret: 'VSFENh1X5UC4MLEuduHLtJDnf8Ydsh5KuSR4zZQufFCAGNtzcs',
+      auth_token: '1506726799266430985-NKM9tqVbPXMnLhHTLYB98SNGtxxi6v',
+      auth_token_secret: 'JpDVIINbqV5TK0th9nKiS1IVokZfjRj06FrXxCrkggF07',
     };
     const user = new Parse.User();
     user.setUsername(uuidv4());

--- a/integration/test/helper.js
+++ b/integration/test/helper.js
@@ -14,6 +14,22 @@ const mountPath = '/parse';
 const serverURL = 'http://localhost:1337/parse';
 let didChangeConfiguration = false;
 
+/*
+  To generate the auth data below, the Twitter app "GitHub CI Test App" has
+  been created, managed by the @ParsePlatform Twitter account. In case this
+  test starts to fail because the token has become invalid, generate a new
+  token according to the OAuth process described in the Twitter docs[1].
+
+  [1] https://developer.twitter.com/en/docs/authentication/oauth-1-0a/obtaining-user-access-tokens
+*/
+const twitterAuthData = {
+  id: '1506726799266430985',
+  consumer_key: 'jeQw6luN2PEWREtoFDb0FdGYf',
+  consumer_secret: 'VSFENh1X5UC4MLEuduHLtJDnf8Ydsh5KuSR4zZQufFCAGNtzcs',
+  auth_token: '1506726799266430985-NKM9tqVbPXMnLhHTLYB98SNGtxxi6v',
+  auth_token_secret: 'JpDVIINbqV5TK0th9nKiS1IVokZfjRj06FrXxCrkggF07',
+};
+
 const defaultConfiguration = {
   databaseURI: 'mongodb://localhost:27017/integration',
   appId: 'integration',
@@ -34,8 +50,8 @@ const defaultConfiguration = {
       appIds: 'test',
     },
     twitter: {
-      consumer_key: 'jeQw6luN2PEWREtoFDb0FdGYf',
-      consumer_secret: 'VSFENh1X5UC4MLEuduHLtJDnf8Ydsh5KuSR4zZQufFCAGNtzcs',
+      consumer_key: twitterAuthData.consumer_key,
+      consumer_secret: twitterAuthData.consumer_secret,
     },
   },
   verbose: false,
@@ -144,3 +160,5 @@ afterEach(async () => {
     await reconfigureServer();
   }
 });
+
+module.exports = { twitterAuthData };

--- a/integration/test/helper.js
+++ b/integration/test/helper.js
@@ -34,8 +34,8 @@ const defaultConfiguration = {
       appIds: 'test',
     },
     twitter: {
-      consumer_key: '5QiVwxr8FQHbo5CMw46Z0jquF',
-      consumer_secret: 'p05FDlIRAnOtqJtjIt0xcw390jCcjj56QMdE9B52iVgOEb7LuK',
+      consumer_key: 'jeQw6luN2PEWREtoFDb0FdGYf',
+      consumer_secret: 'VSFENh1X5UC4MLEuduHLtJDnf8Ydsh5KuSR4zZQufFCAGNtzcs',
     },
   },
   verbose: false,


### PR DESCRIPTION
### New Pull Request Checklist
<!--
    Check every following box [x] before submitting your PR.
    Click the "Preview" tab for better readability.
    Thanks for contributing to Parse Platform!
-->

- [x] I am not disclosing a [vulnerability](https://github.com/parse-community/parse-server/blob/master/SECURITY.md).
- [x] I am creating this PR in reference to an [issue](https://github.com/parse-community/Parse-SDK-JS/issues?q=is%3Aissue).

### Issue Description
Twitter auth related tests fail because they seem to be using real data, trying to verify user credentials against the Twitter API. Not sure that is even a good idea, but in any case the tests started to fail, so updated auth credentials.

Related issue: #n/a

### Approach
Updated credentials by creating a new Twitter app and new Twitter test account. No idea which app and account was used prior to that. This is using a dedicated Twitter test account under Parse Platform control, exclusively for GitHub CI testing. The Twitter app that has been authorized by the user is an app managed under the `@ParsePlatform` Twitter account.

### TODOs before merging
n/a