### PR TITLE
fix: `Schema.addField` does not correctly add value of type `Date`

### DIFF
--- a/src/ParseSchema.js
+++ b/src/ParseSchema.js
@@ -241,6 +241,14 @@ class ParseSchema {
     if (options.defaultValue !== undefined) {
       fieldOptions.defaultValue = options.defaultValue;
     }
+    if (type === 'Date') {
+      if (options && options.defaultValue) {
+        fieldOptions.defaultValue = {
+          __type: 'Date',
+          iso: new Date(options.defaultValue),
+        };
+      }
+    }
     this._fields[name] = fieldOptions;
     return this;
   }
@@ -310,12 +318,6 @@ class ParseSchema {
    * @returns {Parse.Schema} Returns the schema, so you can chain this call.
    */
   addDate(name: string, options: FieldOptions) {
-    if (options && options.defaultValue) {
-      options.defaultValue = {
-        __type: 'Date',
-        iso: new Date(options.defaultValue),
-      };
-    }
     return this.addField(name, 'Date', options);
   }
 

--- a/src/__tests__/ParseSchema-test.js
+++ b/src/__tests__/ParseSchema-test.js
@@ -194,6 +194,15 @@ describe('ParseSchema', () => {
     }
   });
 
+  it('can add date field with default value', () => {
+    const schema = new ParseSchema('NewSchemaTest');
+    const date = new Date();
+    schema.addDate('testField', { defaultValue: date });
+    schema.addField('testField2', 'Date', { defaultValue: date });
+    expect(schema._fields.testField.defaultValue).toEqual({ __type: 'Date', iso: date });
+    expect(schema._fields.testField2.defaultValue).toEqual({ __type: 'Date', iso: date });
+  });
+
   it('cannot add index with null name', done => {
     try {
       const schema = new ParseSchema('SchemaTest');


### PR DESCRIPTION
### New Pull Request Checklist
<!--
    Check every following box [x] before submitting your PR.
    Click the "Preview" tab for better readability.
    Thanks for contributing to Parse Platform!
-->

- [x] I am not disclosing a [vulnerability](https://github.com/parse-community/parse-server/blob/master/SECURITY.md).
- [x] I am creating this PR in reference to an [issue](https://github.com/parse-community/Parse-SDK-JS/issues?q=is%3Aissue).

### Issue Description
<!-- Add a brief description of the issue this PR solves. -->

`Schema.addField` with type of date does not correctly convert date to iso object.

Related issue: https://github.com/parse-community/Parse-SDK-JS/issues/1545

### Approach
<!-- Add a description of the approach in this PR. -->

Fixes `addField` for date type

### TODOs before merging
<!--
    Add TODOs that need to be completed before merging this PR.
    Delete TODOs that do not apply to this PR.
-->

- [x] Add tests
- [x] Add changes to documentation (guides, repository pages, in-code descriptions)