### PR TITLE
fix: `Parse.User.signUp()` does not pass context to Cloud Code 

### DIFF
--- a/src/ParseUser.js
+++ b/src/ParseUser.js
@@ -425,6 +425,9 @@ class ParseUser extends ParseObject {
     if (options.hasOwnProperty('installationId')) {
       signupOptions.installationId = options.installationId;
     }
+    if (options.hasOwnProperty('context') && typeof options.context === 'object') {
+      signupOptions.context = options.context;
+    }
 
     const controller = CoreManager.getUserController();
     return controller.signUp(this, attrs, signupOptions);

--- a/src/ParseUser.js
+++ b/src/ParseUser.js
@@ -425,7 +425,10 @@ class ParseUser extends ParseObject {
     if (options.hasOwnProperty('installationId')) {
       signupOptions.installationId = options.installationId;
     }
-    if (options.hasOwnProperty('context') && typeof options.context === 'object') {
+    if (
+      options.hasOwnProperty('context') &&
+      Object.prototype.toString.call(options.context) === '[object Object]'
+    ) {
       signupOptions.context = options.context;
     }
 

--- a/src/__tests__/ParseUser-test.js
+++ b/src/__tests__/ParseUser-test.js
@@ -1681,6 +1681,30 @@ describe('ParseUser', () => {
     expect(user.existed()).toBe(true);
   });
 
+  it('can signup with context', async () => {
+    CoreManager.setRESTController({
+      ajax() {},
+      request() {
+        return Promise.resolve(
+          {
+            objectId: 'uid3',
+            username: 'username',
+            sessionToken: '123abc',
+          },
+          200
+        );
+      },
+    });
+    const controller = CoreManager.getRESTController();
+    jest.spyOn(controller, 'request');
+    const context = { a: 'a' };
+    const user = new ParseUser();
+    user.setUsername('name');
+    user.setPassword('pass');
+    await user.signUp(null, { context });
+    expect(controller.request.mock.calls[0][3].context).toEqual(context);
+  });
+
   it('can verify user password', async () => {
     ParseUser.enableUnsafeCurrentUser();
     ParseUser._clearCache();


### PR DESCRIPTION
### New Pull Request Checklist
<!--
    Check every following box [x] before submitting your PR.
    Click the "Preview" tab for better readability.
    Thanks for contributing to Parse Platform!
-->

- [x] I am not disclosing a [vulnerability](https://github.com/parse-community/parse-server/blob/master/SECURITY.md).
- [x] I am creating this PR in reference to an [issue](https://github.com/parse-community/Parse-SDK-JS/issues?q=is%3Aissue).

### Issue Description
<!-- Add a brief description of the issue this PR solves. -->

`context` object isn't passed to `signup`.

Related issue: #1526

### Approach
<!-- Add a description of the approach in this PR. -->

Pass context object

### TODOs before merging
<!--
    Add TODOs that need to be completed before merging this PR.
    Delete TODOs that do not apply to this PR.
-->

- [x] Add tests
