### PR TITLE
fix: creating a Parse.File with base64 string fails for some file types

### DIFF
--- a/changelogs/CHANGELOG_release.md
+++ b/changelogs/CHANGELOG_release.md
@@ -54,6 +54,8 @@ for (const className of classNames) {
 ### Bug Fixes
 - Fixes build for WeChat WeApp, to reduce package size, see [issue/#1331](https://github.com/parse-community/Parse-SDK-JS/issues/1331)
 
+- Fixes base64 formatting, see [issue/#1467](https://github.com/parse-community/Parse-SDK-JS/pull/1467)
+
 # [3.1.0](https://github.com/parse-community/Parse-SDK-JS/compare/3.0.0...3.1.0)
 
 ### Breaking Changes

--- a/changelogs/CHANGELOG_release.md
+++ b/changelogs/CHANGELOG_release.md
@@ -54,8 +54,6 @@ for (const className of classNames) {
 ### Bug Fixes
 - Fixes build for WeChat WeApp, to reduce package size, see [issue/#1331](https://github.com/parse-community/Parse-SDK-JS/issues/1331)
 
-- Fixes base64 formatting, see [issue/#1467](https://github.com/parse-community/Parse-SDK-JS/pull/1467)
-
 # [3.1.0](https://github.com/parse-community/Parse-SDK-JS/compare/3.0.0...3.1.0)
 
 ### Breaking Changes

--- a/integration/test/ParseFileTest.js
+++ b/integration/test/ParseFileTest.js
@@ -66,6 +66,7 @@ describe('Parse.File', () => {
 
   it('can get file data from base64', async () => {
     const file = new Parse.File('parse-server-logo', { base64: 'ParseA==' });
+    await file.save();
     let data = await file.getData();
     assert.equal(data, 'ParseA==');
     file._data = null;
@@ -79,6 +80,7 @@ describe('Parse.File', () => {
     const file = new Parse.File('parse-server-logo', {
       base64: 'data:image/jpeg;base64,ParseA==',
     });
+    await file.save();
     let data = await file.getData();
     assert.equal(data, 'ParseA==');
     file._data = null;

--- a/src/ParseFile.js
+++ b/src/ParseFile.js
@@ -158,7 +158,7 @@ class ParseFile {
         // If <mediatype> is omitted, it defaults to text/plain;charset=US-ASCII.
         // As a shorthand, "text/plain" can be omitted but the charset parameter supplied.
         if (dataUriRegex.test(data.base64)) {
-          type ||= 'text/plain';
+          type = type || 'text/plain';
         }
 
         this._source = {

--- a/src/ParseFile.js
+++ b/src/ParseFile.js
@@ -148,7 +148,9 @@ class ParseFile {
         // Check if data URI or base64 string is valid
         const validationRegex = new RegExp(base64Regex.source + '|' + dataUriRegex.source, 'i');
         if (!validationRegex.test(data.base64)) {
-          throw new Error('Files passed in must have valid data URIs or base64 encoded data.');
+          throw new Error(
+            'Cannot create a Parse.File without valid data URIs or base64 encoded data.'
+          );
         }
 
         const base64 = data.base64.split(',').slice(-1)[0];

--- a/src/ParseFile.js
+++ b/src/ParseFile.js
@@ -42,6 +42,16 @@ export type FileSource =
       type: string,
     };
 
+const base64Regex = new RegExp(
+  '([0-9a-zA-Z+/]{4})*(([0-9a-zA-Z+/]{2}==)|([0-9a-zA-Z+/]{3}=))',
+  'i'
+);
+
+const dataUriRegex = new RegExp(
+  `^\\s*data:([a-zA-Z]+\\/[-a-zA-Z0-9+.]+(;[a-z-]+=[a-zA-Z0-9+.-]+)?)?(;base64)?,(${base64Regex.source})*\\s*$`,
+  'i'
+);
+
 function b64Digit(number: number): string {
   if (number < 26) {
     return String.fromCharCode(65 + number);
@@ -135,6 +145,12 @@ class ParseFile {
           type: specifiedType,
         };
       } else if (data && typeof data.base64 === 'string') {
+        // Check if data URI or base64 string is valid
+        const validationRegex = new RegExp(base64Regex.source + '|' + dataUriRegex.source, 'i');
+        if (!validationRegex.test(data.base64)) {
+          throw new Error('Files passed in must have valid data URIs or base64 encoded data.');
+        }
+
         const base64 = data.base64.split(',').at(-1);
         const type = specifiedType || data.base64.split(';').at(0).split(':').at(1) || '';
 

--- a/src/ParseFile.js
+++ b/src/ParseFile.js
@@ -42,8 +42,6 @@ export type FileSource =
       type: string,
     };
 
-const dataUriRegexp = /^data:([a-zA-Z]+\/[-a-zA-Z0-9+.]+)(;charset=[a-zA-Z0-9\-\/]*)?;base64,/;
-
 function b64Digit(number: number): string {
   if (number < 26) {
     return String.fromCharCode(65 + number);
@@ -137,26 +135,18 @@ class ParseFile {
           type: specifiedType,
         };
       } else if (data && typeof data.base64 === 'string') {
-        const base64 = data.base64;
-        const commaIndex = base64.indexOf(',');
+        const base64 = data.base64.split(',').at(-1)
+        const type = specifiedType || data.split(':').at(1).split(';').at(0)
 
-        if (commaIndex !== -1) {
-          const matches = dataUriRegexp.exec(base64.slice(0, commaIndex + 1));
-          // if data URI with type and charset, there will be 4 matches.
-          this._data = base64.slice(commaIndex + 1);
-          this._source = {
-            format: 'base64',
-            base64: this._data,
-            type: matches[1],
-          };
-        } else {
-          this._data = base64;
-          this._source = {
-            format: 'base64',
-            base64: base64,
-            type: specifiedType,
-          };
+        if (!type) {
+          throw new Error('File must have a valid type.');
         }
+
+        this._source = {
+          format: 'base64',
+          base64,
+          type,
+        };
       } else {
         throw new TypeError('Cannot create a Parse.File with that data.');
       }

--- a/src/ParseFile.js
+++ b/src/ParseFile.js
@@ -152,7 +152,7 @@ class ParseFile {
         }
 
         const base64 = data.base64.split(',').at(-1);
-        const type = specifiedType || data.base64.split(';').at(0).split(':').at(1) || '';
+        const type = specifiedType || data.base64.split(';').at(0).split(':').at(1) || 'text/plain';
 
         this._source = {
           format: 'base64',

--- a/src/ParseFile.js
+++ b/src/ParseFile.js
@@ -48,7 +48,7 @@ const base64Regex = new RegExp(
 );
 
 const dataUriRegex = new RegExp(
-  `^\\s*data:([a-zA-Z]+\\/[-a-zA-Z0-9+.]+(;[a-z-]+=[a-zA-Z0-9+.-]+)?)?(;base64)?,(${base64Regex.source})*\\s*$`,
+  `^data:([a-zA-Z]+\\/[-a-zA-Z0-9+.]+(;[a-z-]+=[a-zA-Z0-9+.-]+)?)?(;base64)?,(${base64Regex.source})*$`,
   'i'
 );
 

--- a/src/ParseFile.js
+++ b/src/ParseFile.js
@@ -135,12 +135,8 @@ class ParseFile {
           type: specifiedType,
         };
       } else if (data && typeof data.base64 === 'string') {
-        const base64 = data.base64.split(',').at(-1)
-        const type = specifiedType || data.split(':').at(1).split(';').at(0)
-
-        if (!type) {
-          throw new Error('File must have a valid type.');
-        }
+        const base64 = data.base64.split(',').at(-1);
+        const type = specifiedType || data.base64.split(';').at(0).split(':').at(1) || '';
 
         this._source = {
           format: 'base64',

--- a/src/ParseFile.js
+++ b/src/ParseFile.js
@@ -152,7 +152,14 @@ class ParseFile {
         }
 
         const base64 = data.base64.split(',').at(-1);
-        const type = specifiedType || data.base64.split(';').at(0).split(':').at(1) || 'text/plain';
+        let type = specifiedType || data.base64.split(';').at(0).split(':').at(1) || '';
+
+        // https://tools.ietf.org/html/rfc2397
+        // If <mediatype> is omitted, it defaults to text/plain;charset=US-ASCII.
+        // As a shorthand, "text/plain" can be omitted but the charset parameter supplied.
+        if (dataUriRegex.test(data.base64)) {
+          type ||= 'text/plain';
+        }
 
         this._source = {
           format: 'base64',

--- a/src/ParseFile.js
+++ b/src/ParseFile.js
@@ -151,8 +151,9 @@ class ParseFile {
           throw new Error('Files passed in must have valid data URIs or base64 encoded data.');
         }
 
-        const base64 = data.base64.split(',').at(-1);
-        let type = specifiedType || data.base64.split(';').at(0).split(':').at(1) || '';
+        const base64 = data.base64.split(',').slice(-1)[0];
+        let type =
+          specifiedType || data.base64.split(';').slice(0, 1)[0].split(':').slice(1, 2)[0] || '';
 
         // https://tools.ietf.org/html/rfc2397
         // If <mediatype> is omitted, it defaults to text/plain;charset=US-ASCII.

--- a/src/__tests__/ParseFile-test.js
+++ b/src/__tests__/ParseFile-test.js
@@ -67,11 +67,17 @@ describe('ParseFile', () => {
   });
 
   it('can extract data type from base64', () => {
-    const file = new ParseFile('parse.txt', {
+    const file1 = new ParseFile('parse.txt', {
       base64: 'data:image/png;base64,ParseA==',
     });
-    expect(file._source.base64).toBe('ParseA==');
-    expect(file._source.type).toBe('image/png');
+    expect(file1._source.base64).toBe('ParseA==');
+    expect(file1._source.type).toBe('image/png');
+
+    const file2 = new ParseFile('parse.txt', {
+      base64: 'data:application/pdf;filename=test.pdf;base64,ParseA==',
+    });
+    expect(file2._source.base64).toBe('ParseA==');
+    expect(file2._source.type).toBe('application/pdf');
   });
 
   it('can create files with file uri', () => {

--- a/src/__tests__/ParseFile-test.js
+++ b/src/__tests__/ParseFile-test.js
@@ -67,17 +67,19 @@ describe('ParseFile', () => {
   });
 
   it('can extract data type from base64', () => {
-    const file1 = new ParseFile('parse.txt', {
+    const file = new ParseFile('parse.png', {
       base64: 'data:image/png;base64,ParseA==',
     });
-    expect(file1._source.base64).toBe('ParseA==');
-    expect(file1._source.type).toBe('image/png');
+    expect(file._source.base64).toBe('ParseA==');
+    expect(file._source.type).toBe('image/png');
+  });
 
-    const file2 = new ParseFile('parse.txt', {
-      base64: 'data:application/pdf;filename=test.pdf;base64,ParseA==',
+  it('can extract data type from base64 with a filename parameter', () => {
+    const file = new ParseFile('parse.pdf', {
+      base64: 'data:application/pdf;filename=parse.pdf;base64,ParseA==',
     });
-    expect(file2._source.base64).toBe('ParseA==');
-    expect(file2._source.type).toBe('application/pdf');
+    expect(file._source.base64).toBe('ParseA==');
+    expect(file._source.type).toBe('application/pdf');
   });
 
   it('can create files with file uri', () => {

--- a/src/__tests__/ParseFile-test.js
+++ b/src/__tests__/ParseFile-test.js
@@ -66,6 +66,14 @@ describe('ParseFile', () => {
     expect(file._source.type).toBe('');
   });
 
+  it('can set the default type to be text/plain when using base64', () => {
+    const file = new ParseFile('parse.txt', {
+      base64: 'data:;base64,ParseA==',
+    });
+    expect(file._source.base64).toBe('ParseA==');
+    expect(file._source.type).toBe('text/plain');
+  });
+
   it('can extract data type from base64', () => {
     const file = new ParseFile('parse.png', {
       base64: 'data:image/png;base64,ParseA==',

--- a/src/__tests__/ParseFile-test.js
+++ b/src/__tests__/ParseFile-test.js
@@ -152,6 +152,12 @@ describe('ParseFile', () => {
     expect(function () {
       new ParseFile('parse.txt', 'string');
     }).toThrow('Cannot create a Parse.File with that data.');
+
+    expect(function () {
+      new ParseFile('parse.txt', {
+        base64: 'abc',
+      });
+    }).toThrow('Cannot create a Parse.File without valid data URIs or base64 encoded data.');
   });
 
   it('throws with invalid base64', () => {


### PR DESCRIPTION
### New Pull Request Checklist
<!--
    Check every following box [x] before submitting your PR.
    Click the "Preview" tab for better readability.
    Thanks for contributing to Parse Platform!
-->

- [x] I am not disclosing a [vulnerability](https://github.com/parse-community/parse-server/blob/master/SECURITY.md).
- [x] I am creating this PR in reference to an [issue](https://github.com/parse-community/Parse-SDK-JS/issues?q=is%3Aissue).

### Issue Description
<!-- Add a brief description of the issue this PR solves. -->

Related issue: [#1466](https://github.com/parse-community/Parse-SDK-JS/issues/1466)

### Approach
<!-- Add a description of the approach in this PR. -->
Reworked logic for base64 formatting in ParseFile.js.

### TODOs before merging
<!--
    Add TODOs that need to be completed before merging this PR.
    Delete TODOs that do not apply to this PR.
-->

- [x] Add tests
- [x] Add entry to changelog