### PR TITLE
feat: Add `ParseQuery.watch` to trigger LiveQuery only on update of specific fields

### DIFF
--- a/src/LiveQueryClient.js
+++ b/src/LiveQueryClient.js
@@ -191,7 +191,8 @@ class LiveQueryClient extends EventEmitter {
     const className = query.className;
     const queryJSON = query.toJSON();
     const where = queryJSON.where;
-    const fields = queryJSON.keys ? queryJSON.keys.split(',') : undefined;
+    const fields = queryJSON.keys?.split(',');
+    const watch = queryJSON.watch?.split(',');
     const subscribeRequest = {
       op: OP_TYPES.SUBSCRIBE,
       requestId: this.requestId,
@@ -199,6 +200,7 @@ class LiveQueryClient extends EventEmitter {
         className,
         where,
         fields,
+        watch,
       },
     };
 

--- a/src/ParseQuery.js
+++ b/src/ParseQuery.js
@@ -22,6 +22,7 @@ export type WhereClause = {
 
 export type QueryJSON = {
   where: WhereClause,
+  watch?: string,
   include?: string,
   excludeKeys?: string,
   keys?: string,
@@ -224,6 +225,7 @@ class ParseQuery {
    */
   className: string;
   _where: any;
+  _watch: Array<string>;
   _include: Array<string>;
   _exclude: Array<string>;
   _select: Array<string>;
@@ -265,6 +267,7 @@ class ParseQuery {
     }
 
     this._where = {};
+    this._watch = [];
     this._include = [];
     this._exclude = [];
     this._count = false;
@@ -426,6 +429,9 @@ class ParseQuery {
       where: this._where,
     };
 
+    if (this._watch.length) {
+      params.watch = this._watch.join(',');
+    }
     if (this._include.length) {
       params.include = this._include.join(',');
     }
@@ -493,6 +499,10 @@ class ParseQuery {
   withJSON(json: QueryJSON): ParseQuery {
     if (json.where) {
       this._where = json.where;
+    }
+
+    if (json.watch) {
+      this._watch = json.watch.split(',');
     }
 
     if (json.include) {
@@ -1916,6 +1926,25 @@ class ParseQuery {
         this._exclude = this._exclude.concat(key);
       } else {
         this._exclude.push(key);
+      }
+    });
+    return this;
+  }
+
+  /**
+   * Restricts live query to trigger only for watched fields.
+   *
+   * Requires Parse Server 6.0.0+
+   *
+   * @param {...string|Array<string>} keys The name(s) of the key(s) to watch.
+   * @returns {Parse.Query} Returns the query, so you can chain this call.
+   */
+  watch(...keys: Array<string | Array<string>>): ParseQuery {
+    keys.forEach(key => {
+      if (Array.isArray(key)) {
+        this._watch = this._watch.concat(key);
+      } else {
+        this._watch.push(key);
       }
     });
     return this;

--- a/src/__tests__/ParseQuery-test.js
+++ b/src/__tests__/ParseQuery-test.js
@@ -1078,6 +1078,32 @@ describe('ParseQuery', () => {
     expect(q2._exclude).toEqual(['foo', 'bar']);
   });
 
+  it('can watch keys', () => {
+    const q = new ParseQuery('Item');
+    q.watch('foo');
+    const json = q.toJSON();
+    expect(json).toEqual({
+      where: {},
+      watch: 'foo',
+    });
+    const q2 = new ParseQuery('Item');
+    q2.withJSON(json);
+    expect(q2._watch).toEqual(['foo']);
+  });
+
+  it('can watch multiple keys', () => {
+    const q = new ParseQuery('Item');
+    q.watch(['foo', 'bar']);
+    const json = q.toJSON();
+    expect(json).toEqual({
+      where: {},
+      watch: 'foo,bar',
+    });
+    const q2 = new ParseQuery('Item');
+    q2.withJSON(json);
+    expect(q2._watch).toEqual(['foo', 'bar']);
+  });
+
   it('can use extraOptions', () => {
     const q = new ParseQuery('Item');
     q._extraOptions.randomOption = 'test';
@@ -2334,8 +2360,7 @@ describe('ParseQuery', () => {
 
     const q = new ParseQuery('Thing');
     let testObject;
-    q
-      .find()
+    q.find()
       .then(results => {
         testObject = results[0];
 
@@ -2460,8 +2485,7 @@ describe('ParseQuery', () => {
 
     const q = new ParseQuery('Thing');
     let testObject;
-    q
-      .first()
+    q.first()
       .then(result => {
         testObject = result;
 
@@ -2875,8 +2899,7 @@ describe('ParseQuery', () => {
     const q = new ParseQuery('Thing');
     q.select('other', 'tbd', 'subObject.key1');
     let testObject;
-    q
-      .find()
+    q.find()
       .then(results => {
         testObject = results[0];
 
@@ -2926,8 +2949,7 @@ describe('ParseQuery', () => {
 
     const q = new ParseQuery('Thing');
     let testObject;
-    q
-      .find()
+    q.find()
       .then(results => {
         testObject = results[0];
 


### PR DESCRIPTION
## Pull Request

- Report security issues [confidentially](https://github.com/parse-community/Parse-SDK-JS/security/policy).
- Any contribution is under this [license](https://github.com/parse-community/Parse-SDK-JS/blob/alpha/LICENSE).
- Link this pull request to an [issue](https://github.com/parse-community/Parse-SDK-JS/issues?q=is%3Aissue).

## Issue
<!-- Add the link to the issue that this PR closes. -->
LiveQuery watch was introducted in Parse Server 6 https://github.com/parse-community/parse-server/pull/8028

Closes: https://github.com/parse-community/Parse-SDK-JS/issues/1806
