### PR TITLE
refactor: Fix JSDoc warnings

### DIFF
--- a/src/CloudCode.js
+++ b/src/CloudCode.js
@@ -245,7 +245,6 @@
  * @name Parse.Cloud.job
  * @param {string} name The name of the Background Job
  * @param {Function} func The Background Job to register. This function should take two parameters a {@link Parse.Cloud.JobRequest} and a {@link Parse.Cloud.JobStatus}
- *
  */
 
 /**

--- a/src/LiveQueryClient.js
+++ b/src/LiveQueryClient.js
@@ -182,7 +182,7 @@ class LiveQueryClient extends EventEmitter {
    *
    * @param {object} query - the ParseQuery you want to subscribe to
    * @param {string} sessionToken (optional)
-   * @returns {LiveQuerySubscription} subscription
+   * @returns {LiveQuerySubscription | undefined}
    */
   subscribe(query: Object, sessionToken: ?string): LiveQuerySubscription {
     if (!query) {

--- a/src/ParseFile.js
+++ b/src/ParseFile.js
@@ -184,7 +184,7 @@ class ParseFile {
    * after you get the file from a Parse.Object.
    *
    * @param {object} options An object to specify url options
-   * @returns {string}
+   * @returns {string | undefined}
    */
   url(options?: { forceSecure?: boolean }): ?string {
     options = options || {};
@@ -220,7 +220,7 @@ class ParseFile {
    * Saves the file to the Parse cloud.
    *
    * @param {object} options
-   *  * Valid options are:<ul>
+   * Valid options are:<ul>
    *   <li>useMasterKey: In Cloud Code and Node only, causes the Master Key to
    *     be used for this request.
    *   <li>sessionToken: A valid session token, used for making a request on
@@ -237,9 +237,9 @@ class ParseFile {
    * });
    * </pre>
    * </ul>
-   * @returns {Promise} Promise that is resolved when the save finishes.
+   * @returns {Promise | undefined} Promise that is resolved when the save finishes.
    */
-  save(options?: FullOptions) {
+  save(options?: FullOptions): ?Promise {
     options = options || {};
     options.requestTask = task => (this._requestTask = task);
     options.metadata = this._metadata;
@@ -306,7 +306,7 @@ class ParseFile {
    * In Cloud Code and Node only with Master Key.
    *
    * @param {object} options
-   *  * Valid options are:<ul>
+   * Valid options are:<ul>
    *   <li>useMasterKey: In Cloud Code and Node only, causes the Master Key to
    *     be used for this request.
    * <pre>

--- a/src/ParseObject.js
+++ b/src/ParseObject.js
@@ -148,7 +148,7 @@ class ParseObject {
   _objCount: number;
   className: string;
 
-  /** Prototype getters / setters **/
+  /* Prototype getters / setters */
 
   get attributes(): AttributeMap {
     const stateController = CoreManager.getObjectStateController();
@@ -175,7 +175,7 @@ class ParseObject {
     return this._getServerData().updatedAt;
   }
 
-  /** Private methods **/
+  /* Private methods */
 
   /**
    * Returns a local or server Id used uniquely identify this object
@@ -446,7 +446,7 @@ class ParseObject {
     return classMap;
   }
 
-  /** Public methods **/
+  /* Public methods */
 
   initialize() {
     // NOOP
@@ -910,7 +910,7 @@ class ParseObject {
    * object.op("x") would return an instance of Parse.Op.Increment.
    *
    * @param attr {String} The key.
-   * @returns {Parse.Op} The operation, or undefined if none.
+   * @returns {Parse.Op | undefined} The operation, or undefined if none.
    */
   op(attr: string): ?Op {
     const pending = this._getPendingOps();
@@ -1518,7 +1518,7 @@ class ParseObject {
     return this;
   }
 
-  /** Static methods **/
+  /* Static methods */
 
   static _clearAllState() {
     const stateController = CoreManager.getObjectStateController();

--- a/src/ParseQuery.js
+++ b/src/ParseQuery.js
@@ -596,7 +596,6 @@ class ParseQuery {
    *   <li>context: A dictionary that is accessible in Cloud Code `beforeFind` trigger.
    *   <li>json: Return raw json without converting to Parse.Object
    * </ul>
-   *
    * @returns {Promise} A promise that is resolved with the result when
    * the query completes.
    */
@@ -639,7 +638,6 @@ class ParseQuery {
    *   <li>context: A dictionary that is accessible in Cloud Code `beforeFind` trigger.
    *   <li>json: Return raw json without converting to Parse.Object
    * </ul>
-   *
    * @returns {Promise} A promise that is resolved with the results when
    * the query completes.
    */
@@ -733,7 +731,6 @@ class ParseQuery {
    *   <li>sessionToken: A valid session token, used for making a request on
    *       behalf of a specific user.
    * </ul>
-   *
    * @returns {Promise} A promise that is resolved with the count when
    * the query completes.
    */
@@ -769,7 +766,6 @@ class ParseQuery {
    *   <li>sessionToken: A valid session token, used for making a request on
    *       behalf of a specific user.
    * </ul>
-   *
    * @returns {Promise} A promise that is resolved with the query completes.
    */
   distinct(key: string, options?: FullOptions): Promise<Array<mixed>> {
@@ -802,7 +798,6 @@ class ParseQuery {
    *   <li>sessionToken: A valid session token, used for making a request on
    *       behalf of a specific user.
    * </ul>
-   *
    * @returns {Promise} A promise that is resolved with the query completes.
    */
   aggregate(pipeline: mixed, options?: FullOptions): Promise<Array<mixed>> {
@@ -852,7 +847,6 @@ class ParseQuery {
    *   <li>context: A dictionary that is accessible in Cloud Code `beforeFind` trigger.
    *   <li>json: Return raw json without converting to Parse.Object
    * </ul>
-   *
    * @returns {Promise} A promise that is resolved with the object when
    * the query completes.
    */
@@ -1084,7 +1078,6 @@ class ParseQuery {
    *   <li>index: The index of the current Parse.Object being processed in the array.</li>
    *   <li>query: The query map was called upon.</li>
    * </ul>
-   *
    * @param {object} options Valid options are:<ul>
    *   <li>useMasterKey: In Cloud Code and Node only, causes the Master Key to
    *     be used for this request.
@@ -1173,7 +1166,6 @@ class ParseQuery {
    *   <li>index: The index of the current Parse.Object being processed in the array.</li>
    *   <li>query: The query filter was called upon.</li>
    * </ul>
-   *
    * @param {object} options Valid options are:<ul>
    *   <li>useMasterKey: In Cloud Code and Node only, causes the Master Key to
    *     be used for this request.
@@ -1200,7 +1192,7 @@ class ParseQuery {
     return array;
   }
 
-  /** Query Conditions **/
+  /* Query Conditions */
 
   /**
    * Adds a constraint to the query that requires a particular key's value to
@@ -1729,7 +1721,7 @@ class ParseQuery {
     return this._addCondition(key, '$geoIntersects', { $point: point });
   }
 
-  /** Query Orderings **/
+  /* Query Orderings */
 
   /**
    * Sorts the results in ascending order by the given key.
@@ -1806,7 +1798,7 @@ class ParseQuery {
     return this;
   }
 
-  /** Query Options **/
+  /* Query Options */
 
   /**
    * Sets the number of results to skip before returning any results.


### PR DESCRIPTION
## Pull Request

- Report security issues [confidentially](https://github.com/parse-community/Parse-SDK-JS/security/policy).
- Any contribution is under this [license](https://github.com/parse-community/Parse-SDK-JS/blob/alpha/LICENSE).
- Link this pull request to an [issue](https://github.com/parse-community/Parse-SDK-JS/issues?q=is%3Aissue).

## Issue
<!-- Add the link to the issue that this PR closes. -->

Updating the jsdocs eslint plugin caused warning to shows. This PR addresses them.

[see Issue](https://github.com/parse-community/Parse-SDK-JS/pull/1708/files#diff-d14b2dcbdb9c4dc7cad57a9f58577635dab37ed57062006716966fd22ab30d55)

