### PR TITLE
fix: react Native build does not maintain arrow functions and causes error with AsyncStorage

### DIFF
--- a/integration/test/ParseLocalDatastoreTest.js
+++ b/integration/test/ParseLocalDatastoreTest.js
@@ -2899,7 +2899,7 @@ describe('Parse LocalDatastore', () => {
     { name: 'Default', file: '../../lib/node/LocalDatastoreController' },
     {
       name: 'React-Native',
-      file: '../../lib/node/LocalDatastoreController.react-native',
+      file: '../../lib/react-native/LocalDatastoreController.react-native',
     },
   ];
 

--- a/integration/test/ParseLocalDatastoreTest.js
+++ b/integration/test/ParseLocalDatastoreTest.js
@@ -2899,7 +2899,7 @@ describe('Parse LocalDatastore', () => {
     { name: 'Default', file: '../../lib/node/LocalDatastoreController' },
     {
       name: 'React-Native',
-      file: '../../lib/react-native/LocalDatastoreController.react-native',
+      file: '../../lib/node/LocalDatastoreController.react-native',
     },
   ];
 

--- a/src/StorageController.react-native.js
+++ b/src/StorageController.react-native.js
@@ -9,19 +9,14 @@
  * @flow
  * @private
  */
-
 import CoreManager from './CoreManager';
 
 const StorageController = {
   async: 1,
 
-  getAsyncStorage(): any {
-    return CoreManager.getAsyncStorage();
-  },
-
   getItemAsync(path: string): Promise {
     return new Promise((resolve, reject) => {
-      this.getAsyncStorage().getItem(path, function (err, value) {
+      CoreManager.getAsyncStorage().getItem(path, (err, value) => {
         if (err) {
           reject(err);
         } else {
@@ -33,7 +28,7 @@ const StorageController = {
 
   setItemAsync(path: string, value: string): Promise {
     return new Promise((resolve, reject) => {
-      this.getAsyncStorage().setItem(path, value, function (err, value) {
+      CoreManager.getAsyncStorage().setItem(path, value, (err, value) => {
         if (err) {
           reject(err);
         } else {
@@ -45,7 +40,7 @@ const StorageController = {
 
   removeItemAsync(path: string): Promise {
     return new Promise((resolve, reject) => {
-      this.getAsyncStorage().removeItem(path, function (err) {
+      CoreManager.getAsyncStorage().removeItem(path, (err) => {
         if (err) {
           reject(err);
         } else {
@@ -57,7 +52,7 @@ const StorageController = {
 
   getAllKeysAsync(): Promise {
     return new Promise((resolve, reject) => {
-      this.getAsyncStorage().getAllKeys(function (err, keys) {
+      CoreManager.getAsyncStorage().getAllKeys((err, keys) => {
         if (err) {
           reject(err);
         } else {
@@ -69,7 +64,7 @@ const StorageController = {
 
   multiGet(keys: Array<string>): Promise<Array<Array<string>>> {
     return new Promise((resolve, reject) => {
-      this.getAsyncStorage().multiGet(keys, function (err, result) {
+      CoreManager.getAsyncStorage().multiGet(keys, (err, result) => {
         if (err) {
           reject(err);
         } else {
@@ -81,7 +76,7 @@ const StorageController = {
 
   multiRemove(keys: Array<string>): Promise {
     return new Promise((resolve, reject) => {
-      this.getAsyncStorage().multiRemove(keys, function (err) {
+      CoreManager.getAsyncStorage().multiRemove(keys, (err) => {
         if (err) {
           reject(err);
         } else {
@@ -92,7 +87,7 @@ const StorageController = {
   },
 
   clear() {
-    return this.getAsyncStorage().clear();
+    return CoreManager.getAsyncStorage().clear();
   },
 };
 


### PR DESCRIPTION
### New Pull Request Checklist
<!--
    Check every following box [x] before submitting your PR.
    Click the "Preview" tab for better readability.
    Thanks for contributing to Parse Platform!
-->

- [x] I am not disclosing a [vulnerability](https://github.com/parse-community/parse-server/blob/master/SECURITY.md).
- [x] I am creating this PR in reference to an [issue](https://github.com/parse-community/Parse-SDK-JS/issues?q=is%3Aissue).

### Issue Description
<!-- Add a brief description of the issue this PR solves. -->

The `metro-react-native-babel-preset` turns arrow functions into anonymous functions by default.

`new Promise((resolve, reject) => {}` gets transpiled into 

```
new Promise(function(resolve, reject) {
// Can't use this.getAsyncStorage() because of scope
});
```

Related issue: https://github.com/parse-community/Parse-SDK-JS/issues/1580

### Approach
<!-- Add a description of the approach in this PR. -->

Remove getAsyncStorage wrapper 
