### PR TITLE
fix: invalid name for `Parse.Role` throws incorrect error

### DIFF
--- a/integration/test/ParseACLTest.js
+++ b/integration/test/ParseACLTest.js
@@ -533,4 +533,13 @@ describe('Parse.ACL', () => {
     const obj1withInclude = await query.first();
     assert(obj1withInclude.get('other').get('ACL'));
   });
+
+  it('prevents save with invalid role name', async () => {
+    expect(() => new Parse.Role(':%#', new Parse.ACL())).toThrow(
+      new Parse.Error(
+        Parse.Error.OTHER_CAUSE,
+        `A role's name can be only contain alphanumeric characters, _, -, and spaces.`
+      )
+    );
+  });
 });

--- a/src/ParseRole.js
+++ b/src/ParseRole.js
@@ -75,6 +75,7 @@ class ParseRole extends ParseObject {
    * @returns {(ParseObject|boolean)} true if the set succeeded.
    */
   setName(name: string, options?: mixed): ParseObject | boolean {
+    this._validateName(name);
     return this.set('name', name, options);
   }
 
@@ -108,6 +109,18 @@ class ParseRole extends ParseObject {
     return this.relation('roles');
   }
 
+  _validateName(newName) {
+    if (typeof newName !== 'string') {
+      throw new ParseError(ParseError.OTHER_CAUSE, "A role's name must be a String.");
+    }
+    if (!/^[0-9a-zA-Z\-_ ]+$/.test(newName)) {
+      throw new ParseError(
+        ParseError.OTHER_CAUSE,
+        "A role's name can be only contain alphanumeric characters, _, " + '-, and spaces.'
+      );
+    }
+  }
+
   validate(attrs: AttributeMap, options?: mixed): ParseError | boolean {
     const isInvalid = super.validate(attrs, options);
     if (isInvalid) {
@@ -125,14 +138,10 @@ class ParseRole extends ParseObject {
           "A role's name can only be set before it has been saved."
         );
       }
-      if (typeof newName !== 'string') {
-        return new ParseError(ParseError.OTHER_CAUSE, "A role's name must be a String.");
-      }
-      if (!/^[0-9a-zA-Z\-_ ]+$/.test(newName)) {
-        return new ParseError(
-          ParseError.OTHER_CAUSE,
-          "A role's name can be only contain alphanumeric characters, _, " + '-, and spaces.'
-        );
+      try {
+        this._validateName(newName);
+      } catch (e) {
+        return e;
       }
     }
     return false;

--- a/src/__tests__/ParseRole-test.js
+++ b/src/__tests__/ParseRole-test.js
@@ -45,6 +45,15 @@ describe('ParseRole', () => {
     expect(role.getName()).toBe('');
   });
 
+  it('should throw error string with invalid name', () => {
+    expect(() => new ParseRole('invalid:name')).toThrow(
+      new ParseError(
+        ParseError.OTHER_CAUSE,
+        "A role's name can be only contain alphanumeric characters, _, " + '-, and spaces.'
+      )
+    );
+  });
+
   it('can validate attributes', () => {
     const acl = new ParseACL({ aUserId: { read: true, write: true } });
     const role = new ParseRole('admin', acl);

--- a/src/__tests__/ParseRole-test.js
+++ b/src/__tests__/ParseRole-test.js
@@ -46,7 +46,7 @@ describe('ParseRole', () => {
   });
 
   it('should throw error string with invalid name', () => {
-    expect(() => new ParseRole('invalid:name')).toThrow(
+    expect(() => new ParseRole('invalid:name', new ParseACL())).toThrow(
       new ParseError(
         ParseError.OTHER_CAUSE,
         "A role's name can be only contain alphanumeric characters, _, " + '-, and spaces.'


### PR DESCRIPTION
### New Pull Request Checklist
<!--
    Check every following box [x] before submitting your PR.
    Click the "Preview" tab for better readability.
    Thanks for contributing to Parse Platform!
-->

- [x] I am not disclosing a [vulnerability](https://github.com/parse-community/parse-server/blob/master/SECURITY.md).
- [x] I am creating this PR in reference to an [issue](https://github.com/parse-community/Parse-SDK-JS/issues?q=is%3Aissue).

### Issue Description
<!-- Add a brief description of the issue this PR solves. -->

Creating a role with an invalid name does not throw an error, leaving the API to throw `Error: name is required`

Related issue: #1480

### Approach
<!-- Add a description of the approach in this PR. -->

Validate role name on create

### TODOs before merging
<!--
    Add TODOs that need to be completed before merging this PR.
    Delete TODOs that do not apply to this PR.
-->

- [x] Add tests