### PR TITLE
fix: ParseError message handling 

### DIFF
--- a/src/ParseError.js
+++ b/src/ParseError.js
@@ -22,7 +22,14 @@ class ParseError extends Error {
     this.code = code;
     Object.defineProperty(this, 'message', {
       enumerable: true,
-      value: typeof message === 'string' ? message : JSON.stringify(message),
+      value:
+        typeof message === 'string'
+          ? message
+          : typeof message === 'object' &&
+            typeof message.toString === 'function' &&
+            message.toString() !== '[object Object]'
+            ? message.toString()
+            : JSON.stringify(message),
     });
   }
 

--- a/src/ParseError.js
+++ b/src/ParseError.js
@@ -20,6 +20,15 @@ class ParseError extends Error {
   constructor(code, message) {
     super(message);
     this.code = code;
+
+    const stringify = obj => {
+      let log = '';
+      for (const k in obj) {
+        log += `${obj[k]} `;
+      }
+      return log.trim();
+    };
+
     Object.defineProperty(this, 'message', {
       enumerable: true,
       value:
@@ -27,9 +36,9 @@ class ParseError extends Error {
           ? message
           : typeof message === 'object' &&
             typeof message.toString === 'function' &&
-            message.toString() !== '[object Object]'
+            !message.toString().includes('[object Object]')
             ? message.toString()
-            : JSON.stringify(message),
+            : stringify(message),
     });
   }
 

--- a/src/ParseError.js
+++ b/src/ParseError.js
@@ -22,7 +22,7 @@ class ParseError extends Error {
     this.code = code;
     Object.defineProperty(this, 'message', {
       enumerable: true,
-      value: message,
+      value: typeof message === 'string' ? message : JSON.stringify(message),
     });
   }
 

--- a/src/__tests__/ParseError-test.js
+++ b/src/__tests__/ParseError-test.js
@@ -29,11 +29,25 @@ describe('ParseError', () => {
   });
 
   it('message must be a string', () => {
+    /**
+     * error as object
+     */
     const someRandomError = { code: 420, message: 'time to chill' };
     const error = new ParseError(1337, someRandomError);
     expect(JSON.parse(JSON.stringify(error))).toEqual({
       message: JSON.stringify(someRandomError),
       code: 1337,
+    });
+
+    /**
+     * error as an Error instance
+     */
+    const someRandomError2 = new Error('time to relax');
+    const error2 = new ParseError(420, someRandomError2);
+
+    expect(JSON.parse(JSON.stringify(error2))).toEqual({
+      message: 'Error: time to relax',
+      code: 420,
     });
   });
 });

--- a/src/__tests__/ParseError-test.js
+++ b/src/__tests__/ParseError-test.js
@@ -27,4 +27,13 @@ describe('ParseError', () => {
       code: 123,
     });
   });
+
+  it('message must be a string', () => {
+    const someRandomError = { code: 420, message: 'time to chill' };
+    const error = new ParseError(1337, someRandomError);
+    expect(JSON.parse(JSON.stringify(error))).toEqual({
+      message: JSON.stringify(someRandomError),
+      code: 1337,
+    });
+  });
 });

--- a/src/__tests__/ParseError-test.js
+++ b/src/__tests__/ParseError-test.js
@@ -28,26 +28,50 @@ describe('ParseError', () => {
     });
   });
 
-  it('message must be a string', () => {
-    /**
-     * error as object
-     */
-    const someRandomError = { code: 420, message: 'time to chill' };
+  it('message can be a string', () => {
+    const someRandomError = 'oh no';
+
     const error = new ParseError(1337, someRandomError);
+
     expect(JSON.parse(JSON.stringify(error))).toEqual({
-      message: JSON.stringify(someRandomError),
+      message: someRandomError,
       code: 1337,
     });
+  });
 
-    /**
-     * error as an Error instance
-     */
-    const someRandomError2 = new Error('time to relax');
-    const error2 = new ParseError(420, someRandomError2);
+  it('message can be an object passed trough some external dependency', () => {
+    const someRandomError = { code: '420', message: 'time to chill', status: '🎮' };
 
-    expect(JSON.parse(JSON.stringify(error2))).toEqual({
-      message: 'Error: time to relax',
-      code: 420,
+    const error = new ParseError(1337, someRandomError);
+
+    expect(JSON.parse(JSON.stringify(error))).toEqual({
+      message: '420 time to chill 🎮',
+      code: 1337,
+    });
+  });
+
+  it('message can be an Error instance *receiving a string* passed trough some external dependency', () => {
+    const someRandomError = new Error('good point');
+
+    const error = new ParseError(1337, someRandomError);
+
+    expect(JSON.parse(JSON.stringify(error))).toEqual({
+      message: 'Error: good point',
+      code: 1337,
+    });
+  });
+
+  it('message can be an Error instance *receiving an object* passed trough some external dependency', () => {
+    const someRandomErrorWrong = new Error({
+      code: 'WRONG',
+      message: 'this is not how errors should be handled',
+    });
+
+    const error = new ParseError(1337, someRandomErrorWrong);
+
+    expect(JSON.parse(JSON.stringify(error))).toEqual({
+      message: '', // <-- Yeah because we can't parse errors used like that
+      code: 1337,
     });
   });
 });


### PR DESCRIPTION
### New Pull Request Checklist
<!--
    Check every following box [x] before submitting your PR.
    Click the "Preview" tab for better readability.
    Thanks for contributing to Parse Platform!
-->

- [x] I am not disclosing a [vulnerability](https://github.com/parse-community/parse-server/blob/master/SECURITY.md).
- [ ] I am creating this PR in reference to an [issue](https://github.com/parse-community/Parse-SDK-JS/issues?q=is%3Aissue).

### Issue Description
<!-- Add a brief description of the issue this PR solves. -->

The problem is that log is unclear when some random error happens in the server, eg: MongoDB query has exceeded memory limit

```
error ParseError: [object Object]
    at handleError (/my-project/node_modules/parse-server/node_modules/parse/lib/node/RESTController.js:418:17)
    at processTicksAndRejections (internal/process/task_queues.js:95:5) {
  code: 1
}
```

### Approach
<!-- Add a description of the approach in this PR. -->
My proposal is just to make sure the error message is a string otherwise, stringify it.

So this would be the returned log for the example above
```
error ParseError: "{\"ok\":0,\"code\":292,\"codeName\":\"QueryExceededMemoryLimitNoDiskUseAllowed\"}"
    at handleError (/my-project/node_modules/parse-server/node_modules/parse/lib/node/RESTController.js:418:17)
    at processTicksAndRejections (internal/process/task_queues.js:95:5) {
  code: 1
}
```

Please note that it's strictly necessary making sure those logs are readable, especially when relying on monitoring services like GCP Error Reporting, New Relic, Data Dog, etc...



- [x] Add tests
- [ ] Add changes to documentation (guides, repository pages, in-code descriptions)
