### PR TITLE
feat: Login with username, password and additional authentication data via `ParseUser.logInWithAdditionalAuth`

### DIFF
--- a/src/ParseUser.js
+++ b/src/ParseUser.js
@@ -654,6 +654,34 @@ class ParseUser extends ParseObject {
   }
 
   /**
+   * Logs in a user with a username (or email) and password, and authData. On success, this
+   * saves the session to disk, so you can retrieve the currently logged in
+   * user using <code>current</code>.
+   *
+   * @param {string} username The username (or email) to log in with.
+   * @param {string} password The password to log in with.
+   * @param {object} authData The authData to log in with.
+   * @param {object} options
+   * @static
+   * @returns {Promise} A promise that is fulfilled with the user when
+   *     the login completes.
+   */
+   static logInWithAdditionalAuth(username: string, password: string, authData: AuthData, options?: FullOptions) {
+    if (typeof username !== 'string') {
+      return Promise.reject(new ParseError(ParseError.OTHER_CAUSE, 'Username must be a string.'));
+    }
+    if (typeof password !== 'string') {
+      return Promise.reject(new ParseError(ParseError.OTHER_CAUSE, 'Password must be a string.'));
+    }
+    if (Object.prototype.toString.call(auth) !== '[object Object]') {
+      return Promise.reject(new ParseError(ParseError.OTHER_CAUSE, 'Auth must be an object.'));
+    }
+    const user = new this();
+    user._finishFetch({ username: username, password: password, authData: auth });
+    return user.logIn(options);
+  }
+
+  /**
    * Logs in a user with an objectId. On success, this saves the session
    * to disk, so you can retrieve the currently logged in user using
    * <code>current</code>.
@@ -1098,6 +1126,7 @@ const DefaultController = {
     const auth = {
       username: user.get('username'),
       password: user.get('password'),
+      authData: user.get('authData'),
     };
     return RESTController.request(options.usePost ? 'POST' : 'GET', 'login', auth, options).then(
       response => {

--- a/src/ParseUser.js
+++ b/src/ParseUser.js
@@ -666,18 +666,18 @@ class ParseUser extends ParseObject {
    * @returns {Promise} A promise that is fulfilled with the user when
    *     the login completes.
    */
-   static logInWithAdditionalAuth(username: string, password: string, authData: AuthData, options?: FullOptions) {
+  static logInWithAdditionalAuth(username: string, password: string, authData: AuthData, options?: FullOptions) {
     if (typeof username !== 'string') {
       return Promise.reject(new ParseError(ParseError.OTHER_CAUSE, 'Username must be a string.'));
     }
     if (typeof password !== 'string') {
       return Promise.reject(new ParseError(ParseError.OTHER_CAUSE, 'Password must be a string.'));
     }
-    if (Object.prototype.toString.call(auth) !== '[object Object]') {
+    if (Object.prototype.toString.call(authData) !== '[object Object]') {
       return Promise.reject(new ParseError(ParseError.OTHER_CAUSE, 'Auth must be an object.'));
     }
     const user = new this();
-    user._finishFetch({ username: username, password: password, authData: auth });
+    user._finishFetch({ username: username, password: password, authData });
     return user.logIn(options);
   }
 


### PR DESCRIPTION
## Pull Request

- Report security issues [confidentially](https://github.com/parse-community/Parse-SDK-JS/security/policy).
- Any contribution is under this [license](https://github.com/parse-community/Parse-SDK-JS/blob/alpha/LICENSE).
- Link this pull request to an [issue](https://github.com/parse-community/Parse-SDK-JS/issues?q=is%3Aissue).

## Issue
<!-- Add the link to the issue that this PR closes. -->

It's not currently possible to login with additional auth data

Closes: #1807

## Approach
<!-- Describe the changes in this PR. -->

Creates method `logInWithAdditionalAuth`

## Tasks
<!-- Delete tasks that don't apply. -->

- [x] Add tests
- [ ] Add changes to documentation (guides, repository pages, code comments)
