### PR TITLE
docs: wrong description for `Parse.User.requestEmailVerification` method

### DIFF
--- a/src/ParseUser.js
+++ b/src/ParseUser.js
@@ -779,7 +779,7 @@ class ParseUser extends ParseObject {
    * Request an email verification.
    *
    * @param {string} email The email address associated with the user that
-   *     forgot their password.
+   *     needs to verify their email.
    * @param {object} options
    * @static
    * @returns {Promise}


### PR DESCRIPTION
### New Pull Request Checklist
<!--
    Check every following box [x] before submitting your PR.
    Click the "Preview" tab for better readability.
    Thanks for contributing to Parse Platform!
-->

- [x] I am not disclosing a [vulnerability](https://github.com/parse-community/parse-server/blob/master/SECURITY.md).

### Description
In the api reference documentation the `Parse.User.requestEmailVerification` and the `Parse.User.requestPasswordReset` have the exact same descrition for the `email parameter`.


- [x] Add changes to documentation (guides, repository pages, in-code descriptions)