### PR TITLE
feat: `LiveQueryClient.close` returns promise when WebSocket closes

### DIFF
--- a/integration/test/ParseLiveQueryTest.js
+++ b/integration/test/ParseLiveQueryTest.js
@@ -9,6 +9,12 @@ describe('Parse LiveQuery', () => {
     Parse.User.enableUnsafeCurrentUser();
   });
 
+  afterEach(async () => {
+    const client = await Parse.CoreManager.getLiveQueryController().getDefaultLiveQueryClient();
+    client.state = 'closed';
+    await client.close();
+  });
+
   it('can subscribe to query', async done => {
     const object = new TestObject();
     await object.save();
@@ -66,9 +72,9 @@ describe('Parse LiveQuery', () => {
     const query = new Parse.Query(TestObject);
     query.equalTo('objectId', object.id);
     const subscription = await client.subscribe(query);
-    subscription.on('update', async object => {
+    subscription.on('update', async (object) => {
       assert.equal(object.get('foo'), 'bar');
-      client.close();
+      await client.close();
       done();
     });
     await subscription.subscribePromise;
@@ -279,7 +285,8 @@ describe('Parse LiveQuery', () => {
     await expectAsync(subscription.subscribePromise).toBeRejectedWith(
       new Parse.Error(141, 'not allowed to subscribe')
     );
-    client.close();
+    client.state = 'closed';
+    await client.close();
   });
 
   it('connectPromise does throw', async () => {
@@ -306,6 +313,7 @@ describe('Parse LiveQuery', () => {
     await expectAsync(subscription.subscribePromise).toBeRejectedWith(
       new Parse.Error(141, 'not allowed to connect')
     );
-    client.close();
+    client.state = 'closed';
+    await client.close();
   });
 });

--- a/src/Socket.weapp.js
+++ b/src/Socket.weapp.js
@@ -13,8 +13,8 @@ module.exports = class SocketWeapp {
       this.onmessage(msg);
     });
 
-    wx.onSocketClose(() => {
-      this.onclose();
+    wx.onSocketClose((event) => {
+      this.onclose(event);
     });
 
     wx.onSocketError(error => {


### PR DESCRIPTION
## Pull Request

- Report security issues [confidentially](https://github.com/parse-community/Parse-SDK-JS/security/policy).
- Any contribution is under this [license](https://github.com/parse-community/Parse-SDK-JS/blob/alpha/LICENSE).
- Link this pull request to an [issue](https://github.com/parse-community/Parse-SDK-JS/issues?q=is%3Aissue).

## Issue
<!-- Add the link to the issue that this PR closes. -->

Closes: https://github.com/parse-community/Parse-SDK-JS/issues/1734

## Approach
<!-- Describe the changes in this PR. -->
* Returns Websocket CloseEvent [@see link](https://developer.mozilla.org/en-US/docs/Web/API/WebSocket/close_event)
* Improves tests to ensure server connections are closed properly.
* Improve WeChat Mini Websockets onclose event [@see link](https://developers.weixin.qq.com/miniprogram/en/dev/api/network/websocket/wx.onSocketClose.html)
* Ensure socket exists

- [x] Add tests
- [x] Add changes to documentation (guides, repository pages, code comments)
