### PR TITLE
feat: Add `Parse.User.loginAs`

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -42,6 +42,7 @@
     "jsdoc/require-param-description": 0,
     "jsdoc/require-property-description": 0,
     "jsdoc/require-param-type": 0,
+    "jsdoc/tag-lines": 0,
     "jsdoc/check-param-names": [
       "error",
       {


### PR DESCRIPTION
## Pull Request

- Report security issues [confidentially](https://github.com/parse-community/Parse-SDK-JS/security/policy).
- Any contribution is under this [license](https://github.com/parse-community/Parse-SDK-JS/blob/alpha/LICENSE).
- Link this pull request to an [issue](https://github.com/parse-community/Parse-SDK-JS/issues?q=is%3Aissue).

## Issue
<!-- Add the link to the issue that this PR closes. -->
Later versions of Parse Server https://github.com/parse-community/parse-server/pull/7406. Given a userId and the master key, one can become logged in as the user associated to the userId provided. This PR adds the PHP Parse SDK method to call the Parse Server endpoint.

- [x] Add tests
- [x] Add changes to documentation (guides, repository pages, code comments)
