### PR TITLE
ci: enable dependabot updates for Parse Server dependency

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,17 @@
+# Dependabot dependency updates
+# Docs: https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    # Location of package-lock.json
+    directory: "/"
+    # Check daily for updates
+    schedule:
+      interval: "daily"
+    commit-message:
+      # Set commit message prefix
+      prefix: "refactor"
+    # Define dependencies to update
+    allow:
+      - dependency-name: "parse-server"


### PR DESCRIPTION
### New Pull Request Checklist
<!--
    Check every following box [x] before submitting your PR.
    Click the "Preview" tab for better readability.
    Thanks for contributing to Parse Platform!
-->

- [x] I am not disclosing a [vulnerability](https://github.com/parse-community/parse-server/blob/master/SECURITY.md).
- [x] I am creating this PR in reference to an [issue](https://github.com/parse-community/Parse-SDK-JS/issues?q=is%3Aissue).

### Issue Description

The parse-server dependency to test against in the CI points to the `parse-server@alpha` branch. Parse Server isn't updated in `package-lock.json` when a new commit is made on the alpha branch, because dependabot and Synk only detect new releases and cannot compare `alpha` to a pre-release tag.

Related issue: https://github.com/parse-community/Parse-SDK-JS/issues/1515

### Approach

Enables dependabot updates for parse-server dependency.

### TODOs before merging
n/a