### PR TITLE
ci: fix release scheduler not adapted for pre-release branches

### DIFF
--- a/.github/workflows/release-automated-scheduler.yml
+++ b/.github/workflows/release-automated-scheduler.yml
@@ -11,10 +11,10 @@ jobs:
   create-pr-release:
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout alpha branch
+      - name: Checkout beta branch
         uses: actions/checkout@v2
         with:
-          ref: alpha
+          ref: beta
       - name: Compose branch name for PR
         id: branch
         run: echo "::set-output name=name::build-release-${{ github.run_id }}${{ github.run_number }}"
@@ -34,6 +34,38 @@ jobs:
           pr_target: release
           pr_body: |
             ## Release
+
+            This pull request was created because a new release is due according to the release cycle of this repository.
+            Just resolve any conflicts and it's good to merge. Any version increment will be done by release automation.
+
+            *⚠️ Use `Merge commit` to merge this pull request. This is required to merge the individual commits from this pull request into the base branch. Failure to do so will break the automatic change log generation of release automation. Do not use "Squash and merge"!*
+  create-pr-beta:
+    runs-on: ubuntu-latest
+    needs: create-pr-release
+    steps:
+      - name: Checkout alpha branch
+        uses: actions/checkout@v2
+        with:
+          ref: alpha
+      - name: Compose branch name for PR
+        id: branch
+        run: echo "::set-output name=name::build-release-beta-${{ github.run_id }}${{ github.run_number }}"
+      - name: Create branch
+        run: |
+          git config --global user.email ${{ github.actor }}@users.noreply.github.com
+          git config --global user.name ${{ github.actor }}
+          git checkout -b ${{ steps.branch.outputs.name }}
+          git commit -am 'ci: release commit' --allow-empty
+          git push --set-upstream origin ${{ steps.branch.outputs.name }}
+      - name: Create PR
+        uses: k3rnels-actions/pr-update@v1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          pr_title: "build: release beta"
+          pr_source: ${{ steps.branch.outputs.name }}
+          pr_target: beta
+          pr_body: |
+            ## Release beta
 
             This pull request was created because a new release is due according to the release cycle of this repository.
             Just resolve any conflicts and it's good to merge. Any version increment will be done by release automation.


### PR DESCRIPTION
### New Pull Request Checklist
<!--
    Check every following box [x] before submitting your PR.
    Click the "Preview" tab for better readability.
    Thanks for contributing to Parse Platform!
-->

- [x] I am not disclosing a [vulnerability](https://github.com/parse-community/parse-server/blob/master/SECURITY.md).
- [x] I am creating this PR in reference to an [issue](https://github.com/parse-community/Parse-SDK-JS/issues?q=is%3Aissue).

### Issue Description

Release scheduler not adapted for pre-release branches; creates release PRs for alpha -> release merge which is incorrect

Related issue: #n/a

### Approach

Adapt scheduler for pre-release branches

### TODOs before merging
n/a