### PR TITLE
fix: Local datastore query with `containedIn` not working when field is an array

### DIFF
--- a/integration/test/ParseLiveQueryTest.js
+++ b/integration/test/ParseLiveQueryTest.js
@@ -257,38 +257,6 @@ describe('Parse LiveQuery', () => {
     await object.save();
   });
 
-  it('can handle containsAll query', async (done) => {
-    const object = new TestObject({ arrayField: [1, 2, 3] });
-    await object.save();
-
-    const query = new Parse.Query(TestObject);
-    query.containsAll('arrayField', [2, 3, 4]);
-    const subscription = await query.subscribe();
-
-    subscription.on('enter', object => {
-      expect(object.get('arrayField')).toEqual([1, 2, 3, 4]);
-      done();
-    });
-    object.addUnique('arrayField', 4);
-    await object.save();
-  });
-
-  it('can handle containedIn query', async (done) => {
-    const object = new TestObject({ arrayField: [1, 2, 3] });
-    await object.save();
-
-    const query = new Parse.Query(TestObject);
-    query.containedIn('arrayField', [4]);
-    const subscription = await query.subscribe();
-
-    subscription.on('enter', object => {
-      expect(object.get('arrayField')).toEqual([1, 2, 3, 4]);
-      done();
-    });
-    object.addUnique('arrayField', 4);
-    await object.save();
-  });
-
   it('live query can handle beforeConnect and beforeSubscribe errors', async () => {
     await reconfigureServer({
       cloud({ Cloud }) {

--- a/integration/test/ParseLiveQueryTest.js
+++ b/integration/test/ParseLiveQueryTest.js
@@ -257,6 +257,38 @@ describe('Parse LiveQuery', () => {
     await object.save();
   });
 
+  it('can handle containsAll query', async (done) => {
+    const object = new TestObject({ arrayField: [1, 2, 3] });
+    await object.save();
+
+    const query = new Parse.Query(TestObject);
+    query.containsAll('arrayField', [2, 3, 4]);
+    const subscription = await query.subscribe();
+
+    subscription.on('enter', object => {
+      expect(object.get('arrayField')).toEqual([1, 2, 3, 4]);
+      done();
+    });
+    object.addUnique('arrayField', 4);
+    await object.save();
+  });
+
+  it('can handle containedIn query', async (done) => {
+    const object = new TestObject({ arrayField: [1, 2, 3] });
+    await object.save();
+
+    const query = new Parse.Query(TestObject);
+    query.containedIn('arrayField', [4]);
+    const subscription = await query.subscribe();
+
+    subscription.on('enter', object => {
+      expect(object.get('arrayField')).toEqual([1, 2, 3, 4]);
+      done();
+    });
+    object.addUnique('arrayField', 4);
+    await object.save();
+  });
+
   it('live query can handle beforeConnect and beforeSubscribe errors', async () => {
     await reconfigureServer({
       cloud({ Cloud }) {

--- a/integration/test/ParseLocalDatastoreTest.js
+++ b/integration/test/ParseLocalDatastoreTest.js
@@ -1267,7 +1267,7 @@ function runTest(controller) {
       expect(results.length).toEqual(0);
     });
 
-    fit(`${controller.name} can handle notContainedIn query on array`, async () => {
+    it(`${controller.name} can handle notContainedIn query on array`, async () => {
       const obj1 = new TestObject({ arrayField: [1, 2, 3, 4] });
       const obj2 = new TestObject({ arrayField: [0, 2] });
       const obj3 = new TestObject({ arrayField: [1, 2, 3] });

--- a/integration/test/ParseLocalDatastoreTest.js
+++ b/integration/test/ParseLocalDatastoreTest.js
@@ -1227,6 +1227,32 @@ function runTest(controller) {
       assert.equal(results[0].id, parent3.id);
     });
 
+    it(`${controller.name} can handle containsAll query on array`, async () => {
+      const object = new TestObject({ arrayField: [1, 2, 3, 4] });
+      await object.save();
+      await object.pin();
+
+      const query = new Parse.Query(TestObject);
+      query.containsAll('arrayField', [2, 3, 4]);
+      query.fromPin();
+      const results = await query.find();
+
+      expect(results.length).toBe(1);
+      expect(results[0].get('arrayField')).toEqual([1, 2, 3, 4]);
+    });
+
+    it(`${controller.name} can handle containedIn query on array`, async () => {
+      const object = new TestObject({ arrayField: [1, 2, 3] });
+      await object.save();
+      await object.pin();
+
+      const query = new Parse.Query(TestObject);
+      query.containedIn('arrayField', [3]);
+      query.fromPin();
+      const results = await query.find();
+      expect(results[0].get('arrayField')).toEqual([1, 2, 3]);
+    });
+
     it(`${controller.name} can test equality with undefined`, async () => {
       const query = new Parse.Query('BoxedNumber');
       query.equalTo('number', undefined);

--- a/integration/test/ParseLocalDatastoreTest.js
+++ b/integration/test/ParseLocalDatastoreTest.js
@@ -1228,29 +1228,63 @@ function runTest(controller) {
     });
 
     it(`${controller.name} can handle containsAll query on array`, async () => {
-      const object = new TestObject({ arrayField: [1, 2, 3, 4] });
-      await object.save();
-      await object.pin();
+      const obj1 = new TestObject({ arrayField: [1, 2, 3, 4] });
+      const obj2 = new TestObject({ arrayField: [0, 2] });
+      const obj3 = new TestObject({ arrayField: [1, 2, 3] });
+      await Parse.Object.saveAll([obj1, obj2, obj3]);
+      await Parse.Object.pinAll([obj1, obj2, obj3]);
 
-      const query = new Parse.Query(TestObject);
-      query.containsAll('arrayField', [2, 3, 4]);
+      let query = new Parse.Query(TestObject);
+      query.containsAll('arrayField', [1, 2]);
       query.fromPin();
-      const results = await query.find();
+      let results = await query.find();
+      expect(results.length).toBe(2);
 
-      expect(results.length).toBe(1);
-      expect(results[0].get('arrayField')).toEqual([1, 2, 3, 4]);
+      query = new Parse.Query(TestObject);
+      query.containsAll('arrayField', [5, 6]);
+      query.fromPin();
+      results = await query.find();
+      expect(results.length).toBe(0);
     });
 
     it(`${controller.name} can handle containedIn query on array`, async () => {
-      const object = new TestObject({ arrayField: [1, 2, 3] });
-      await object.save();
-      await object.pin();
+      const obj1 = new TestObject({ arrayField: [1, 2, 3, 4] });
+      const obj2 = new TestObject({ arrayField: [0, 2] });
+      const obj3 = new TestObject({ arrayField: [1, 2, 3] });
+      await Parse.Object.saveAll([obj1, obj2, obj3]);
+      await Parse.Object.pinAll([obj1, obj2, obj3]);
 
-      const query = new Parse.Query(TestObject);
+      let query = new Parse.Query(TestObject);
       query.containedIn('arrayField', [3]);
       query.fromPin();
-      const results = await query.find();
-      expect(results[0].get('arrayField')).toEqual([1, 2, 3]);
+      let results = await query.find();
+      expect(results.length).toEqual(2);
+
+      query = new Parse.Query(TestObject);
+      query.containedIn('arrayField', [5]);
+      query.fromPin();
+      results = await query.find();
+      expect(results.length).toEqual(0);
+    });
+
+    fit(`${controller.name} can handle notContainedIn query on array`, async () => {
+      const obj1 = new TestObject({ arrayField: [1, 2, 3, 4] });
+      const obj2 = new TestObject({ arrayField: [0, 2] });
+      const obj3 = new TestObject({ arrayField: [1, 2, 3] });
+      await Parse.Object.saveAll([obj1, obj2, obj3]);
+      await Parse.Object.pinAll([obj1, obj2, obj3]);
+
+      let query = new Parse.Query(TestObject);
+      query.notContainedIn('arrayField', [3]);
+      query.fromPin();
+      let results = await query.find();
+      expect(results.length).toEqual(1);
+
+      query = new Parse.Query(TestObject);
+      query.notContainedIn('arrayField', [5]);
+      query.fromPin();
+      results = await query.find();
+      expect(results.length).toEqual(3);
     });
 
     it(`${controller.name} can test equality with undefined`, async () => {

--- a/src/OfflineQuery.js
+++ b/src/OfflineQuery.js
@@ -24,6 +24,13 @@ function contains(haystack, needle) {
     }
     return false;
   }
+  if (Array.isArray(needle)) {
+    for (const need of needle) {
+      if (contains(haystack, need)) {
+        return true;
+      }
+    }
+  }
   return haystack.indexOf(needle) > -1;
 }
 

--- a/src/__tests__/OfflineQuery-test.js
+++ b/src/__tests__/OfflineQuery-test.js
@@ -610,6 +610,33 @@ describe('OfflineQuery', () => {
     expect(matchesQuery(q.className, message, [], q)).toBe(false);
   });
 
+  it('should support containedIn with array of pointers', () => {
+    const profile1 = new ParseObject('Profile');
+    profile1.id = 'yeahaw';
+    const profile2 = new ParseObject('Profile');
+    profile2.id = 'yes';
+
+    const message = new ParseObject('Message');
+    message.id = 'O2';
+    message.set('profiles', [profile1, profile2]);
+
+    let q = new ParseQuery('Message');
+    q.containedIn('profiles', [
+      ParseObject.fromJSON({ className: 'Profile', objectId: 'no' }),
+      ParseObject.fromJSON({ className: 'Profile', objectId: 'yes' }),
+    ]);
+
+    expect(matchesQuery(q.className, message, [], q)).toBe(true);
+
+    q = new ParseQuery('Message');
+    q.containedIn('profiles', [
+      ParseObject.fromJSON({ className: 'Profile', objectId: 'no' }),
+      ParseObject.fromJSON({ className: 'Profile', objectId: 'nope' }),
+    ]);
+
+    expect(matchesQuery(q.className, message, [], q)).toBe(false);
+  });
+
   it('should support notContainedIn with pointers', () => {
     const profile = new ParseObject('Profile');
     profile.id = 'abc';


### PR DESCRIPTION
### New Pull Request Checklist
<!--
    Check every following box [x] before submitting your PR.
    Click the "Preview" tab for better readability.
    Thanks for contributing to Parse Platform!
-->

- [x] I am not disclosing a [vulnerability](https://github.com/parse-community/parse-server/blob/master/SECURITY.md).
- [x] I am creating this PR in reference to an [issue](https://github.com/parse-community/Parse-SDK-JS/issues?q=is%3Aissue).

### Issue Description
<!-- Add a brief description of the issue this PR solves. -->

Similar to https://github.com/parse-community/parse-server/pull/8128

Closes: Added additional test case for https://github.com/parse-community/parse-server/issues/8335

### Approach
<!-- Add a description of the approach in this PR. -->

### TODOs before merging
<!--
    Add TODOs that need to be completed before merging this PR.
    Delete TODOs that do not apply to this PR.
-->

- [x] Add tests
- [x] Add changes to documentation (guides, repository pages, in-code descriptions)
