### PR TITLE
ci: Add support for Parse Server 6

### DIFF
--- a/integration/test/ParseLiveQueryTest.js
+++ b/integration/test/ParseLiveQueryTest.js
@@ -285,7 +285,7 @@ describe('Parse LiveQuery', () => {
   it('connectPromise does throw', async () => {
     await reconfigureServer({
       cloud({ Cloud }) {
-        Cloud.beforeConnect((params) => {
+        Cloud.beforeConnect(params => {
           if (params.sessionToken === 'testToken') {
             throw 'not allowed to connect';
           }

--- a/integration/test/ParseObjectTest.js
+++ b/integration/test/ParseObjectTest.js
@@ -1644,49 +1644,36 @@ describe('Parse Object', () => {
       });
   });
 
-  it('merges user attributes on fetchAll', done => {
+  it('merges user attributes on fetchAll', async () => {
     Parse.User.enableUnsafeCurrentUser();
-    let sameUser;
+    const acl = new Parse.ACL();
+    acl.setPublicReadAccess(true);
     let user = new Parse.User();
     user.set('username', 'asdf');
     user.set('password', 'zxcv');
     user.set('foo', 'bar');
-    user
-      .signUp()
-      .then(() => {
-        Parse.User.logOut();
-        const query = new Parse.Query(Parse.User);
-        return query.get(user.id);
-      })
-      .then(userAgain => {
-        user = userAgain;
-        sameUser = new Parse.User();
-        sameUser.set('username', 'asdf');
-        sameUser.set('password', 'zxcv');
-        return sameUser.logIn();
-      })
-      .then(() => {
-        assert(!user.getSessionToken());
-        assert(sameUser.getSessionToken());
-        sameUser.set('baz', 'qux');
-        return sameUser.save();
-      })
-      .then(() => {
-        return Parse.Object.fetchAll([user]);
-      })
-      .then(() => {
-        assert.equal(user.createdAt.getTime(), sameUser.createdAt.getTime());
-        assert.equal(user.updatedAt.getTime(), sameUser.updatedAt.getTime());
-        return Parse.User.logOut().then(
-          () => {
-            done();
-          },
-          () => {
-            done();
-          }
-        );
-      })
-      .catch(done.fail);
+    user.setACL(acl);
+    await user.signUp();
+
+    Parse.User.logOut();
+    const query = new Parse.Query(Parse.User);
+    user = await query.get(user.id);
+
+    const sameUser = new Parse.User();
+    sameUser.set('username', 'asdf');
+    sameUser.set('password', 'zxcv');
+    sameUser.setACL(acl);
+    await sameUser.logIn();
+
+    assert(!user.getSessionToken());
+    assert(sameUser.getSessionToken());
+    sameUser.set('baz', 'qux');
+    await sameUser.save();
+
+    await Parse.Object.fetchAll([user]);
+    assert.equal(user.createdAt.getTime(), sameUser.createdAt.getTime());
+    assert.equal(user.updatedAt.getTime(), sameUser.updatedAt.getTime());
+    await Parse.User.logOut();
   });
 
   it('can fetchAllIfNeededWithInclude', async () => {

--- a/integration/test/ParseQueryTest.js
+++ b/integration/test/ParseQueryTest.js
@@ -1774,22 +1774,22 @@ describe('Parse Query', () => {
     }
   });
 
-  it('can include User fields', done => {
-    Parse.User.signUp('bob', 'password', { age: 21 })
-      .then(user => {
-        const obj = new TestObject();
-        return obj.save({ owner: user });
-      })
-      .then(obj => {
-        const query = new Parse.Query(TestObject);
-        query.include('owner');
-        return query.get(obj.id);
-      })
-      .then(objAgain => {
-        assert(objAgain.get('owner') instanceof Parse.User);
-        assert.equal(objAgain.get('owner').get('age'), 21);
-        done();
-      });
+  it('can include User fields', async () => {
+    const user = new Parse.User();
+    user.set('username', 'bob');
+    user.set('password', 'password');
+    user.set('age', 21);
+    const acl = new Parse.ACL();
+    acl.setPublicReadAccess(true);
+    user.setACL(acl);
+    await user.signUp();
+    const obj = new TestObject();
+    await obj.save({ owner: user });
+    const query = new Parse.Query(TestObject);
+    query.include('owner');
+    const objAgain = await query.get(obj.id);
+    assert(objAgain.get('owner') instanceof Parse.User);
+    assert.equal(objAgain.get('owner').get('age'), 21);
   });
 
   it('can build OR queries', done => {

--- a/integration/test/ParseQueryTest.js
+++ b/integration/test/ParseQueryTest.js
@@ -71,12 +71,15 @@ describe('Parse Query', () => {
     assert.strictEqual(result.className, 'TestObject');
     assert.strictEqual(result.objectId, object.id);
 
-    await query.each((obj) => {
-      assert.strictEqual(obj instanceof Parse.Object, false);
-      assert.strictEqual(obj.foo, 'bar');
-      assert.strictEqual(obj.className, 'TestObject');
-      assert.strictEqual(obj.objectId, object.id);
-    }, { json: true });
+    await query.each(
+      obj => {
+        assert.strictEqual(obj instanceof Parse.Object, false);
+        assert.strictEqual(obj.foo, 'bar');
+        assert.strictEqual(obj.className, 'TestObject');
+        assert.strictEqual(obj.objectId, object.id);
+      },
+      { json: true }
+    );
   });
 
   it('can do query with count', async () => {

--- a/integration/test/ParseUserTest.js
+++ b/integration/test/ParseUserTest.js
@@ -521,26 +521,24 @@ describe('Parse User', () => {
       });
   });
 
-  it('can count users', done => {
+  it('can count users', async () => {
     const james = new Parse.User();
     james.set('username', 'james');
     james.set('password', 'mypass');
-    james
-      .signUp()
-      .then(() => {
-        const kevin = new Parse.User();
-        kevin.set('username', 'kevin');
-        kevin.set('password', 'mypass');
-        return kevin.signUp();
-      })
-      .then(() => {
-        const query = new Parse.Query(Parse.User);
-        return query.count();
-      })
-      .then(c => {
-        assert.equal(c, 2);
-        done();
-      });
+    const acl = new Parse.ACL();
+    acl.setPublicReadAccess(true);
+    james.setACL(acl);
+    await james.signUp();
+    const kevin = new Parse.User();
+    kevin.set('username', 'kevin');
+    kevin.set('password', 'mypass');
+    kevin.setACL(acl);
+    await kevin.signUp();
+
+    const query = new Parse.Query(Parse.User);
+    const c = await query.count();
+
+    assert.equal(c, 2);
   });
 
   it('can sign up user with container class', done => {

--- a/integration/test/helper.js
+++ b/integration/test/helper.js
@@ -97,38 +97,28 @@ const destroyAliveConnections = function () {
 let parseServer;
 let server;
 
-const reconfigureServer = (changedConfiguration = {}) => {
-  return new Promise((resolve, reject) => {
-    if (server) {
-      return parseServer.handleShutdown().then(() => {
-        server.close(() => {
-          parseServer = undefined;
-          server = undefined;
-          reconfigureServer(changedConfiguration).then(resolve, reject);
-        });
+const reconfigureServer = async (changedConfiguration = {}) => {
+  if (server) {
+    return parseServer.handleShutdown().then(() => {
+      server.close(() => {
+        parseServer = undefined;
+        server = undefined;
+        return reconfigureServer(changedConfiguration);
       });
-    }
-    try {
-      didChangeConfiguration = Object.keys(changedConfiguration).length !== 0;
-      const newConfiguration = Object.assign({}, defaultConfiguration, changedConfiguration || {}, {
-        serverStartComplete: error => {
-          if (error) {
-            reject(error);
-          } else {
-            resolve(parseServer);
-          }
-        },
-        mountPath,
-        port,
-      });
-      parseServer = ParseServer.start(newConfiguration);
-      const app = parseServer.expressApp;
-      for (const fileName of ['parse.js', 'parse.min.js']) {
-        const file = fs
-          .readFileSync(path.resolve(__dirname, `./../../dist/${fileName}`))
-          .toString();
-        app.get(`/${fileName}`, (req, res) => {
-          res.send(`<html><head>
+    });
+  }
+
+  didChangeConfiguration = Object.keys(changedConfiguration).length !== 0;
+  const newConfiguration = Object.assign({}, defaultConfiguration, changedConfiguration || {}, {
+    mountPath,
+    port,
+  });
+  parseServer = await ParseServer.startApp(newConfiguration);
+  const app = parseServer.expressApp;
+  for (const fileName of ['parse.js', 'parse.min.js']) {
+    const file = fs.readFileSync(path.resolve(__dirname, `./../../dist/${fileName}`)).toString();
+    app.get(`/${fileName}`, (req, res) => {
+      res.send(`<html><head>
           <meta charset="utf-8">
           <meta http-equiv="X-UA-Compatible" content="IE=edge">
           <title>Parse Functionality Test</title>
@@ -142,25 +132,21 @@ const reconfigureServer = (changedConfiguration = {}) => {
           </head>
         <body>
         </body></html>`);
-        });
-      }
-      app.get('/clear/:fast', (req, res) => {
-        const { fast } = req.params;
-        TestUtils.destroyAllDataPermanently(fast).then(() => {
-          res.send('{}');
-        });
-      });
-      server = parseServer.server;
-      server.on('connection', connection => {
-        const key = `${connection.remoteAddress}:${connection.remotePort}`;
-        openConnections[key] = connection;
-        connection.on('close', () => {
-          delete openConnections[key];
-        });
-      });
-    } catch (error) {
-      reject(error);
-    }
+    });
+  }
+  app.get('/clear/:fast', (req, res) => {
+    const { fast } = req.params;
+    TestUtils.destroyAllDataPermanently(fast).then(() => {
+      res.send('{}');
+    });
+  });
+  server = parseServer.server;
+  server.on('connection', connection => {
+    const key = `${connection.remoteAddress}:${connection.remotePort}`;
+    openConnections[key] = connection;
+    connection.on('close', () => {
+      delete openConnections[key];
+    });
   });
 };
 global.DiffObject = Parse.Object.extend('DiffObject');

--- a/integration/test/helper.js
+++ b/integration/test/helper.js
@@ -99,13 +99,11 @@ let server;
 
 const reconfigureServer = async (changedConfiguration = {}) => {
   if (server) {
-    return parseServer.handleShutdown().then(() => {
-      server.close(() => {
-        parseServer = undefined;
-        server = undefined;
-        return reconfigureServer(changedConfiguration);
-      });
-    });
+    await parseServer.handleShutdown();
+    await new Promise(resolve => server.close(resolve));
+    parseServer = undefined;
+    server = undefined;
+    return reconfigureServer(changedConfiguration);
   }
 
   didChangeConfiguration = Object.keys(changedConfiguration).length !== 0;
@@ -148,6 +146,7 @@ const reconfigureServer = async (changedConfiguration = {}) => {
       delete openConnections[key];
     });
   });
+  return parseServer;
 };
 global.DiffObject = Parse.Object.extend('DiffObject');
 global.Item = Parse.Object.extend('Item');

--- a/package-lock.json
+++ b/package-lock.json
@@ -43,6 +43,31 @@
         "source-map": "^0.5.0"
       }
     },
+    "@babel/eslint-parser": {
+      "version": "7.19.1",
+      "resolved": "https://registry.npmjs.org/@babel/eslint-parser/-/eslint-parser-7.19.1.tgz",
+      "integrity": "sha512-AqNf2QWt1rtu2/1rLswy6CDP7H9Oh3mMhk177Y67Rg8d7RD9WfOLLv8CGn6tisFvS2htm86yIe1yLF6I1UDaGQ==",
+      "dev": true,
+      "requires": {
+        "@nicolo-ribaudo/eslint-scope-5-internals": "5.1.1-v1",
+        "eslint-visitor-keys": "^2.1.0",
+        "semver": "^6.3.0"
+      },
+      "dependencies": {
+        "eslint-visitor-keys": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-2.1.0.tgz",
+          "integrity": "sha512-0rSmRBzXgDzIsD6mGdJgevzgezI534Cer5L/vyMX0kHzT/jiB43jRhd9YUlMGYLQy2zprNmoT8qasCGtY+QaKw==",
+          "dev": true
+        },
+        "semver": {
+          "version": "6.3.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+          "dev": true
+        }
+      }
+    },
     "@babel/generator": {
       "version": "7.19.0",
       "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.19.0.tgz",
@@ -1948,6 +1973,57 @@
       "integrity": "sha512-XQr74QaLeMiqhStEhLn1im9EOMnkypp7MZOwQhGzqp2Weu5eQJbpPxWxixxlYRKWPOmJjsk6qYfYH9kq43yc2w==",
       "dev": true,
       "optional": true
+    },
+    "@nicolo-ribaudo/eslint-scope-5-internals": {
+      "version": "5.1.1-v1",
+      "resolved": "https://registry.npmjs.org/@nicolo-ribaudo/eslint-scope-5-internals/-/eslint-scope-5-internals-5.1.1-v1.tgz",
+      "integrity": "sha512-54/JRvkLIzzDWshCWfuhadfrfZVPiElY8Fcgmg1HroEly/EDSszzhBAsarCux+D/kOslTRquNzuyGSmUSTTHGg==",
+      "dev": true,
+      "requires": {
+        "eslint-scope": "5.1.1"
+      }
+    },
+    "@node-redis/bloom": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@node-redis/bloom/-/bloom-1.0.1.tgz",
+      "integrity": "sha512-mXEBvEIgF4tUzdIN89LiYsbi6//EdpFA7L8M+DHCvePXg+bfHWi+ct5VI6nHUFQE5+ohm/9wmgihCH3HSkeKsw==",
+      "dev": true
+    },
+    "@node-redis/client": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/@node-redis/client/-/client-1.0.5.tgz",
+      "integrity": "sha512-ESZ3bd1f+od62h4MaBLKum+klVJfA4wAeLHcVQBkoXa1l0viFesOWnakLQqKg+UyrlJhZmXJWtu0Y9v7iTMrig==",
+      "dev": true,
+      "requires": {
+        "cluster-key-slot": "1.1.0",
+        "generic-pool": "3.8.2",
+        "redis-parser": "3.0.0",
+        "yallist": "4.0.0"
+      }
+    },
+    "@node-redis/graph": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@node-redis/graph/-/graph-1.0.0.tgz",
+      "integrity": "sha512-mRSo8jEGC0cf+Rm7q8mWMKKKqkn6EAnA9IA2S3JvUv/gaWW/73vil7GLNwion2ihTptAm05I9LkepzfIXUKX5g==",
+      "dev": true
+    },
+    "@node-redis/json": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@node-redis/json/-/json-1.0.2.tgz",
+      "integrity": "sha512-qVRgn8WfG46QQ08CghSbY4VhHFgaTY71WjpwRBGEuqGPfWwfRcIf3OqSpR7Q/45X+v3xd8mvYjywqh0wqJ8T+g==",
+      "dev": true
+    },
+    "@node-redis/search": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/@node-redis/search/-/search-1.0.5.tgz",
+      "integrity": "sha512-MCOL8iCKq4v+3HgEQv8zGlSkZyXSXtERgrAJ4TSryIG/eLFy84b57KmNNa/V7M1Q2Wd2hgn2nPCGNcQtk1R1OQ==",
+      "dev": true
+    },
+    "@node-redis/time-series": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@node-redis/time-series/-/time-series-1.0.2.tgz",
+      "integrity": "sha512-HGQ8YooJ8Mx7l28tD7XjtB3ImLEjlUxG1wC1PAjxu6hPJqjPshUZxAICzDqDjtIbhDTf48WXXUcx8TQJB1XTKA==",
+      "dev": true
     },
     "@node-rs/bcrypt": {
       "version": "1.1.0",
@@ -5190,13 +5266,13 @@
       }
     },
     "@types/express": {
-      "version": "4.17.14",
-      "resolved": "https://registry.npmjs.org/@types/express/-/express-4.17.14.tgz",
-      "integrity": "sha512-TEbt+vaPFQ+xpxFLFssxUDXj5cWCxZJjIcB7Yg0k0GMHGtgtQgpvx/MUQUeAkNbA9AAGrwkAsoeItdTgS7FMyg==",
+      "version": "4.17.15",
+      "resolved": "https://registry.npmjs.org/@types/express/-/express-4.17.15.tgz",
+      "integrity": "sha512-Yv0k4bXGOH+8a+7bELd2PqHQsuiANB+A8a4gnQrkRWzrkKlb6KHaVvyXhqs04sVW/OWlbPyYxRgYlIXLfrufMQ==",
       "dev": true,
       "requires": {
         "@types/body-parser": "*",
-        "@types/express-serve-static-core": "^4.17.18",
+        "@types/express-serve-static-core": "^4.17.31",
         "@types/qs": "*",
         "@types/serve-static": "*"
       }
@@ -7225,6 +7301,12 @@
           }
         }
       }
+    },
+    "cluster-key-slot": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/cluster-key-slot/-/cluster-key-slot-1.1.0.tgz",
+      "integrity": "sha512-2Nii8p3RwAPiFwsnZvukotvow2rIHM+yQ6ZcBXGHdniadkYGZYiGmkHJIbZPIV9nfv7m/U1IPMVVcAhoWFeklw==",
+      "dev": true
     },
     "co": {
       "version": "4.6.0",
@@ -10153,6 +10235,12 @@
         }
       }
     },
+    "generic-pool": {
+      "version": "3.8.2",
+      "resolved": "https://registry.npmjs.org/generic-pool/-/generic-pool-3.8.2.tgz",
+      "integrity": "sha512-nGToKy6p3PAbYQ7p1UlWl6vSPwfwU6TMSWK7TTu+WUY4ZjyZQGniGGt2oNVvyNSpyZYSB43zMXVLcBm08MTMkg==",
+      "dev": true
+    },
     "gensync": {
       "version": "1.0.0-beta.2",
       "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
@@ -11885,6 +11973,15 @@
       "resolved": "https://registry.npmjs.org/ip/-/ip-2.0.0.tgz",
       "integrity": "sha512-WKa+XuLG1A1R0UWhl2+1XQSi+fZWMsYKffMZTTYsiZaUD8k2yDAj5atimTUD2TZkyCkNEeYE5NhFZmupOGtjYQ==",
       "dev": true
+    },
+    "ip-range-check": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/ip-range-check/-/ip-range-check-0.2.0.tgz",
+      "integrity": "sha512-oaM3l/3gHbLlt/tCWLvt0mj1qUaI+STuRFnUvARGCujK9vvU61+2JsDpmkMzR4VsJhuFXWWgeKKVnwwoFfzCqw==",
+      "dev": true,
+      "requires": {
+        "ipaddr.js": "^1.0.1"
+      }
     },
     "ipaddr.js": {
       "version": "1.9.1",
@@ -15245,9 +15342,9 @@
       }
     },
     "mongodb-connection-string-url": {
-      "version": "2.5.4",
-      "resolved": "https://registry.npmjs.org/mongodb-connection-string-url/-/mongodb-connection-string-url-2.5.4.tgz",
-      "integrity": "sha512-SeAxuWs0ez3iI3vvmLk/j2y+zHwigTDKQhtdxTgt5ZCOQQS5+HW4g45/Xw5vzzbn7oQXCNQ24Z40AkJsizEy7w==",
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/mongodb-connection-string-url/-/mongodb-connection-string-url-2.6.0.tgz",
+      "integrity": "sha512-WvTZlI9ab0QYtTYnuMLgobULWhokRjtC7db9LtcVfJ+Hsnyr5eo6ZtNAt3Ly24XZScGMelOcGtm7lSn0332tPQ==",
       "dev": true,
       "requires": {
         "@types/whatwg-url": "^8.2.1",
@@ -18000,10 +18097,11 @@
       "dev": true
     },
     "parse-server": {
-      "version": "git+https://github.com/parse-community/parse-server.git#7cb266b207f2619d466922c6c227cfd2f430a8cc",
-      "from": "git+https://github.com/parse-community/parse-server.git#7cb266b207f2619d466922c6c227cfd2f430a8cc",
+      "version": "git+https://github.com/parse-community/parse-server.git#d19acf1c1a594566409c152f513d670167aabdc8",
+      "from": "git+https://github.com/parse-community/parse-server.git#d19acf1c1a594566409c152f513d670167aabdc8",
       "dev": true,
       "requires": {
+        "@babel/eslint-parser": "7.19.1",
         "@graphql-tools/merge": "8.3.6",
         "@graphql-tools/schema": "9.0.4",
         "@graphql-tools/utils": "8.12.0",
@@ -18023,6 +18121,7 @@
         "graphql-relay": "0.10.0",
         "graphql-tag": "2.12.6",
         "intersect": "1.0.1",
+        "ip-range-check": "0.2.0",
         "jsonwebtoken": "8.5.1",
         "jwks-rsa": "2.1.5",
         "ldapjs": "2.3.3",
@@ -18035,7 +18134,7 @@
         "pg-monitor": "1.5.0",
         "pg-promise": "10.12.1",
         "pluralize": "8.0.0",
-        "redis": "3.1.2",
+        "redis": "4.0.6",
         "semver": "7.3.8",
         "subscriptions-transport-ws": "0.11.0",
         "tv4": "1.3.0",
@@ -19358,30 +19457,18 @@
       }
     },
     "redis": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/redis/-/redis-3.1.2.tgz",
-      "integrity": "sha512-grn5KoZLr/qrRQVwoSkmzdbw6pwF+/rwODtrOr6vuBRiR/f3rjSTGupbF90Zpqm2oenix8Do6RV7pYEkGwlKkw==",
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/redis/-/redis-4.0.6.tgz",
+      "integrity": "sha512-IaPAxgF5dV0jx+A9l6yd6R9/PAChZIoAskDVRzUODeLDNhsMlq7OLLTmu0AwAr0xjrJ1bibW5xdpRwqIQ8Q0Xg==",
       "dev": true,
       "requires": {
-        "denque": "^1.5.0",
-        "redis-commands": "^1.7.0",
-        "redis-errors": "^1.2.0",
-        "redis-parser": "^3.0.0"
-      },
-      "dependencies": {
-        "denque": {
-          "version": "1.5.1",
-          "resolved": "https://registry.npmjs.org/denque/-/denque-1.5.1.tgz",
-          "integrity": "sha512-XwE+iZ4D6ZUB7mfYRMb5wByE8L74HCn30FBN7sWnXksWc1LO1bPDl67pBR9o/kC4z/xSNAwkMYcGgqDV3BE3Hw==",
-          "dev": true
-        }
+        "@node-redis/bloom": "1.0.1",
+        "@node-redis/client": "1.0.5",
+        "@node-redis/graph": "1.0.0",
+        "@node-redis/json": "1.0.2",
+        "@node-redis/search": "1.0.5",
+        "@node-redis/time-series": "1.0.2"
       }
-    },
-    "redis-commands": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/redis-commands/-/redis-commands-1.7.0.tgz",
-      "integrity": "sha512-nJWqw3bTFy21hX/CPKHth6sfhZbdiHP6bTawSgQBlKOVRG7EZkfHbbHwQJnrE4vsQf0CMNE+3gJ4Fmm16vdVlQ==",
-      "dev": true
     },
     "redis-errors": {
       "version": "1.2.0",

--- a/src/StorageController.react-native.js
+++ b/src/StorageController.react-native.js
@@ -40,7 +40,7 @@ const StorageController = {
 
   removeItemAsync(path: string): Promise {
     return new Promise((resolve, reject) => {
-      CoreManager.getAsyncStorage().removeItem(path, (err) => {
+      CoreManager.getAsyncStorage().removeItem(path, err => {
         if (err) {
           reject(err);
         } else {
@@ -76,7 +76,7 @@ const StorageController = {
 
   multiRemove(keys: Array<string>): Promise {
     return new Promise((resolve, reject) => {
-      CoreManager.getAsyncStorage().multiRemove(keys, (err) => {
+      CoreManager.getAsyncStorage().multiRemove(keys, err => {
         if (err) {
           reject(err);
         } else {

--- a/src/__tests__/LiveQueryClient-test.js
+++ b/src/__tests__/LiveQueryClient-test.js
@@ -369,7 +369,12 @@ describe('LiveQueryClient', () => {
 
     try {
       liveQueryClient._handleWebSocketMessage(event);
-      await Promise.all([subscription.connectPromise, subscription.subscribePromise, liveQueryClient.connectPromise, liveQueryClient.subscribePromise]);
+      await Promise.all([
+        subscription.connectPromise,
+        subscription.subscribePromise,
+        liveQueryClient.connectPromise,
+        liveQueryClient.subscribePromise,
+      ]);
     } catch (e) {
       expect(e.message).toEqual('error thrown');
     }

--- a/src/__tests__/ParseQuery-test.js
+++ b/src/__tests__/ParseQuery-test.js
@@ -1377,12 +1377,15 @@ describe('ParseQuery', () => {
     expect(result.name).toEqual('Product 3');
     expect(result.className).toEqual('Item');
 
-    await q.each((obj) => {
-      expect(obj.objectId).toBe('I1');
-      expect(obj.size).toBe('small');
-      expect(obj.name).toEqual('Product 3');
-      expect(obj.className).toEqual('Item');
-    }, { json: true });
+    await q.each(
+      obj => {
+        expect(obj.objectId).toBe('I1');
+        expect(obj.size).toBe('small');
+        expect(obj.name).toEqual('Product 3');
+        expect(obj.className).toEqual('Item');
+      },
+      { json: true }
+    );
   });
 
   it('will error when getting a nonexistent object', done => {


### PR DESCRIPTION
### New Pull Request Checklist
<!--
    Check every following box [x] before submitting your PR.
    Click the "Preview" tab for better readability.
    Thanks for contributing to Parse Platform!
-->

- [x] I am not disclosing a [vulnerability](https://github.com/parse-community/parse-server/blob/master/SECURITY.md).
- [x] I am creating this PR in reference to an [issue](https://github.com/parse-community/Parse-SDK-JS/issues?q=is%3Aissue).

### Issue Description
<!-- Add a brief description of the issue this PR solves. -->

SDK does not currently support Parse Server 6, as the startup method has changed.

Closes: #1637

### Approach
<!-- Add a description of the approach in this PR. -->

### TODOs before merging
<!--
    Add TODOs that need to be completed before merging this PR.
    Delete TODOs that do not apply to this PR.
-->

- [x] Add tests

