### PR TITLE
fix: creating a Parse.File with base64 string fails for some encodings

### DIFF
--- a/src/ParseFile.js
+++ b/src/ParseFile.js
@@ -43,7 +43,7 @@ export type FileSource =
     };
 
 const base64Regex = new RegExp(
-  '([0-9a-zA-Z+/]{4})*(([0-9a-zA-Z+/]{2}==)|([0-9a-zA-Z+/]{3}=))',
+  '([0-9a-zA-Z+/]{4})*(([0-9a-zA-Z+/]{2}==)|([0-9a-zA-Z+/]{3}=)|([0-9a-zA-Z+/]{4}))',
   'i'
 );
 

--- a/src/ParseFile.js
+++ b/src/ParseFile.js
@@ -43,7 +43,7 @@ export type FileSource =
     };
 
 const base64Regex = new RegExp(
-  '([0-9a-zA-Z+/]{4})*(([0-9a-zA-Z+/]{2}==)|([0-9a-zA-Z+/]{3}=)|([0-9a-zA-Z+/]{4}))',
+  '([0-9a-zA-Z+/]{4})*(([0-9a-zA-Z+/][AQgw]==)|([0-9a-zA-Z+/]{2}[AEIMQUYcgkosw048]=)|([0-9a-zA-Z+/]{4}))',
   'i'
 );
 

--- a/src/__tests__/ParseFile-test.js
+++ b/src/__tests__/ParseFile-test.js
@@ -66,6 +66,12 @@ describe('ParseFile', () => {
     expect(file._source.type).toBe('');
   });
 
+  it('can create files with base64 encoding (no padding)', () => {
+    const file = new ParseFile('parse.txt', { base64: 'SGVsbG8gV29ybGQh' });
+    expect(file._source.base64).toBe('SGVsbG8gV29ybGQh');
+    expect(file._source.type).toBe('');
+  });
+
   it('can set the default type to be text/plain when using base64', () => {
     const file = new ParseFile('parse.txt', {
       base64: 'data:;base64,ParseA==',

--- a/src/__tests__/ParseFile-test.js
+++ b/src/__tests__/ParseFile-test.js
@@ -60,15 +60,21 @@ describe('ParseFile', () => {
     process.env.PARSE_BUILD = 'node';
   });
 
-  it('can create files with base64 encoding', () => {
-    const file = new ParseFile('parse.txt', { base64: 'ParseA==' });
-    expect(file._source.base64).toBe('ParseA==');
+  it('can create files with base64 encoding (no padding)', () => {
+    const file = new ParseFile('parse.txt', { base64: 'YWJj' });
+    expect(file._source.base64).toBe('YWJj');
     expect(file._source.type).toBe('');
   });
 
-  it('can create files with base64 encoding (no padding)', () => {
-    const file = new ParseFile('parse.txt', { base64: 'SGVsbG8gV29ybGQh' });
-    expect(file._source.base64).toBe('SGVsbG8gV29ybGQh');
+  it('can create files with base64 encoding (1 padding)', () => {
+    const file = new ParseFile('parse.txt', { base64: 'YWI=' });
+    expect(file._source.base64).toBe('YWI=');
+    expect(file._source.type).toBe('');
+  });
+
+  it('can create files with base64 encoding (2 padding)', () => {
+    const file = new ParseFile('parse.txt', { base64: 'ParseA==' });
+    expect(file._source.base64).toBe('ParseA==');
     expect(file._source.type).toBe('');
   });
 


### PR DESCRIPTION
### New Pull Request Checklist
<!--
    Check every following box [x] before submitting your PR.
    Click the "Preview" tab for better readability.
    Thanks for contributing to Parse Platform!
-->

- [x] I am not disclosing a [vulnerability](https://github.com/parse-community/parse-server/blob/master/SECURITY.md).
- [x] I am creating this PR in reference to an [issue](https://github.com/parse-community/Parse-SDK-JS/issues?q=is%3Aissue).

### Issue Description
<!-- Add a brief description of the issue this PR solves. -->

Related issue: #1510

### Approach

Adding a failing unit test for reproducing base64 regex issue.

### TODOs before merging
<!--
    Add TODOs that need to be completed before merging this PR.
    Delete TODOs that do not apply to this PR.
-->

- [x] Add tests