### PR TITLE
refactor: Bump Jasmine to 4.5.0

### DIFF
--- a/integration/test/ParseEventuallyQueueTest.js
+++ b/integration/test/ParseEventuallyQueueTest.js
@@ -190,67 +190,63 @@ describe('Parse EventuallyQueue', () => {
     assert.strictEqual(length, 0);
   });
 
-  it('can saveEventually', async done => {
+  it('can saveEventually', async () => {
     const parseServer = await reconfigureServer();
     const object = new TestObject({ hash: 'saveSecret' });
-    parseServer.server.close(async () => {
-      await object.saveEventually();
-      let length = await Parse.EventuallyQueue.length();
-      assert(Parse.EventuallyQueue.isPolling());
-      assert.strictEqual(length, 1);
+    await new Promise((resolve) => parseServer.server.close(resolve));
+    await object.saveEventually();
+    let length = await Parse.EventuallyQueue.length();
+    assert(Parse.EventuallyQueue.isPolling());
+    assert.strictEqual(length, 1);
 
-      await reconfigureServer({});
-      while (Parse.EventuallyQueue.isPolling()) {
-        await sleep(100);
-      }
-      assert.strictEqual(Parse.EventuallyQueue.isPolling(), false);
+    await reconfigureServer({});
+    while (Parse.EventuallyQueue.isPolling()) {
+      await sleep(100);
+    }
+    assert.strictEqual(Parse.EventuallyQueue.isPolling(), false);
 
-      while (await Parse.EventuallyQueue.length()) {
-        await sleep(100);
-      }
-      length = await Parse.EventuallyQueue.length();
-      assert.strictEqual(length, 0);
+    while (await Parse.EventuallyQueue.length()) {
+      await sleep(100);
+    }
+    length = await Parse.EventuallyQueue.length();
+    assert.strictEqual(length, 0);
 
-      const query = new Parse.Query(TestObject);
-      query.equalTo('hash', 'saveSecret');
-      let results = await query.find();
-      while (results.length === 0) {
-        results = await query.find();
-      }
-      assert.strictEqual(results.length, 1);
-      done();
-    });
+    const query = new Parse.Query(TestObject);
+    query.equalTo('hash', 'saveSecret');
+    let results = await query.find();
+    while (results.length === 0) {
+      results = await query.find();
+    }
+    assert.strictEqual(results.length, 1);
   });
 
-  it('can destroyEventually', async done => {
+  it('can destroyEventually', async () => {
     const parseServer = await reconfigureServer();
     const object = new TestObject({ hash: 'deleteSecret' });
     await object.save();
-    parseServer.server.close(async () => {
-      await object.destroyEventually();
-      let length = await Parse.EventuallyQueue.length();
-      assert(Parse.EventuallyQueue.isPolling());
-      assert.strictEqual(length, 1);
+    await new Promise((resolve) => parseServer.server.close(resolve));
+    await object.destroyEventually();
+    let length = await Parse.EventuallyQueue.length();
+    assert(Parse.EventuallyQueue.isPolling());
+    assert.strictEqual(length, 1);
 
-      await reconfigureServer({});
-      while (Parse.EventuallyQueue.isPolling()) {
-        await sleep(100);
-      }
-      assert.strictEqual(Parse.EventuallyQueue.isPolling(), false);
-      while (await Parse.EventuallyQueue.length()) {
-        await sleep(100);
-      }
-      length = await Parse.EventuallyQueue.length();
-      assert.strictEqual(length, 0);
+    await reconfigureServer({});
+    while (Parse.EventuallyQueue.isPolling()) {
+      await sleep(100);
+    }
+    assert.strictEqual(Parse.EventuallyQueue.isPolling(), false);
+    while (await Parse.EventuallyQueue.length()) {
+      await sleep(100);
+    }
+    length = await Parse.EventuallyQueue.length();
+    assert.strictEqual(length, 0);
 
-      const query = new Parse.Query(TestObject);
-      query.equalTo('hash', 'deleteSecret');
-      let results = await query.find();
-      while (results.length) {
-        results = await query.find();
-      }
-      assert.strictEqual(results.length, 0);
-      done();
-    });
+    const query = new Parse.Query(TestObject);
+    query.equalTo('hash', 'deleteSecret');
+    let results = await query.find();
+    while (results.length) {
+      results = await query.find();
+    }
+    assert.strictEqual(results.length, 0);
   });
 });

--- a/integration/test/ParseLiveQueryTest.js
+++ b/integration/test/ParseLiveQueryTest.js
@@ -3,6 +3,7 @@
 const assert = require('assert');
 const Parse = require('../../node');
 const sleep = require('./sleep');
+const { resolvingPromise } = require('../../lib/node/promiseUtils');
 
 describe('Parse LiveQuery', () => {
   beforeEach(() => {
@@ -15,7 +16,7 @@ describe('Parse LiveQuery', () => {
     await client.close();
   });
 
-  it('can subscribe to query', async done => {
+  it('can subscribe to query', async () => {
     const object = new TestObject();
     await object.save();
     const installationId = await Parse.CoreManager.getInstallationController().currentInstallationId();
@@ -23,17 +24,18 @@ describe('Parse LiveQuery', () => {
     const query = new Parse.Query(TestObject);
     query.equalTo('objectId', object.id);
     const subscription = await query.subscribe();
-
+    const promise = resolvingPromise();
     subscription.on('update', (object, original, response) => {
       assert.equal(object.get('foo'), 'bar');
       assert.equal(response.installationId, installationId);
-      done();
+      promise.resolve();
     });
     object.set({ foo: 'bar' });
     await object.save();
+    await promise;
   });
 
-  it('can subscribe to query with client', async done => {
+  it('can subscribe to query with client', async () => {
     const object = new TestObject();
     await object.save();
     const installationId = await Parse.CoreManager.getInstallationController().currentInstallationId();
@@ -45,18 +47,19 @@ describe('Parse LiveQuery', () => {
       client.open();
     }
     const subscription = client.subscribe(query);
-
+    const promise = resolvingPromise();
     subscription.on('update', (object, original, response) => {
       assert.equal(object.get('foo'), 'bar');
       assert.equal(response.installationId, installationId);
-      done();
+      promise.resolve();
     });
     await subscription.subscribePromise;
     object.set({ foo: 'bar' });
     await object.save();
+    await promise;
   });
 
-  it('can subscribe to query with null connect fields', async done => {
+  it('can subscribe to query with null connect fields', async () => {
     const client = new Parse.LiveQueryClient({
       applicationId: 'integration',
       serverURL: 'ws://localhost:1337',
@@ -72,14 +75,16 @@ describe('Parse LiveQuery', () => {
     const query = new Parse.Query(TestObject);
     query.equalTo('objectId', object.id);
     const subscription = await client.subscribe(query);
+    const promise = resolvingPromise();
     subscription.on('update', async (object) => {
       assert.equal(object.get('foo'), 'bar');
       await client.close();
-      done();
+      promise.resolve();
     });
     await subscription.subscribePromise;
     object.set({ foo: 'bar' });
     await object.save();
+    await promise;
   });
 
   it('can subscribe to multiple queries', async () => {
@@ -186,7 +191,7 @@ describe('Parse LiveQuery', () => {
     assert.equal(count, 1);
   });
 
-  it('can subscribe to ACL', async done => {
+  it('can subscribe to ACL', async () => {
     const user = await Parse.User.signUp('ooo', 'password');
     const ACL = new Parse.ACL(user);
 
@@ -197,15 +202,17 @@ describe('Parse LiveQuery', () => {
     const query = new Parse.Query(TestObject);
     query.equalTo('objectId', object.id);
     const subscription = await query.subscribe(user.getSessionToken());
+    const promise = resolvingPromise();
     subscription.on('update', async object => {
       assert.equal(object.get('foo'), 'bar');
       await Parse.User.logOut();
-      done();
+      promise.resolve()
     });
     await object.save({ foo: 'bar' });
+    await promise;
   });
 
-  it('can subscribe to null sessionToken', async done => {
+  it('can subscribe to null sessionToken', async () => {
     const user = await Parse.User.signUp('oooooo', 'password');
 
     const readOnly = Parse.User.readOnlyAttributes();
@@ -219,32 +226,36 @@ describe('Parse LiveQuery', () => {
     const query = new Parse.Query(TestObject);
     query.equalTo('objectId', object.id);
     const subscription = await query.subscribe();
+    const promise = resolvingPromise();
     subscription.on('update', async object => {
       assert.equal(object.get('foo'), 'bar');
       Parse.User.readOnlyAttributes = function () {
         return readOnly;
       };
       await Parse.User.logOut();
-      done();
+      promise.resolve();
     });
     await object.save({ foo: 'bar' });
+    await promise;
   });
 
-  it('can subscribe with open event', async done => {
+  it('can subscribe with open event', async () => {
     const object = new TestObject();
     await object.save();
 
     const query = new Parse.Query(TestObject);
     query.equalTo('objectId', object.id);
     const subscription = await query.subscribe();
+    const promise = resolvingPromise();
     subscription.on('open', response => {
       assert(response.clientId);
       assert(response.installationId);
-      done();
+      promise.resolve();
     });
+    await promise;
   });
 
-  it('can subscribe to query with fields', async done => {
+  it('can subscribe to query with fields', async () => {
     const object = new TestObject();
     await object.save({ name: 'hello', age: 21 });
 
@@ -253,14 +264,16 @@ describe('Parse LiveQuery', () => {
     query.select(['name']);
     const subscription = await query.subscribe();
 
+    const promise = resolvingPromise();
     subscription.on('update', object => {
       assert.equal(object.get('name'), 'hello');
       assert.equal(object.get('age'), undefined);
       assert.equal(object.get('foo'), undefined);
-      done();
+      promise.resolve();
     });
     object.set({ foo: 'bar' });
     await object.save();
+    await promise;
   });
 
   it('live query can handle beforeConnect and beforeSubscribe errors', async () => {

--- a/integration/test/ParseObjectTest.js
+++ b/integration/test/ParseObjectTest.js
@@ -1108,7 +1108,7 @@ describe('Parse Object', () => {
       });
   });
 
-  it('can skip cascade saving as per request', async done => {
+  it('can skip cascade saving as per request', async () => {
     const Parent = Parse.Object.extend('Parent');
     const Child = Parse.Object.extend('Child');
 
@@ -1142,8 +1142,6 @@ describe('Parse Object', () => {
     await parent.save(null, { cascadeSave: false });
     const john = await new Parse.Query(Child).doesNotExist('lastname').first();
     expect(john.get('lastname')).toBeUndefined();
-
-    done();
   });
 
   it('can do two saves at the same time', done => {
@@ -1956,7 +1954,7 @@ describe('Parse Object', () => {
     }
   });
 
-  it('can clone with relation', async done => {
+  it('can clone with relation', async () => {
     const testObject = new TestObject();
     const o = new TestObject();
     await o.save();
@@ -1982,8 +1980,6 @@ describe('Parse Object', () => {
 
     relations = await o2.relation('aRelation').query().find();
     assert.equal(relations.length, 1);
-
-    done();
   });
 
   it('isDataAvailable', async () => {

--- a/integration/test/ParseQueryAggregateTest.js
+++ b/integration/test/ParseQueryAggregateTest.js
@@ -89,19 +89,15 @@ describe('Parse Aggregate Query', () => {
     expect(results[0].tempPointer.value).toEqual(2);
   });
 
-  it('aggregate pipeline on top of a simple query', async done => {
+  it('aggregate pipeline on top of a simple query', async () => {
     const pipeline = {
       $group: { _id: '$name' },
     };
     let results = await new Parse.Query(TestObject).equalTo('name', 'foo').aggregate(pipeline);
-
     expect(results.length).toBe(1);
 
     results = await new Parse.Query(TestObject).equalTo('score', 20).aggregate(pipeline);
-
     expect(results.length).toBe(1);
-
-    done();
   });
 
   it('distinct query', () => {

--- a/integration/test/ParseQueryTest.js
+++ b/integration/test/ParseQueryTest.js
@@ -1761,17 +1761,11 @@ describe('Parse Query', () => {
       });
   });
 
-  it('supports objects with length', async done => {
+  it('supports objects with length', async () => {
     const obj = new TestObject();
     obj.set('length', 5);
     assert.equal(obj.get('length'), 5);
-    try {
-      await obj.save();
-      done.fail();
-    } catch (e) {
-      assert.strictEqual(e.message, 'Invalid field name: length.');
-      done();
-    }
+    await expectAsync(obj.save()).toBeRejectedWithError('Invalid field name: length.');
   });
 
   it('can include User fields', async () => {

--- a/integration/test/ParseServerTest.js
+++ b/integration/test/ParseServerTest.js
@@ -3,32 +3,21 @@
 const assert = require('assert');
 
 describe('ParseServer', () => {
-  it('can reconfigure server', async done => {
+  it('can reconfigure server', async () => {
     const parseServer = await reconfigureServer({ serverURL: 'www.google.com' });
     assert.strictEqual(parseServer.config.serverURL, 'www.google.com');
-    parseServer.server.close(async () => {
-      await reconfigureServer();
-      done();
-    });
+    await new Promise((resolve) => parseServer.server.close(resolve));
+    await reconfigureServer();
   });
 
-  it('can shutdown', async done => {
+  it('can shutdown', async () => {
     const parseServer = await reconfigureServer();
     const object = new TestObject({ foo: 'bar' });
     await parseServer.handleShutdown();
-    parseServer.server.close(async () => {
-      try {
-        await object.save();
-      } catch (e) {
-        assert.strictEqual(
-          e.message,
-          'XMLHttpRequest failed: "Unable to connect to the Parse API"'
-        );
-        await reconfigureServer({});
-        await object.save();
-        assert(object.id);
-        done();
-      }
-    });
+    await new Promise((resolve) => parseServer.server.close(resolve));
+    await expectAsync(object.save()).toBeRejectedWithError('XMLHttpRequest failed: "Unable to connect to the Parse API"');
+    await reconfigureServer({});
+    await object.save();
+    assert(object.id);
   });
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -54,7 +54,7 @@
         "gulp-uglify": "3.0.2",
         "gulp-watch": "5.0.1",
         "husky": "8.0.3",
-        "jasmine": "3.5.0",
+        "jasmine": "4.5.0",
         "jasmine-reporters": "2.5.2",
         "jasmine-spec-reporter": "7.0.0",
         "jest": "29.4.2",
@@ -14355,22 +14355,22 @@
       "dev": true
     },
     "node_modules/jasmine": {
-      "version": "3.5.0",
-      "resolved": "https://registry.npmjs.org/jasmine/-/jasmine-3.5.0.tgz",
-      "integrity": "sha512-DYypSryORqzsGoMazemIHUfMkXM7I7easFaxAvNM3Mr6Xz3Fy36TupTrAOxZWN8MVKEU5xECv22J4tUQf3uBzQ==",
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/jasmine/-/jasmine-4.5.0.tgz",
+      "integrity": "sha512-9olGRvNZyADIwYL9XBNBst5BTU/YaePzuddK+YRslc7rI9MdTIE4r3xaBKbv2GEmzYYUfMOdTR8/i6JfLZaxSQ==",
       "dev": true,
       "dependencies": {
-        "glob": "^7.1.4",
-        "jasmine-core": "~3.5.0"
+        "glob": "^7.1.6",
+        "jasmine-core": "^4.5.0"
       },
       "bin": {
         "jasmine": "bin/jasmine.js"
       }
     },
     "node_modules/jasmine-core": {
-      "version": "3.5.0",
-      "resolved": "https://registry.npmjs.org/jasmine-core/-/jasmine-core-3.5.0.tgz",
-      "integrity": "sha512-nCeAiw37MIMA9w9IXso7bRaLl+c/ef3wnxsoSAlYrzS+Ot0zTG6nU8G/cIfGkqpkjX2wNaIW9RFG0TwIFnG6bA==",
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/jasmine-core/-/jasmine-core-4.5.0.tgz",
+      "integrity": "sha512-9PMzyvhtocxb3aXJVOPqBDswdgyAeSB81QnLop4npOpbqnheaTEwPc9ZloQeVswugPManznQBjD8kWDTjlnHuw==",
       "dev": true
     },
     "node_modules/jasmine-reporters": {
@@ -38794,19 +38794,19 @@
       "dev": true
     },
     "jasmine": {
-      "version": "3.5.0",
-      "resolved": "https://registry.npmjs.org/jasmine/-/jasmine-3.5.0.tgz",
-      "integrity": "sha512-DYypSryORqzsGoMazemIHUfMkXM7I7easFaxAvNM3Mr6Xz3Fy36TupTrAOxZWN8MVKEU5xECv22J4tUQf3uBzQ==",
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/jasmine/-/jasmine-4.5.0.tgz",
+      "integrity": "sha512-9olGRvNZyADIwYL9XBNBst5BTU/YaePzuddK+YRslc7rI9MdTIE4r3xaBKbv2GEmzYYUfMOdTR8/i6JfLZaxSQ==",
       "dev": true,
       "requires": {
-        "glob": "^7.1.4",
-        "jasmine-core": "~3.5.0"
+        "glob": "^7.1.6",
+        "jasmine-core": "^4.5.0"
       }
     },
     "jasmine-core": {
-      "version": "3.5.0",
-      "resolved": "https://registry.npmjs.org/jasmine-core/-/jasmine-core-3.5.0.tgz",
-      "integrity": "sha512-nCeAiw37MIMA9w9IXso7bRaLl+c/ef3wnxsoSAlYrzS+Ot0zTG6nU8G/cIfGkqpkjX2wNaIW9RFG0TwIFnG6bA==",
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/jasmine-core/-/jasmine-core-4.5.0.tgz",
+      "integrity": "sha512-9PMzyvhtocxb3aXJVOPqBDswdgyAeSB81QnLop4npOpbqnheaTEwPc9ZloQeVswugPManznQBjD8kWDTjlnHuw==",
       "dev": true
     },
     "jasmine-reporters": {
@@ -44811,7 +44811,7 @@
       "version": "git+ssh://git@github.com/parse-community/parse-server.git#e76123b48249bc216651e41c2075331d3b30c75f",
       "integrity": "sha512-VMDOqjBWItwHYUddRKidkarN+yvlJVh+VyvEItGu9ZgnbydvKw54ETM8XjNQXPazlsktPJW22qmP/DE0y/a7Bg==",
       "dev": true,
-      "from": "parse-server@git+https://github.com/parse-community/parse-server#e76123b48249bc216651e41c2075331d3b30c75f",
+      "from": "parse-server@git+https://github.com/parse-community/parse-server#alpha",
       "requires": {
         "@babel/eslint-parser": "7.19.1",
         "@graphql-tools/merge": "8.3.6",

--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
     "gulp-uglify": "3.0.2",
     "gulp-watch": "5.0.1",
     "husky": "8.0.3",
-    "jasmine": "3.5.0",
+    "jasmine": "4.5.0",
     "jasmine-reporters": "2.5.2",
     "jasmine-spec-reporter": "7.0.0",
     "jest": "29.4.2",


### PR DESCRIPTION
## Pull Request

- Report security issues [confidentially](https://github.com/parse-community/Parse-SDK-JS/security/policy).
- Any contribution is under this [license](https://github.com/parse-community/Parse-SDK-JS/blob/alpha/LICENSE).
- Link this pull request to an [issue](https://github.com/parse-community/Parse-SDK-JS/issues?q=is%3Aissue).

## Issue
<!-- Add the link to the issue that this PR closes. -->
In the new Jasmine update there can't be async / await and `done` at the same time
```
- An asynchronous before/it/after function was defined with the async keyword but also took a done callback. Either remove the done callback (recommended) or remove the async keyword. thrown
```
Closes: https://github.com/parse-community/Parse-SDK-JS/pull/1756

- [x] Add tests
- [x] Add changes to documentation (guides, repository pages, code comments)
