### PR TITLE
feat: Add support to invoke a Cloud Function with a custom `installationId` via `Parse.Cloud.run`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -45402,7 +45402,7 @@
       "version": "git+ssh://git@github.com/parse-community/parse-server.git#c78a5a6f10ce09032579fed8ef4cbd84c1ee96a9",
       "integrity": "sha512-C6E8mkVW5IUtliqfH+StD0K6ycJJH7GVbmwj0zou9crKfKNP4iiLwBGklnMM9yBmfKpj2fMGztXFDju5HZ3irw==",
       "dev": true,
-      "from": "parse-server@git+https://github.com/parse-community/parse-server#c78a5a6f10ce09032579fed8ef4cbd84c1ee96a9",
+      "from": "parse-server@git+https://github.com/parse-community/parse-server#alpha",
       "requires": {
         "@babel/eslint-parser": "7.19.1",
         "@graphql-tools/merge": "8.3.6",

--- a/src/Cloud.js
+++ b/src/Cloud.js
@@ -47,6 +47,9 @@ export function run(name: string, data: mixed, options: RequestOptions): Promise
   if (options.sessionToken) {
     requestOptions.sessionToken = options.sessionToken;
   }
+  if (options.installationId) {
+    requestOptions.installationId = options.installationId;
+  }
   if (options.context && typeof options.context === 'object') {
     requestOptions.context = options.context;
   }

--- a/src/__tests__/Cloud-test.js
+++ b/src/__tests__/Cloud-test.js
@@ -80,6 +80,15 @@ describe('Cloud', () => {
     ]);
   });
 
+  it('run passes installationId option', () => {
+    Cloud.run('myfunction', {}, { installationId: 'asdf1234' });
+    expect(CoreManager.getCloudController().run.mock.calls[0]).toEqual([
+      'myfunction',
+      {},
+      { installationId: 'asdf1234' },
+    ]);
+  });
+
   it('startJob throws with an invalid job name', () => {
     expect(Cloud.startJob).toThrow('Cloud job name must be a string.');
 


### PR DESCRIPTION
## Pull Request

- Report security issues [confidentially](https://github.com/parse-community/Parse-SDK-JS/security/policy).
- Any contribution is under this [license](https://github.com/parse-community/Parse-SDK-JS/blob/alpha/LICENSE).
- Link this pull request to an [issue](https://github.com/parse-community/Parse-SDK-JS/issues?q=is%3Aissue).

## Issue
<!-- Add the link to the issue that this PR closes. -->

Closes: #1938 

## Approach
<!-- Describe the changes in this PR. -->

Pass `installationId` in Cloud Function request.

