### PR TITLE
fix: Hard-coding of `react-native` path does not work for workspace builds

### DIFF
--- a/src/EventEmitter.js
+++ b/src/EventEmitter.js
@@ -3,7 +3,7 @@
  */
 
 if (process.env.PARSE_BUILD === 'react-native') {
-  let EventEmitter = require('../../../react-native/Libraries/vendor/emitter/EventEmitter');
+  let EventEmitter = require('react-native/Libraries/vendor/emitter/EventEmitter');
   if (EventEmitter.default) {
     EventEmitter = EventEmitter.default;
   }

--- a/src/__tests__/react-native-test.js
+++ b/src/__tests__/react-native-test.js
@@ -10,7 +10,7 @@ jest.dontMock('../ParseObject');
 jest.dontMock('../Storage');
 
 jest.mock(
-  '../../../../react-native/Libraries/vendor/emitter/EventEmitter',
+  'react-native/Libraries/vendor/emitter/EventEmitter',
   () => {
     return {
       default: {
@@ -23,8 +23,7 @@ jest.mock(
   { virtual: true }
 );
 
-const mockEmitter = require('../../../../react-native/Libraries/vendor/emitter/EventEmitter')
-  .default;
+const mockEmitter = require('react-native/Libraries/vendor/emitter/EventEmitter').default;
 const CoreManager = require('../CoreManager');
 
 describe('React Native', () => {


### PR DESCRIPTION
## Pull Request

- Report security issues [confidentially](https://github.com/parse-community/Parse-SDK-JS/security/policy).
- Any contribution is under this [license](https://github.com/parse-community/Parse-SDK-JS/blob/alpha/LICENSE).
- Link this pull request to an [issue](https://github.com/parse-community/Parse-SDK-JS/issues?q=is%3Aissue).

## Issue
<!-- Add the link to the issue that this PR closes. -->

This hard-coding of `../../../react-native/...` prevents the package from working in workspace builds.

Closes: None.  But the build fails when you use `parse/react-native` when using PNPM workspaces.

## Approach
<!-- Describe the changes in this PR. -->
Change import path from the legacy, hard-coded `require('../../../react-native/...')` to `require('react-native/...')`

## Tasks
<!-- Delete tasks that don't apply. -->
