### PR TITLE
ci: Fix flaky tests due to open server connection

### DIFF
--- a/integration/test/ParseCloudTest.js
+++ b/integration/test/ParseCloudTest.js
@@ -4,6 +4,16 @@ const assert = require('assert');
 const Parse = require('../../node');
 const sleep = require('./sleep');
 
+const waitForJobStatus = async (jobStatusId, status) => {
+  const checkJobStatus = async () => {
+    const result = await Parse.Cloud.getJobStatus(jobStatusId);
+    return result && result.get('status') === status;
+  };
+  while (!(await checkJobStatus())) {
+    await sleep(100);
+  }
+};
+
 describe('Parse Cloud', () => {
   it('run function', done => {
     const params = { key1: 'value2', key2: 'value1' };
@@ -86,14 +96,8 @@ describe('Parse Cloud', () => {
   it('run job', async () => {
     const params = { startedBy: 'Monty Python' };
     const jobStatusId = await Parse.Cloud.startJob('CloudJob1', params);
+    await waitForJobStatus(jobStatusId, 'succeeded');
 
-    const checkJobStatus = async () => {
-      const result = await Parse.Cloud.getJobStatus(jobStatusId);
-      return result && result.get('status') === 'succeeded';
-    };
-    while (!(await checkJobStatus())) {
-      await sleep(100);
-    }
     const jobStatus = await Parse.Cloud.getJobStatus(jobStatusId);
     assert.equal(jobStatus.get('status'), 'succeeded');
     assert.equal(jobStatus.get('params').startedBy, 'Monty Python');
@@ -104,14 +108,8 @@ describe('Parse Cloud', () => {
 
     let jobStatus = await Parse.Cloud.getJobStatus(jobStatusId);
     assert.equal(jobStatus.get('status'), 'running');
+    await waitForJobStatus(jobStatusId, 'succeeded');
 
-    const checkJobStatus = async () => {
-      const result = await Parse.Cloud.getJobStatus(jobStatusId);
-      return result && result.get('status') === 'succeeded';
-    };
-    while (!(await checkJobStatus())) {
-      await sleep(100);
-    }
     jobStatus = await Parse.Cloud.getJobStatus(jobStatusId);
     assert.equal(jobStatus.get('status'), 'succeeded');
   });
@@ -126,16 +124,13 @@ describe('Parse Cloud', () => {
       });
   });
 
-  it('run failing job', done => {
-    Parse.Cloud.startJob('CloudJobFailing')
-      .then(jobStatusId => {
-        return Parse.Cloud.getJobStatus(jobStatusId);
-      })
-      .then(jobStatus => {
-        assert.equal(jobStatus.get('status'), 'failed');
-        assert.equal(jobStatus.get('message'), 'cloud job failed');
-        done();
-      });
+  it('run failing job', async () => {
+    const jobStatusId = await Parse.Cloud.startJob('CloudJobFailing');
+    await waitForJobStatus(jobStatusId, 'failed');
+
+    const jobStatus = await Parse.Cloud.getJobStatus(jobStatusId);
+    assert.equal(jobStatus.get('status'), 'failed');
+    assert.equal(jobStatus.get('message'), 'cloud job failed');
   });
 
   it('get jobs data', done => {

--- a/integration/test/ParseDistTest.js
+++ b/integration/test/ParseDistTest.js
@@ -1,12 +1,19 @@
 const puppeteer = require('puppeteer');
+let browser = null;
 let page = null;
 for (const fileName of ['parse.js', 'parse.min.js']) {
-  beforeAll(async () => {
-    const browser = await puppeteer.launch();
-    page = await browser.newPage();
-    await page.goto(`http://localhost:1337/${fileName}`);
-  });
   describe(`Parse Dist Test ${fileName}`, () => {
+    beforeEach(async () => {
+      browser = await puppeteer.launch();
+      page = await browser.newPage();
+      await page.goto(`http://localhost:1337/${fileName}`);
+    });
+
+    afterEach(async () => {
+      await page.close();
+      await browser.close();
+    });
+
     it('can save an object', async () => {
       const response = await page.evaluate(async () => {
         const object = await new Parse.Object('TestObject').save();
@@ -17,6 +24,7 @@ for (const fileName of ['parse.js', 'parse.min.js']) {
       expect(obj).toBeDefined();
       expect(obj.id).toEqual(response);
     });
+
     it('can query an object', async () => {
       const obj = await new Parse.Object('TestObject').save();
       const response = await page.evaluate(async () => {

--- a/integration/test/helper.js
+++ b/integration/test/helper.js
@@ -166,11 +166,14 @@ beforeAll(async () => {
 
 afterEach(async () => {
   await Parse.User.logOut();
+  // Connection close events are not immediate on node 10+... wait a bit
+  await sleep(0);
+  if (Object.keys(openConnections).length > 0) {
+    console.warn('There were open connections to the server left after the test finished');
+  }
   Parse.Storage._clear();
   await TestUtils.destroyAllDataPermanently(true);
   destroyAliveConnections();
-  // Connection close events are not immediate on node 10+... wait a bit
-  await sleep(0);
   if (didChangeConfiguration) {
     await reconfigureServer();
   }


### PR DESCRIPTION
### New Pull Request Checklist
<!--
    Check every following box [x] before submitting your PR.
    Click the "Preview" tab for better readability.
    Thanks for contributing to Parse Platform!
-->

- [x] I am not disclosing a [vulnerability](https://github.com/parse-community/parse-server/blob/master/SECURITY.md).
- [x] I am creating this PR in reference to an [issue](https://github.com/parse-community/Parse-SDK-JS/issues?q=is%3Aissue).

### Issue Description
<!-- Add a brief description of the issue this PR solves. -->

Sometimes the job status is returned as `running` when it should be `failed`. The status is returned too quickly before the job failed. 

```
Parse Cloud run failing job
  Message:
    Unhandled promise rejection: AssertionError [ERR_ASSERTION]: 'running' == 'failed'
```

I've taken initial steps to find the fix for this. Once a test finishes there shouldn't be any open connections to the server. If there are then we log them in the CI and fix the as we go. Hopefully we can find which test is leaking.
```
- Error: Timeout - Async function did not complete within 20000ms (set by jasmine.DEFAULT_TIMEOUT_INTERVAL)
        - MongoNotConnectedError: Client must be connected before running operations
```

I removed the beforeAll from `ParseDistTest` as I only recommend using only one beforeAll in the test suite (one already exists in `helper.js`). I ensured the headless browser closes and doesn't leave any connections to the server.

### Approach
<!-- Add a description of the approach in this PR. -->

Refactor Cloud Code Jobs to wait for the job status to change.

### TODOs before merging
<!--
    Add TODOs that need to be completed before merging this PR.
    Delete TODOs that do not apply to this PR.
-->

- [x] Add tests
- [x] Add changes to documentation (guides, repository pages, in-code descriptions)
