### PR TITLE
fix: initialization fails in non-browser environment that doesn't support `indexedDB`

### DIFF
--- a/src/IndexedDBStorageController.js
+++ b/src/IndexedDBStorageController.js
@@ -1,10 +1,11 @@
 /**
  * @flow
  */
+/* global window */
 
 import { createStore, del, set, get, clear, keys } from 'idb-keyval';
 
-try {
+if (window && window.indexedDB) {
   const ParseStore = createStore('parseDB', 'parseStore');
 
   const IndexedDBStorageController = {
@@ -27,6 +28,7 @@ try {
   };
 
   module.exports = IndexedDBStorageController;
-} catch (e) {
+} else {
   // IndexedDB not supported
+  module.exports = undefined;
 }

--- a/src/IndexedDBStorageController.js
+++ b/src/IndexedDBStorageController.js
@@ -5,7 +5,7 @@
 
 import { createStore, del, set, get, clear, keys } from 'idb-keyval';
 
-if (window && window.indexedDB) {
+if (typeof window !== 'undefined' && window.indexedDB) {
   const ParseStore = createStore('parseDB', 'parseStore');
 
   const IndexedDBStorageController = {

--- a/src/Parse.js
+++ b/src/Parse.js
@@ -246,8 +246,9 @@ Parse.Storage = require('./Storage');
 Parse.User = require('./ParseUser').default;
 Parse.LiveQuery = require('./ParseLiveQuery').default;
 Parse.LiveQueryClient = require('./LiveQueryClient').default;
-Parse.IndexedDB = require('./IndexedDBStorageController');
-
+if (process.env.PARSE_BUILD === 'browser') {
+  Parse.IndexedDB = require('./IndexedDBStorageController');
+}
 Parse._request = function (...args) {
   return CoreManager.getRESTController().request.apply(null, args);
 };

--- a/src/__tests__/Parse-test.js
+++ b/src/__tests__/Parse-test.js
@@ -16,6 +16,7 @@ jest.dontMock('../LocalDatastore');
 jest.dontMock('crypto-js/aes');
 jest.setMock('../EventuallyQueue', { poll: jest.fn() });
 
+global.indexedDB = require('./test_helpers/mockIndexedDB');
 const CoreManager = require('../CoreManager');
 const EventuallyQueue = require('../EventuallyQueue');
 const Parse = require('../Parse');
@@ -240,7 +241,6 @@ describe('Parse module', () => {
   });
 
   it('can get IndexedDB storage', () => {
-    console.log(Parse.IndexedDB);
     expect(Parse.IndexedDB).toBeDefined();
     CoreManager.setStorageController(Parse.IndexedDB);
     const currentStorage = CoreManager.getStorageController();

--- a/src/__tests__/Parse-test.js
+++ b/src/__tests__/Parse-test.js
@@ -19,9 +19,15 @@ jest.setMock('../EventuallyQueue', { poll: jest.fn() });
 global.indexedDB = require('./test_helpers/mockIndexedDB');
 const CoreManager = require('../CoreManager');
 const EventuallyQueue = require('../EventuallyQueue');
-const Parse = require('../Parse');
 
 describe('Parse module', () => {
+  let Parse;
+  beforeEach(() => {
+    jest.isolateModules(() => {
+      Parse = require('../Parse');
+    });
+  });
+
   it('can be initialized with keys', () => {
     Parse.initialize('A', 'B');
     expect(CoreManager.get('APPLICATION_ID')).toBe('A');
@@ -166,6 +172,7 @@ describe('Parse module', () => {
     Parse.enableEncryptedUser();
     expect(Parse.encryptedUser).toBe(true);
     expect(Parse.isEncryptedUserEnabled()).toBe(true);
+    process.env.PARSE_BUILD = 'node';
   });
 
   it('can set an encrypt token as String', () => {
@@ -241,9 +248,13 @@ describe('Parse module', () => {
   });
 
   it('can get IndexedDB storage', () => {
-    expect(Parse.IndexedDB).toBeDefined();
-    CoreManager.setStorageController(Parse.IndexedDB);
+    expect(Parse.IndexedDB).toBeUndefined();
+    process.env.PARSE_BUILD = 'browser';
+    const ParseInstance = require('../Parse');
+    expect(ParseInstance.IndexedDB).toBeDefined();
+    CoreManager.setStorageController(ParseInstance.IndexedDB);
     const currentStorage = CoreManager.getStorageController();
-    expect(currentStorage).toEqual(Parse.IndexedDB);
+    expect(currentStorage).toEqual(ParseInstance.IndexedDB);
+    process.env.PARSE_BUILD = 'node';
   });
 });

--- a/src/__tests__/Storage-test.js
+++ b/src/__tests__/Storage-test.js
@@ -17,6 +17,7 @@ const CoreManager = require('../CoreManager');
 
 global.wx = mockWeChat;
 global.localStorage = mockStorageInterface;
+global.indexedDB = mockIndexedDB;
 jest.mock('idb-keyval', () => {
   return mockIndexedDB;
 });
@@ -165,10 +166,12 @@ describe('React Native StorageController', () => {
   });
 });
 
-const IndexedDBStorageController = require('../IndexedDBStorageController');
-
-describe('React Native StorageController', () => {
+describe('IndexDB StorageController', () => {
+  let IndexedDBStorageController;
   beforeEach(() => {
+    jest.isolateModules(() => {
+      IndexedDBStorageController = require('../IndexedDBStorageController');
+    });
     IndexedDBStorageController.clear();
   });
 
@@ -202,6 +205,13 @@ describe('React Native StorageController', () => {
     expect(result).toBe('myValue');
     const keys = await IndexedDBStorageController.getAllKeysAsync();
     expect(keys[0]).toBe('myKey');
+  });
+
+  it('handle indexedDB is not defined', async () => {
+    global.indexedDB = undefined;
+    const dbController = require('../IndexedDBStorageController');
+    expect(dbController).toBeUndefined();
+    global.indexedDB = mockIndexedDB;
   });
 });
 


### PR DESCRIPTION
### New Pull Request Checklist
<!--
    Check every following box [x] before submitting your PR.
    Click the "Preview" tab for better readability.
    Thanks for contributing to Parse Platform!
-->

- [x] I am not disclosing a [vulnerability](https://github.com/parse-community/parse-server/blob/master/SECURITY.md).
- [x] I am creating this PR in reference to an [issue](https://github.com/parse-community/Parse-SDK-JS/issues?q=is%3Aissue).

### Issue Description
<!-- Add a brief description of the issue this PR solves. -->

IndexedDB is only available in the browser. `createStore` is a promise that runs in the background. If indexedDB isn't supported, the promise rejects with `Unhandled promise rejection`.

Closes: https://github.com/parse-community/Parse-SDK-JS/issues/1552, https://github.com/parse-community/Parse-SDK-JS/issues/1440, https://github.com/parse-community/Parse-SDK-JS/issues/1505, https://github.com/parse-community/Parse-SDK-JS/issues/1441

### Approach
<!-- Add a description of the approach in this PR. -->

* Add indexedDBStorageController for `process.env.PARSE_BUILD === 'browser'`
* Check if indexedDB exists

### TODOs before merging
<!--
    Add TODOs that need to be completed before merging this PR.
    Delete TODOs that do not apply to this PR.
-->

- [x] Add tests