### PR TITLE
fix: Remove support for Node <14

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 [![Snyk Badge](https://snyk.io/test/github/parse-community/Parse-SDK-JS/badge.svg)](https://snyk.io/test/github/parse-community/Parse-SDK-JS)
 [![Coverage](http://codecov.io/github/parse-community/Parse-SDK-JS/coverage.svg?branch=alpha)](http://codecov.io/github/parse-community/Parse-SDK-JS?branch=alpha)
 
-[![Node Version](https://img.shields.io/badge/nodejs-12,_14,_15-green.svg?logo=node.js&style=flat)](https://nodejs.org/)
+[![Node Version](https://img.shields.io/badge/nodejs-14-green.svg?logo=node.js&style=flat)](https://nodejs.org/)
 [![auto-release](https://img.shields.io/badge/%F0%9F%9A%80-auto--release-9e34eb.svg)](https://github.com/parse-community/parse-dashboard/releases)
 
 [![npm latest version](https://img.shields.io/npm/v/parse/latest.svg)](https://www.npmjs.com/package/parse)
@@ -29,6 +29,7 @@ A library that gives you access to the powerful Parse Server backend from your J
 
 - [Getting Started](#getting-started)
   - [Using Parse on Different Platforms](#using-parse-on-different-platforms)
+- [Compatibility](#compatibility)
 - [Upgrading to Parse SDK 2.0.0](#upgrading-to-parse-sdk-200)
 - [3rd Party Authentications](#3rd-party-authentications)
 - [Want to ride the bleeding edge?](#want-to-ride-the-bleeding-edge)
@@ -89,6 +90,17 @@ $ npm install @types/parse
 
 Types are updated manually after every release. If a definition doesn't exist, please submit a pull request to [@types/parse][types-parse]
 
+## Compatibility
+
+### Node.js
+
+Parse JS SDK is continuously tested with the most recent releases of Node.js to ensure compatibility. We follow the [Node.js Long Term Support plan](https://github.com/nodejs/Release) and only test against versions that are officially supported and have not reached their end-of-life date.
+
+| Version    | Latest Version | End-of-Life | Compatible |
+|------------|----------------|-------------|------------|
+| Node.js 14 | 14.19.1        | April 2023  | ✅ Yes      |
+
+
 ## Upgrading to Parse SDK 2.0.0
 
 With Parse SDK 2.0.0, gone are the backbone style callbacks and Parse.Promises.
@@ -113,12 +125,12 @@ And don't forget, if you plan to deploy it remotely, you should run `npm install
 
 We really want Parse to be yours, to see it grow and thrive in the open source community. Please see the [Contributing to Parse Javascript SDK guide][contributing].
 
- 
+
 [3rd-party-auth]: http://docs.parseplatform.org/parse-server/guide/#oauth-and-3rd-party-authentication
 [contributing]: https://github.com/parse-community/Parse-SDK-JS/blob/master/CONTRIBUTING.md
 [custom-auth-module]: https://docs.parseplatform.org/js/guide/#custom-authentication-module
 [link-with]: https://docs.parseplatform.org/js/guide/#linking-users
 [migration]: https://github.com/parse-community/Parse-SDK-JS/blob/master/2.0.0.md
 [open-collective-link]: https://opencollective.com/parse-server
-[types-parse]: https://github.com/DefinitelyTyped/DefinitelyTyped/tree/master/types/parse 
+[types-parse]: https://github.com/DefinitelyTyped/DefinitelyTyped/tree/master/types/parse
 [license-link]: LICENSE

--- a/babel-jest.js
+++ b/babel-jest.js
@@ -3,7 +3,7 @@ const babelJest = require('babel-jest');
 module.exports = babelJest.createTransformer({
   presets: [["@babel/preset-env", {
     "targets": {
-      "node": "8"
+      "node": "14"
     },
     useBuiltIns: 'entry',
     corejs: 3,

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -27,7 +27,7 @@ const PRESETS = {
     "targets": "> 0.25%, not dead"
   }], '@babel/react'],
   'node': [["@babel/preset-env", {
-    "targets": { "node": "8" }
+    "targets": { "node": "14" }
   }]],
   'react-native': ['module:metro-react-native-babel-preset'],
 };

--- a/package.json
+++ b/package.json
@@ -122,6 +122,9 @@
       "git add"
     ]
   },
+  "engines": {
+    "node": ">=14.21.0 <17 || >=18 <19"
+  },
   "jest": {
     "automock": true,
     "collectCoverage": true,


### PR DESCRIPTION
### New Pull Request Checklist
<!--
    Check every following box [x] before submitting your PR.
    Click the "Preview" tab for better readability.
    Thanks for contributing to Parse Platform!
-->

- [x] I am not disclosing a [vulnerability](https://github.com/parse-community/parse-server/blob/master/SECURITY.md).
- [x] I am creating this PR in reference to an [issue](https://github.com/parse-community/Parse-SDK-JS/issues?q=is%3Aissue).

### Issue Description
<!-- Add a brief description of the issue this PR solves. -->

Currently Parse JS SDK supports NodeJS versions that have reached EOL.

Related issue: #1535
Closes https://github.com/parse-community/Parse-SDK-JS/issues/1535

### Approach
<!-- Add a description of the approach in this PR. -->

Removes Node 12 support, changes build target to Node 14

### TODOs before merging
<!--
    Add TODOs that need to be completed before merging this PR.
    Delete TODOs that do not apply to this PR.
-->

- [x] Add changes to documentation (guides, repository pages, in-code descriptions)