### PR TITLE
perf: Avoid CORS preflight request by removing upload listener when not used

### DIFF
--- a/src/RESTController.js
+++ b/src/RESTController.js
@@ -169,24 +169,24 @@ const RESTController = {
         headers[key] = customHeaders[key];
       }
 
-      function handleProgress(type, event) {
-        if (options && typeof options.progress === 'function') {
+      if (options && typeof options.progress === 'function') {
+        const handleProgress = function (type, event) {
           if (event.lengthComputable) {
             options.progress(event.loaded / event.total, event.loaded, event.total, { type });
           } else {
             options.progress(null, null, null, { type });
           }
-        }
-      }
-
-      xhr.onprogress = event => {
-        handleProgress('download', event);
-      };
-
-      if (xhr.upload) {
-        xhr.upload.onprogress = event => {
-          handleProgress('upload', event);
         };
+
+        xhr.onprogress = event => {
+          handleProgress('download', event);
+        };
+
+        if (xhr.upload) {
+          xhr.upload.onprogress = event => {
+            handleProgress('upload', event);
+          };
+        }
       }
 
       xhr.open(method, url, true);

--- a/src/__tests__/RESTController-test.js
+++ b/src/__tests__/RESTController-test.js
@@ -570,6 +570,20 @@ describe('RESTController', () => {
     );
   });
 
+  it('does not set upload progress listener when callback is not provided to avoid CORS pre-flight', () => {
+    const xhr = {
+      setRequestHeader: jest.fn(),
+      open: jest.fn(),
+      upload: jest.fn(),
+      send: jest.fn(),
+    };
+    RESTController._setXHR(function () {
+      return xhr;
+    });
+    RESTController.ajax('POST', 'users', {});
+    expect(xhr.upload.onprogress).toBeUndefined();
+  });
+
   it('does not upload progress when total is uncomputable', done => {
     const xhr = mockXHR([{ status: 200, response: { success: true } }], {
       progress: {

--- a/src/__tests__/test_helpers/mockXHR.js
+++ b/src/__tests__/test_helpers/mockXHR.js
@@ -35,8 +35,14 @@ function mockXHR(results, options = {}) {
       this.readyState = 4;
       attempts++;
       this.onreadystatechange();
-      this.onprogress(options.progress);
-      this.upload.onprogress(options.progress);
+
+      if (typeof this.onprogress === 'function') {
+        this.onprogress(options.progress);
+      }
+
+      if (typeof this.upload.onprogress === 'function') {
+        this.upload.onprogress(options.progress);
+      }
     },
   };
   return XHR;


### PR DESCRIPTION
### New Pull Request Checklist
<!--
    Check every following box [x] before submitting your PR.
    Click the "Preview" tab for better readability.
    Thanks for contributing to Parse Platform!
-->

- [x] I am not disclosing a [vulnerability](https://github.com/parse-community/parse-server/blob/master/SECURITY.md).
- [x] I am creating this PR in reference to an [issue](https://github.com/parse-community/Parse-SDK-JS/issues?q=is%3Aissue).

### Issue Description
<!-- Add a brief description of the issue this PR solves. -->

Related issue: #1609
Closes #1609

Starting with v2.13.0, most Parse JS SDK operations began triggering the need for a preflight request. This is due to the addition of a progress listener on upload for all XHR requests with `RESTController`: https://github.com/parse-community/Parse-SDK-JS/pull/1133 . This listener triggers the need for a preflight request: https://developer.mozilla.org/en-US/docs/Web/API/XMLHttpRequest/upload#sect1

> Note: Attaching event listeners to this object prevents the request from being a "simple request" and will cause a preflight request to be issued if cross-origin; see CORS.

While this upload progress listener is useful in cases where a progress callback is being used, it should not be set when no progress callback is provided to avoid the performance issue.

### Approach
<!-- Add a description of the approach in this PR. -->

Only set the progress listeners on the XHR when a progress callback is provided.

### TODOs before merging
<!--
    Add TODOs that need to be completed before merging this PR.
    Delete TODOs that do not apply to this PR.
-->

- [x] Add tests