### PR TITLE
ci: Fix flaky tests

### DIFF
--- a/integration/test/IdempotencyTest.js
+++ b/integration/test/IdempotencyTest.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const Parse = require('../../node');
+const sleep = require('./sleep');
 
 const Item = Parse.Object.extend('IdempotencyItem');
 const RESTController = Parse.CoreManager.getRESTController();
@@ -47,6 +48,13 @@ describe('Idempotency', () => {
       'Duplicate request'
     );
 
+    const checkJobStatus = async () => {
+      const result = await Parse.Cloud.getJobStatus(jobStatusId);
+      return result && result.get('status') === 'succeeded';
+    };
+    while (!(await checkJobStatus())) {
+      await sleep(100);
+    }
     const jobStatus = await Parse.Cloud.getJobStatus(jobStatusId);
     expect(jobStatus.get('status')).toBe('succeeded');
     expect(jobStatus.get('params').startedBy).toBe('Monty Python');

--- a/integration/test/ParseCloudTest.js
+++ b/integration/test/ParseCloudTest.js
@@ -83,17 +83,20 @@ describe('Parse Cloud', () => {
     });
   });
 
-  it('run job', done => {
+  it('run job', async () => {
     const params = { startedBy: 'Monty Python' };
-    Parse.Cloud.startJob('CloudJob1', params)
-      .then(jobStatusId => {
-        return Parse.Cloud.getJobStatus(jobStatusId);
-      })
-      .then(jobStatus => {
-        assert.equal(jobStatus.get('status'), 'succeeded');
-        assert.equal(jobStatus.get('params').startedBy, 'Monty Python');
-        done();
-      });
+    const jobStatusId = await Parse.Cloud.startJob('CloudJob1', params);
+
+    const checkJobStatus = async () => {
+      const result = await Parse.Cloud.getJobStatus(jobStatusId);
+      return result && result.get('status') === 'succeeded';
+    };
+    while (!(await checkJobStatus())) {
+      await sleep(100);
+    }
+    const jobStatus = await Parse.Cloud.getJobStatus(jobStatusId);
+    assert.equal(jobStatus.get('status'), 'succeeded');
+    assert.equal(jobStatus.get('params').startedBy, 'Monty Python');
   });
 
   it('run long job', async () => {

--- a/integration/test/ParseObjectTest.js
+++ b/integration/test/ParseObjectTest.js
@@ -1674,6 +1674,7 @@ describe('Parse Object', () => {
     assert.equal(user.createdAt.getTime(), sameUser.createdAt.getTime());
     assert.equal(user.updatedAt.getTime(), sameUser.updatedAt.getTime());
     await Parse.User.logOut();
+    Parse.User.disableUnsafeCurrentUser();
   });
 
   it('can fetchAllIfNeededWithInclude', async () => {
@@ -2014,7 +2015,7 @@ describe('Parse Object', () => {
     assert.equal(user.isDataAvailable(), true);
 
     const query = new Parse.Query(Parse.User);
-    const fetched = await query.get(user.id);
+    const fetched = await query.get(user.id, { useMasterKey: true });
     assert.equal(fetched.isDataAvailable(), true);
   });
 

--- a/integration/test/ParseQueryTest.js
+++ b/integration/test/ParseQueryTest.js
@@ -2365,7 +2365,15 @@ describe('Parse Query', () => {
     query.hint('_id_');
     query.explain();
     const explain = await query.find();
-    assert.equal(explain.queryPlanner.winningPlan.inputStage.inputStage.indexName, '_id_');
+    let indexName = '';
+    // https://www.mongodb.com/docs/manual/reference/explain-results/#std-label-queryPlanner
+    const plan = explain.queryPlanner.winningPlan;
+    if (plan.inputStage) {
+      indexName = plan.inputStage.inputStage.indexName;
+    } else {
+      indexName = plan.queryPlan.inputStage.inputStage.indexName;
+    }
+    assert.equal(indexName, '_id_');
   });
 
   it('can query with select on null field', async () => {

--- a/integration/test/ParseSchemaTest.js
+++ b/integration/test/ParseSchemaTest.js
@@ -26,6 +26,19 @@ const defaultCLPS = {
 };
 
 describe('Schema', () => {
+  beforeEach(async () => {
+    try {
+      const schemas = await Parse.Schema.all();
+      for (const result of schemas) {
+        const schema = new Parse.Schema(result.className);
+        await schema.purge();
+        await schema.delete();
+      }
+    } catch (_) {
+      // Schema not found
+    }
+  });
+
   it('invalid get all no schema', done => {
     Parse.Schema.all()
       .then(() => {})

--- a/integration/test/ParseUserTest.js
+++ b/integration/test/ParseUserTest.js
@@ -185,6 +185,7 @@ describe('Parse User', () => {
   });
 
   it('cannot save non-authed user', done => {
+    Parse.User.enableUnsafeCurrentUser();
     let user = new Parse.User();
     let notAuthed = null;
     user.set({
@@ -220,6 +221,7 @@ describe('Parse User', () => {
   });
 
   it('cannot delete non-authed user', done => {
+    Parse.User.enableUnsafeCurrentUser();
     let user = new Parse.User();
     let notAuthed = null;
     user
@@ -436,6 +438,7 @@ describe('Parse User', () => {
   });
 
   it('can query for users', done => {
+    Parse.User.enableUnsafeCurrentUser();
     const user = new Parse.User();
     user.set('password', 'asdf');
     user.set('email', 'asdf@exxample.com');
@@ -458,6 +461,7 @@ describe('Parse User', () => {
   });
 
   it('preserves the session token when querying the current user', done => {
+    Parse.User.enableUnsafeCurrentUser();
     const user = new Parse.User();
     user.set('password', 'asdf');
     user.set('email', 'asdf@example.com');

--- a/integration/test/ParseUserTest.js
+++ b/integration/test/ParseUserTest.js
@@ -252,6 +252,7 @@ describe('Parse User', () => {
   });
 
   it('cannot saveAll with non-authed user', done => {
+    Parse.User.enableUnsafeCurrentUser();
     let user = new Parse.User();
     let notAuthed = null;
     user


### PR DESCRIPTION
### New Pull Request Checklist
<!--
    Check every following box [x] before submitting your PR.
    Click the "Preview" tab for better readability.
    Thanks for contributing to Parse Platform!
-->

- [x] I am not disclosing a [vulnerability](https://github.com/parse-community/parse-server/blob/master/SECURITY.md).
- [x] I am creating this PR in reference to an [issue](https://github.com/parse-community/Parse-SDK-JS/issues?q=is%3Aissue).

### Issue Description
<!-- Add a brief description of the issue this PR solves. -->

The integration tests are ran in random order. This will allow us to catch invariants within the tests. Meaning the state of the entire suite should be the same before and after each test within a spec file. Most flaky tests can be found by running them standalone with `fit` or running the suite randomly and check the order than ran.

Sometimes the job status is returned as `running` when it should be `successful`. The status is returned too quickly before the job is complete. There potentially could be performance improvements on the server side.
https://github.com/parse-community/Parse-SDK-JS/actions/runs/4001584644/jobs/6867964716
https://github.com/parse-community/Parse-SDK-JS/actions/runs/4011556752/jobs/6889541063

The schema isn't cleared before each test. When the server starts there is a `_User` and `_Role` schema created
https://github.com/parse-community/Parse-SDK-JS/actions/runs/4011007512/jobs/6888113575

These tests relied on the state of previous tests, specifically when `Parse.User.enableUnsafeCurrentUser` should be used
https://github.com/parse-community/Parse-SDK-JS/actions/runs/4006643738/jobs/6878441649
https://github.com/parse-community/Parse-SDK-JS/actions/runs/4006643738/jobs/6878442018

The MongoDB query optimizer can return different results when using explain() + hint(). https://www.mongodb.com/docs/manual/reference/explain-results/#std-label-queryPlanner

```
1) Parse Query can query with hint
  - TypeError: Cannot read properties of undefined (reading 'inputStage')
```

### TODOs before merging
<!--
    Add TODOs that need to be completed before merging this PR.
    Delete TODOs that do not apply to this PR.
-->

- [x] Add tests
- [x] Add changes to documentation (guides, repository pages, in-code descriptions)
