### PR TITLE
docs: Fix incorrect type in docs for `Parse.Query.containedIn` and `Parse.Query.notContainedIn`

### DIFF
--- a/src/ParseQuery.js
+++ b/src/ParseQuery.js
@@ -1284,10 +1284,10 @@ class ParseQuery {
    * be contained in the provided list of values.
    *
    * @param {string} key The key to check.
-   * @param {*} value The values that will match.
+   * @param {array} value The values that will match.
    * @returns {Parse.Query} Returns the query, so you can chain this call.
    */
-  containedIn(key: string, value: mixed): ParseQuery {
+  containedIn(key: string, value: Array<mixed>): ParseQuery {
     return this._addCondition(key, '$in', value);
   }
 
@@ -1296,10 +1296,10 @@ class ParseQuery {
    * not be contained in the provided list of values.
    *
    * @param {string} key The key to check.
-   * @param {*} value The values that will not match.
+   * @param {array} value The values that will not match.
    * @returns {Parse.Query} Returns the query, so you can chain this call.
    */
-  notContainedIn(key: string, value: mixed): ParseQuery {
+  notContainedIn(key: string, value: Array<mixed>): ParseQuery {
     return this._addCondition(key, '$nin', value);
   }
 

--- a/src/ParseQuery.js
+++ b/src/ParseQuery.js
@@ -1296,7 +1296,7 @@ class ParseQuery {
    * not be contained in the provided list of values.
    *
    * @param {string} key The key to check.
-   * @param {array} value The values that will not match.
+   * @param {Array<*>} value The values that will not match.
    * @returns {Parse.Query} Returns the query, so you can chain this call.
    */
   notContainedIn(key: string, value: Array<mixed>): ParseQuery {

--- a/src/ParseQuery.js
+++ b/src/ParseQuery.js
@@ -1284,7 +1284,7 @@ class ParseQuery {
    * be contained in the provided list of values.
    *
    * @param {string} key The key to check.
-   * @param {array} value The values that will match.
+   * @param {Array<*>} value The values that will match.
    * @returns {Parse.Query} Returns the query, so you can chain this call.
    */
   containedIn(key: string, value: Array<mixed>): ParseQuery {


### PR DESCRIPTION
## Pull Request

- Report security issues [confidentially](https://github.com/parse-community/Parse-SDK-JS/security/policy).
- Any contribution is under this [license](https://github.com/parse-community/Parse-SDK-JS/blob/alpha/LICENSE).
- Link this pull request to an [issue](https://github.com/parse-community/Parse-SDK-JS/issues?q=is%3Aissue).

## Issue

Closes: #1783 

## Approach
<!-- Describe the changes in this PR. -->
Documentation and method parameter type updated for `Parse.Query.containedIn` and `Parse.Query.notContainedIn`

## Tasks

- [x] Add changes to documentation (guides, repository pages, code comments)
