### PR TITLE
fix: remove base64 validation due to validation inefficiency

### DIFF
--- a/src/ParseFile.js
+++ b/src/ParseFile.js
@@ -42,16 +42,6 @@ export type FileSource =
       type: string,
     };
 
-const base64Regex = new RegExp(
-  '([0-9a-zA-Z+/]{4})*(([0-9a-zA-Z+/][AQgw]==)|([0-9a-zA-Z+/]{2}[AEIMQUYcgkosw048]=)|([0-9a-zA-Z+/]{4}))',
-  'i'
-);
-
-const dataUriRegex = new RegExp(
-  `^data:([a-zA-Z]+\\/[-a-zA-Z0-9+.]+(;[a-z-]+=[a-zA-Z0-9+.-]+)?)?(;base64)?,(${base64Regex.source})*$`,
-  'i'
-);
-
 function b64Digit(number: number): string {
   if (number < 26) {
     return String.fromCharCode(65 + number);
@@ -145,29 +135,13 @@ class ParseFile {
           type: specifiedType,
         };
       } else if (data && typeof data.base64 === 'string') {
-        // Check if data URI or base64 string is valid
-        const validationRegex = new RegExp(base64Regex.source + '|' + dataUriRegex.source, 'i');
-        if (!validationRegex.test(data.base64)) {
-          throw new Error(
-            'Cannot create a Parse.File without valid data URIs or base64 encoded data.'
-          );
-        }
-
         const base64 = data.base64.split(',').slice(-1)[0];
-        let type =
-          specifiedType || data.base64.split(';').slice(0, 1)[0].split(':').slice(1, 2)[0] || '';
-
-        // https://tools.ietf.org/html/rfc2397
-        // If <mediatype> is omitted, it defaults to text/plain;charset=US-ASCII.
-        // As a shorthand, "text/plain" can be omitted but the charset parameter supplied.
-        if (dataUriRegex.test(data.base64)) {
-          type = type || 'text/plain';
-        }
-
+        const dataType =
+          specifiedType || data.base64.split(';').slice(0, 1)[0].split(':').slice(1, 2)[0] || 'text/plain';
         this._source = {
           format: 'base64',
           base64,
-          type,
+          type: dataType,
         };
       } else {
         throw new TypeError('Cannot create a Parse.File with that data.');

--- a/src/__tests__/ParseFile-test.js
+++ b/src/__tests__/ParseFile-test.js
@@ -63,19 +63,19 @@ describe('ParseFile', () => {
   it('can create files with base64 encoding (no padding)', () => {
     const file = new ParseFile('parse.txt', { base64: 'YWJj' });
     expect(file._source.base64).toBe('YWJj');
-    expect(file._source.type).toBe('');
+    expect(file._source.type).toBe('text/plain');
   });
 
   it('can create files with base64 encoding (1 padding)', () => {
     const file = new ParseFile('parse.txt', { base64: 'YWI=' });
     expect(file._source.base64).toBe('YWI=');
-    expect(file._source.type).toBe('');
+    expect(file._source.type).toBe('text/plain');
   });
 
   it('can create files with base64 encoding (2 padding)', () => {
     const file = new ParseFile('parse.txt', { base64: 'ParseA==' });
     expect(file._source.base64).toBe('ParseA==');
-    expect(file._source.type).toBe('');
+    expect(file._source.type).toBe('text/plain');
   });
 
   it('can set the default type to be text/plain when using base64', () => {
@@ -164,12 +164,6 @@ describe('ParseFile', () => {
     expect(function () {
       new ParseFile('parse.txt', 'string');
     }).toThrow('Cannot create a Parse.File with that data.');
-
-    expect(function () {
-      new ParseFile('parse.txt', {
-        base64: 'abc',
-      });
-    }).toThrow('Cannot create a Parse.File without valid data URIs or base64 encoded data.');
   });
 
   it('throws with invalid base64', () => {


### PR DESCRIPTION
### New Pull Request Checklist
<!--
    Check every following box [x] before submitting your PR.
    Click the "Preview" tab for better readability.
    Thanks for contributing to Parse Platform!
-->

- [x] I am not disclosing a [vulnerability](https://github.com/parse-community/parse-server/blob/master/SECURITY.md).
- [x] I am creating this PR in reference to an [issue](https://github.com/parse-community/Parse-SDK-JS/issues?q=is%3Aissue).

### Issue Description
<!-- Add a brief description of the issue this PR solves. -->

RegExp validation of base64 can take a long time to resolve

Related issue: #1532

### Approach
<!-- Add a description of the approach in this PR. -->

Removes client side base64 validation.

### TODOs before merging
<!--
    Add TODOs that need to be completed before merging this PR.
    Delete TODOs that do not apply to this PR.
-->

- [x] Add tests