### PR TITLE
fix: Request execution time keeps increasing over time when using `Parse.Object.extend`

### DIFF
--- a/src/ParseObject.js
+++ b/src/ParseObject.js
@@ -121,12 +121,6 @@ class ParseObject {
       this.initialize.apply(this, arguments);
     }
 
-    if (this._initializers) {
-      for (const initializer of this._initializers) {
-        initializer.apply(this, arguments);
-      }
-    }
-
     let toSet = null;
     this._objCount = objectCount++;
     if (typeof className === 'string') {

--- a/src/ParseObject.js
+++ b/src/ParseObject.js
@@ -1959,10 +1959,8 @@ class ParseObject {
     let parentProto = ParseObject.prototype;
     if (this.hasOwnProperty('__super__') && this.__super__) {
       parentProto = this.prototype;
-    } else if (classMap[adjustedClassName]) {
-      parentProto = classMap[adjustedClassName].prototype;
     }
-    const ParseObjectSubclass = function (attributes, options) {
+    let ParseObjectSubclass = function (attributes, options) {
       this.className = adjustedClassName;
       this._objCount = objectCount++;
       // Enable legacy initializers
@@ -1976,17 +1974,20 @@ class ParseObject {
         }
       }
     };
-    ParseObjectSubclass.className = adjustedClassName;
-    ParseObjectSubclass.__super__ = parentProto;
-
-    ParseObjectSubclass.prototype = Object.create(parentProto, {
-      constructor: {
-        value: ParseObjectSubclass,
-        enumerable: false,
-        writable: true,
-        configurable: true,
-      },
-    });
+    if (classMap[adjustedClassName]) {
+      ParseObjectSubclass = classMap[adjustedClassName];
+    } else {
+      ParseObjectSubclass.className = adjustedClassName;
+      ParseObjectSubclass.__super__ = parentProto;
+      ParseObjectSubclass.prototype = Object.create(parentProto, {
+        constructor: {
+          value: ParseObjectSubclass,
+          enumerable: false,
+          writable: true,
+          configurable: true,
+        },
+      });
+    }
 
     if (protoProps) {
       for (const prop in protoProps) {

--- a/src/ParseObject.js
+++ b/src/ParseObject.js
@@ -1989,6 +1989,13 @@ class ParseObject {
     if (classMap[adjustedClassName]) {
       ParseObjectSubclass = classMap[adjustedClassName];
     } else {
+      ParseObjectSubclass.extend = function (name, protoProps, classProps) {
+        if (typeof name === 'string') {
+          return ParseObject.extend.call(ParseObjectSubclass, name, protoProps, classProps);
+        }
+        return ParseObject.extend.call(ParseObjectSubclass, adjustedClassName, name, protoProps);
+      };
+      ParseObjectSubclass.createWithoutData = ParseObject.createWithoutData;
       ParseObjectSubclass.className = adjustedClassName;
       ParseObjectSubclass.__super__ = parentProto;
       ParseObjectSubclass.prototype = Object.create(parentProto, {
@@ -2034,16 +2041,6 @@ class ParseObject {
           });
         }
       }
-    }
-
-    if (!classMap[adjustedClassName]) {
-      ParseObjectSubclass.extend = function (name, protoProps, classProps) {
-        if (typeof name === 'string') {
-          return ParseObject.extend.call(ParseObjectSubclass, name, protoProps, classProps);
-        }
-        return ParseObject.extend.call(ParseObjectSubclass, adjustedClassName, name, protoProps);
-      };
-      ParseObjectSubclass.createWithoutData = ParseObject.createWithoutData;
     }
     classMap[adjustedClassName] = ParseObjectSubclass;
     return ParseObjectSubclass;

--- a/src/__tests__/ParseObject-test.js
+++ b/src/__tests__/ParseObject-test.js
@@ -3524,14 +3524,14 @@ describe('ParseObject extensions', () => {
       // eslint-disable-next-line
       const parent = new Parent();
     }
-    expect(Date.now() - startExtend).toBeLessThan(100);
+    expect(Date.now() - startExtend).toBeLessThan(200);
 
     const startNew = Date.now();
     for (let i = 0; i < 100000; i++) {
       // eslint-disable-next-line
       const parent = new ParseObject('Parent');
     }
-    expect(Date.now() - startNew).toBeLessThan(100);
+    expect(Date.now() - startNew).toBeLessThan(200);
   });
 
   it('can generate ParseObjects with a default className', () => {

--- a/src/__tests__/ParseObject-test.js
+++ b/src/__tests__/ParseObject-test.js
@@ -3516,6 +3516,24 @@ describe('ParseObject extensions', () => {
     ParseObject.enableSingleInstance();
   });
 
+  it('can extend object', () => {
+    const startExtend = Date.now();
+    for (let i = 0; i < 100000; i++) {
+      // eslint-disable-next-line
+      const Parent = ParseObject.extend('Parent');
+      // eslint-disable-next-line
+      const parent = new Parent();
+    }
+    expect(Date.now() - startExtend).toBeLessThan(100);
+
+    const startNew = Date.now();
+    for (let i = 0; i < 100000; i++) {
+      // eslint-disable-next-line
+      const parent = new ParseObject('Parent');
+    }
+    expect(Date.now() - startNew).toBeLessThan(100);
+  });
+
   it('can generate ParseObjects with a default className', () => {
     const YourObject = ParseObject.extend('YourObject');
     const yo = new YourObject();


### PR DESCRIPTION
### New Pull Request Checklist
<!--
    Check every following box [x] before submitting your PR.
    Click the "Preview" tab for better readability.
    Thanks for contributing to Parse Platform!
-->

- [x] I am not disclosing a [vulnerability](https://github.com/parse-community/parse-server/blob/master/SECURITY.md).
- [x] I am creating this PR in reference to an [issue](https://github.com/parse-community/Parse-SDK-JS/issues?q=is%3Aissue).

### Issue Description
<!-- Add a brief description of the issue this PR solves. -->

`new Parse.Object.extend("")` takes increasing execution time when ran in a loop, as it seems that the constructor somehow gets deep assigned each time, meaning that it is exponentially called.

Closes: https://github.com/parse-community/Parse-SDK-JS/issues/1683

### Approach
<!-- Add a description of the approach in this PR. -->

First commit shows the issue, with:

```js
 for (let i = 0; i < 100000; i++) {
      // eslint-disable-next-line
      const Parent = ParseObject.extend('Parent');
      // eslint-disable-next-line
      const parent = new Parent();
}
```

Timing out the CI, taking too long.

With these changes, this function only takes 38ms.

### TODOs before merging
<!--
    Add TODOs that need to be completed before merging this PR.
    Delete TODOs that do not apply to this PR.
-->

- [ ] Add tests
- [ ] Add changes to documentation (guides, repository pages, in-code descriptions)
