### PR TITLE
test: Fix failing Twitter auth tests due to invalid token

### DIFF
--- a/integration/test/ParseUserTest.js
+++ b/integration/test/ParseUserTest.js
@@ -986,7 +986,7 @@ describe('Parse User', () => {
     expect(Parse.AnonymousUtils.isLinked(user)).toBe(true);
   });
 
-  it('can link with twitter', async () => {
+  fit('can link with twitter', async () => {
     Parse.User.enableUnsafeCurrentUser();
     const user = new Parse.User();
     user.setUsername(uuidv4());
@@ -1001,7 +1001,7 @@ describe('Parse User', () => {
     expect(user._isLinked('twitter')).toBe(false);
   });
 
-  it('can link with twitter and facebook', async () => {
+  fit('can link with twitter and facebook', async () => {
     Parse.User.enableUnsafeCurrentUser();
     Parse.FacebookUtils.init();
     const user = new Parse.User();

--- a/integration/test/helper.js
+++ b/integration/test/helper.js
@@ -31,8 +31,11 @@ let didChangeConfiguration = false;
   [1] https://developer.twitter.com/en/docs/authentication/oauth-1-0a/obtaining-user-access-tokens
 */
 const twitterAuthData = {
+  id: '1506726799266430985',
   consumer_key: 'jYA34RcTrIhSEFLSJRAbQE0bO',
   consumer_secret: '0wFg9LXI2lC9iJZWV3GvKnoNQHlXx2BBTFXzHsci1yu0Nfpc3L',
+  auth_token: 'l9jSEgAAAAABoGoNAAABiKflo3I',
+  auth_token_secret: '1salpD6K0Vdn0RjDv2VD2EuoGuy4Ujqt',
 };
 
 const defaultConfiguration = {

--- a/integration/test/helper.js
+++ b/integration/test/helper.js
@@ -32,10 +32,8 @@ let didChangeConfiguration = false;
 */
 const twitterAuthData = {
   id: '1506726799266430985',
-  consumer_key: 'jeQw6luN2PEWREtoFDb0FdGYf',
-  consumer_secret: 'VSFENh1X5UC4MLEuduHLtJDnf8Ydsh5KuSR4zZQufFCAGNtzcs',
-  auth_token: '1506726799266430985-NKM9tqVbPXMnLhHTLYB98SNGtxxi6v',
-  auth_token_secret: 'JpDVIINbqV5TK0th9nKiS1IVokZfjRj06FrXxCrkggF07',
+  consumer_key: 'DZcqOwKVKLHqyZEFnRpGBx1QP',
+  consumer_secret: '09q5nvb1VnX5eeRxd65FLW6WTwVyWcEgot7GdFP9lvsBup3hv6',
 };
 
 const defaultConfiguration = {

--- a/integration/test/helper.js
+++ b/integration/test/helper.js
@@ -31,11 +31,11 @@ let didChangeConfiguration = false;
   [1] https://developer.twitter.com/en/docs/authentication/oauth-1-0a/obtaining-user-access-tokens
 */
 const twitterAuthData = {
-  id: '1506726799266430985',
+  id: '27290305',
   consumer_key: 'jYA34RcTrIhSEFLSJRAbQE0bO',
   consumer_secret: '0wFg9LXI2lC9iJZWV3GvKnoNQHlXx2BBTFXzHsci1yu0Nfpc3L',
-  auth_token: 'l9jSEgAAAAABoGoNAAABiKflo3I',
-  auth_token_secret: '1salpD6K0Vdn0RjDv2VD2EuoGuy4Ujqt',
+  auth_token: '1506726799266430985-OLCIZMkMpWGWhfDngyvUteouCNxEPk',
+  auth_token_secret: 'zeAGCuuEtlJH2HHgTOg5sUDMLsZfCPcQ63t5OarwLPMaB',
 };
 
 const defaultConfiguration = {

--- a/integration/test/helper.js
+++ b/integration/test/helper.js
@@ -31,9 +31,8 @@ let didChangeConfiguration = false;
   [1] https://developer.twitter.com/en/docs/authentication/oauth-1-0a/obtaining-user-access-tokens
 */
 const twitterAuthData = {
-  id: '1506726799266430985',
-  consumer_key: 'DZcqOwKVKLHqyZEFnRpGBx1QP',
-  consumer_secret: '09q5nvb1VnX5eeRxd65FLW6WTwVyWcEgot7GdFP9lvsBup3hv6',
+  consumer_key: 'jYA34RcTrIhSEFLSJRAbQE0bO',
+  consumer_secret: '0wFg9LXI2lC9iJZWV3GvKnoNQHlXx2BBTFXzHsci1yu0Nfpc3L',
 };
 
 const defaultConfiguration = {


### PR DESCRIPTION
## Pull Request

- Report security issues [confidentially](https://github.com/parse-community/Parse-SDK-JS/security/policy).
- Any contribution is under this [license](https://github.com/parse-community/Parse-SDK-JS/blob/alpha/LICENSE).
- Link this pull request to an [issue](https://github.com/parse-community/Parse-SDK-JS/issues?q=is%3Aissue).

## Issue
<!-- Add the link to the issue that this PR closes. -->

Closes: #1917 

## Approach

Renew Twitter test app tokens; this works but is not a good solution because it exposes the Twitter test app tokens to the public.

