### PR TITLE
ci: fix auto-release

### DIFF
--- a/release.config.js
+++ b/release.config.js
@@ -83,21 +83,20 @@ async function config() {
       ['@semantic-release/git', {
         assets: [changelogFile, 'package.json', 'package-lock.json', 'npm-shrinkwrap.json'],
       }],
+      ['@semantic-release/github', {
+        successComment: getReleaseComment(),
+        labels: ['type:ci'],
+        releasedLabels: ['state:released<%= nextRelease.channel ? `-\${nextRelease.channel}` : "" %>']
+      }],
       [
         '@saithodev/semantic-release-backmerge',
         {
           'branches': [
             { from: 'beta', to: 'alpha' },
             { from: 'release', to: 'beta' },
-            { from: 'release', to: 'alpha' },
           ]
         }
       ],
-      ['@semantic-release/github', {
-        successComment: getReleaseComment(),
-        labels: ['type:ci'],
-        releasedLabels: ['state:released<%= nextRelease.channel ? `-\${nextRelease.channel}` : "" %>']
-      }],
     ],
   };
 


### PR DESCRIPTION
### New Pull Request Checklist
<!--
    Check every following box [x] before submitting your PR.
    Click the "Preview" tab for better readability.
    Thanks for contributing to Parse Platform!
-->

- [x] I am not disclosing a [vulnerability](https://github.com/parse-community/parse-server/blob/master/SECURITY.md).
- [x] I am creating this PR in reference to an [issue](https://github.com/parse-community/Parse-SDK-JS/issues?q=is%3Aissue).

### Issue Description
Auto-release back-merging over 2 sequential pre-release branches doesn't work.

Related issue: #n/a

### Approach
Disable backmerging of `alpha` when during release on `release`.

### TODOs before merging
n/a