### PR TITLE
ci: Fix dependabot only upgrading parse-server

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,3 +15,5 @@ updates:
     # Define dependencies to update
     allow:
       - dependency-name: "parse-server"
+      # Allow both direct and indirect updates for all packages
+      - dependency-type: "all"


### PR DESCRIPTION
### New Pull Request Checklist
<!--
    Check every following box [x] before submitting your PR.
    Click the "Preview" tab for better readability.
    Thanks for contributing to Parse Platform!
-->

- [x] I am not disclosing a [vulnerability](https://github.com/parse-community/parse-server/blob/master/SECURITY.md).
- [x] I am creating this PR in reference to an [issue](https://github.com/parse-community/Parse-SDK-JS/issues?q=is%3Aissue).

### Issue Description

Closes: #1671 

### Approach

Change dependabot config.

