### PR TITLE
feat: add authorization header as query option

### DIFF
--- a/src/RESTController.js
+++ b/src/RESTController.js
@@ -35,6 +35,7 @@ export type FullOptions = {
   installationId?: string,
   progress?: any,
   usePost?: boolean,
+  authorizationHeader?: string,
 };
 
 let XHR = null;
@@ -163,6 +164,9 @@ const RESTController = {
       if (CoreManager.get('SERVER_AUTH_TYPE') && CoreManager.get('SERVER_AUTH_TOKEN')) {
         headers['Authorization'] =
           CoreManager.get('SERVER_AUTH_TYPE') + ' ' + CoreManager.get('SERVER_AUTH_TOKEN');
+      }
+      if (options?.authorizationHeader) {
+        headers['Authorization'] = options.authorizationHeader;
       }
       const customHeaders = CoreManager.get('REQUEST_HEADERS');
       for (const key in customHeaders) {

--- a/src/__tests__/RESTController-test.js
+++ b/src/__tests__/RESTController-test.js
@@ -540,6 +540,54 @@ describe('RESTController', () => {
     CoreManager.set('SERVER_AUTH_TOKEN', null);
   });
 
+  it('sends auth header when auth header option is provided', async () => {
+    const credentialsHeader = header => 'Authorization' === header[0];
+    const xhr = {
+      setRequestHeader: jest.fn(),
+      open: jest.fn(),
+      send: jest.fn(),
+    };
+    RESTController._setXHR(function () {
+      return xhr;
+    });
+    RESTController.request(
+      'GET',
+      'classes/MyObject',
+      {},
+      { authorizationHeader: 'Bearer some_random_token' }
+    );
+    await flushPromises();
+    expect(xhr.setRequestHeader.mock.calls.filter(credentialsHeader)).toEqual([
+      ['Authorization', 'Bearer some_random_token'],
+    ]);
+  });
+
+  it('auth header option overrides CoreManager auth header', async () => {
+    CoreManager.set('SERVER_AUTH_TYPE', 'Bearer');
+    CoreManager.set('SERVER_AUTH_TOKEN', 'some_random_token');
+    const credentialsHeader = header => 'Authorization' === header[0];
+    const xhr = {
+      setRequestHeader: jest.fn(),
+      open: jest.fn(),
+      send: jest.fn(),
+    };
+    RESTController._setXHR(function () {
+      return xhr;
+    });
+    RESTController.request(
+      'GET',
+      'classes/MyObject',
+      {},
+      { authorizationHeader: 'Bearer some_other_random_token' }
+    );
+    await flushPromises();
+    expect(xhr.setRequestHeader.mock.calls.filter(credentialsHeader)).toEqual([
+      ['Authorization', 'Bearer some_other_random_token'],
+    ]);
+    CoreManager.set('SERVER_AUTH_TYPE', null);
+    CoreManager.set('SERVER_AUTH_TOKEN', null);
+  });
+
   it('reports upload/download progress of the AJAX request when callback is provided', done => {
     const xhr = mockXHR([{ status: 200, response: { success: true } }], {
       progress: {


### PR DESCRIPTION
### New Pull Request Checklist
<!--
    Check every following box [x] before submitting your PR.
    Click the "Preview" tab for better readability.
    Thanks for contributing to Parse Platform!
-->

- [x] I am not disclosing a [vulnerability](https://github.com/parse-community/parse-server/blob/master/SECURITY.md).
- [x] I am creating this PR in reference to an [issue](https://github.com/parse-community/Parse-SDK-JS/issues?q=is%3Aissue).

### Issue Description
<!-- Add a brief description of the issue this PR solves. -->

Related issue: #1528 

### Approach
<!-- Add a description of the approach in this PR. -->

I chose the simple option for now and added a specific option for adding the auth header. I could change this to a map of multiple header options as mentioned in #1528 if preferred.

### TODOs before merging
<!--
    Add TODOs that need to be completed before merging this PR.
    Delete TODOs that do not apply to this PR.
-->

- [x] Add tests
- [ ] Add entry to changelog
- [ ] Add changes to documentation (guides, repository pages, in-code descriptions)