### PR TITLE
fix: Uuid on AnonymousUtils.js

### DIFF
--- a/src/AnonymousUtils.js
+++ b/src/AnonymousUtils.js
@@ -11,7 +11,7 @@
 
 import ParseUser from './ParseUser';
 import type { RequestOptions } from './RESTController';
-const uuidv4 = require('./uuid');
+const {v4: uuidv4} = require('uuid');
 
 let registered = false;
 


### PR DESCRIPTION
### New Pull Request Checklist
<!--
    Check every following box [x] before submitting your PR.
    Click the "Preview" tab for better readability.
    Thanks for contributing to Parse Platform!
-->

- [x] I am not disclosing a [vulnerability](https://github.com/parse-community/parse-server/blob/master/SECURITY.md).
- [x] I am creating this PR in reference to an [issue](https://github.com/parse-community/Parse-SDK-JS/issues?q=is%3Aissue).

### Issue Description

Closes: https://github.com/parse-community/Parse-SDK-JS/issues/1491

This PR fix this error :

Error [ERR_PACKAGE_PATH_NOT_EXPORTED]: Package subpath './v4' is not defined by "exports" in /PATH/node_modules/uuid/package.json
    at new NodeError (node:internal/errors:400:5)
    at exportsNotFound (node:internal/modules/esm/resolve:361:10)
    at packageExportsResolve (node:internal/modules/esm/resolve:697:9)
    at resolveExports (node:internal/modules/cjs/loader:538:36)
    at Module._findPath (node:internal/modules/cjs/loader:607:31)
    at Module._resolveFilename (node:internal/modules/cjs/loader:1025:27)
    at Module._load (node:internal/modules/cjs/loader:885:27)
    at Module.require (node:internal/modules/cjs/loader:1105:19)
    at require (node:internal/modules/cjs/helpers:103:18)
    at Object.<anonymous> (/PATH/node_modules/parse/lib/node/AnonymousUtils.js:27:16) {
  code: 'ERR_PACKAGE_PATH_NOT_EXPORTED'
}

### Approach
<!-- Add a description of the approach in this PR. -->

### TODOs before merging
<!--
    Add TODOs that need to be completed before merging this PR.
    Delete TODOs that do not apply to this PR.
-->

- [x] Add tests
- [x] Add changes to documentation (guides, repository pages, in-code descriptions)
