### PR TITLE
feat: Add support for custom EventEmitter

### DIFF
--- a/src/CoreManager.js
+++ b/src/CoreManager.js
@@ -216,6 +216,13 @@ const CoreManager = {
     config[key] = value;
   },
 
+  setIfNeeded: function (key: string, value: any): any {
+    if (!config.hasOwnProperty(key)) {
+      config[key] = value;
+    }
+    return config[key];
+  },
+
   /* Specialized Controller Setters/Getters */
 
   setAnalyticsController(controller: AnalyticsController) {
@@ -254,6 +261,14 @@ const CoreManager = {
     return config['CryptoController'];
   },
 
+  setEventEmitter(eventEmitter: any) {
+    config['EventEmitter'] = eventEmitter;
+  },
+
+  getEventEmitter(): any {
+    return config['EventEmitter'];
+  },
+
   setFileController(controller: FileController) {
     requireMethods('FileController', ['saveFile', 'saveBase64'], controller);
     config['FileController'] = controller;
@@ -270,6 +285,14 @@ const CoreManager = {
 
   getInstallationController(): InstallationController {
     return config['InstallationController'];
+  },
+
+  setLiveQuery(liveQuery: any) {
+    config['LiveQuery'] = liveQuery;
+  },
+
+  getLiveQuery(): any {
+    return config['LiveQuery'];
   },
 
   setObjectController(controller: ObjectController) {

--- a/src/EventEmitter.js
+++ b/src/EventEmitter.js
@@ -6,7 +6,7 @@ let EventEmitter;
 
 try {
   if (process.env.PARSE_BUILD === 'react-native') {
-    let EventEmitter = require('react-native/Libraries/vendor/emitter/EventEmitter');
+    EventEmitter = require('react-native/Libraries/vendor/emitter/EventEmitter');
     if (EventEmitter.default) {
       EventEmitter = EventEmitter.default;
     }
@@ -15,7 +15,6 @@ try {
     EventEmitter = require('events').EventEmitter;
   }
 } catch (_) {
-  // Event emitter not available
+  // EventEmitter unavailable
 }
-
 module.exports = EventEmitter;

--- a/src/EventEmitter.js
+++ b/src/EventEmitter.js
@@ -2,13 +2,20 @@
  * This is a simple wrapper to unify EventEmitter implementations across platforms.
  */
 
-if (process.env.PARSE_BUILD === 'react-native') {
-  let EventEmitter = require('react-native/Libraries/vendor/emitter/EventEmitter');
-  if (EventEmitter.default) {
-    EventEmitter = EventEmitter.default;
+let EventEmitter;
+
+try {
+  if (process.env.PARSE_BUILD === 'react-native') {
+    let EventEmitter = require('react-native/Libraries/vendor/emitter/EventEmitter');
+    if (EventEmitter.default) {
+      EventEmitter = EventEmitter.default;
+    }
+    EventEmitter.prototype.on = EventEmitter.prototype.addListener;
+  } else {
+    EventEmitter = require('events').EventEmitter;
   }
-  EventEmitter.prototype.on = EventEmitter.prototype.addListener;
-  module.exports = EventEmitter;
-} else {
-  module.exports = require('events').EventEmitter;
+} catch (_) {
+  // Event emitter not available
 }
+
+module.exports = EventEmitter;

--- a/src/LiveQueryClient.js
+++ b/src/LiveQueryClient.js
@@ -1,7 +1,6 @@
 /* global WebSocket */
 
 import CoreManager from './CoreManager';
-import EventEmitter from './EventEmitter';
 import ParseObject from './ParseObject';
 import LiveQuerySubscription from './LiveQuerySubscription';
 import { resolvingPromise } from './promiseUtils';
@@ -63,7 +62,6 @@ const generateInterval = k => {
 
 /**
  * Creates a new LiveQueryClient.
- * Extends events.EventEmitter
  * <a href="https://nodejs.org/api/events.html#events_class_eventemitter">cloud functions</a>.
  *
  * A wrapper of a standard WebSocket client. We add several useful methods to
@@ -105,7 +103,7 @@ const generateInterval = k => {
  *
  * @alias Parse.LiveQueryClient
  */
-class LiveQueryClient extends EventEmitter {
+class LiveQueryClient {
   attempts: number;
   id: number;
   requestId: number;
@@ -138,8 +136,6 @@ class LiveQueryClient extends EventEmitter {
     sessionToken,
     installationId,
   }) {
-    super();
-
     if (!serverURL || serverURL.indexOf('ws') !== 0) {
       throw new Error(
         'You need to set a proper Parse LiveQuery server url before using LiveQueryClient'
@@ -160,7 +156,11 @@ class LiveQueryClient extends EventEmitter {
     this.connectPromise = resolvingPromise();
     this.subscriptions = new Map();
     this.state = CLIENT_STATE.INITIALIZED;
+    const EventEmitter = CoreManager.getEventEmitter();
+    this.emitter = new EventEmitter();
 
+    this.on = this.emitter.on;
+    this.emit = this.emitter.emit;
     // adding listener so process does not crash
     // best practice is for developer to register their own listener
     this.on('error', () => {});

--- a/src/LiveQuerySubscription.js
+++ b/src/LiveQuerySubscription.js
@@ -1,10 +1,8 @@
-import EventEmitter from './EventEmitter';
 import CoreManager from './CoreManager';
 import { resolvingPromise } from './promiseUtils';
 
 /**
  * Creates a new LiveQuery Subscription.
- * Extends events.EventEmitter
  * <a href="https://nodejs.org/api/events.html#events_class_eventemitter">cloud functions</a>.
  *
  * <p>Response Object - Contains data from the client that made the request
@@ -84,24 +82,25 @@ import { resolvingPromise } from './promiseUtils';
  * subscription.on('close', () => {
  *
  * });</pre></p>
- *
- * @alias Parse.LiveQuerySubscription
  */
-class Subscription extends EventEmitter {
+class Subscription {
   /*
    * @param {string} id - subscription id
    * @param {string} query - query to subscribe to
    * @param {string} sessionToken - optional session token
    */
   constructor(id, query, sessionToken) {
-    super();
     this.id = id;
     this.query = query;
     this.sessionToken = sessionToken;
     this.subscribePromise = resolvingPromise();
     this.unsubscribePromise = resolvingPromise();
     this.subscribed = false;
+    const EventEmitter = CoreManager.getEventEmitter();
+    this.emitter = new EventEmitter();
 
+    this.on = this.emitter.on;
+    this.emit = this.emitter.emit;
     // adding listener so process does not crash
     // best practice is for developer to register their own listener
     this.on('error', () => {});

--- a/src/Parse.ts
+++ b/src/Parse.ts
@@ -11,6 +11,7 @@ import AnonymousUtils from './AnonymousUtils'
 import * as Cloud from './Cloud';
 import CLP from './ParseCLP';
 import CoreManager from './CoreManager';
+import EventEmitter from './EventEmitter';
 import Config from './ParseConfig'
 import ParseError from './ParseError'
 import FacebookUtils from './FacebookUtils'
@@ -76,7 +77,7 @@ interface ParseType {
   Session: typeof Session,
   Storage: typeof Storage,
   User: typeof User,
-  LiveQuery: typeof LiveQuery,
+  LiveQuery?: typeof LiveQuery,
   LiveQueryClient: typeof LiveQueryClient,
 
   initialize(applicationId: string, javaScriptKey: string): void,
@@ -143,12 +144,11 @@ const Parse: ParseType = {
   Session:  Session,
   Storage:  Storage,
   User:  User,
-  LiveQuery:  LiveQuery,
   LiveQueryClient:  LiveQueryClient,
+  LiveQuery:  undefined,
   IndexedDB: undefined,
   Hooks: undefined,
   Parse: undefined,
-
 
   /**
    * Call this method first to set up your authentication tokens for Parse.
@@ -179,6 +179,10 @@ const Parse: ParseType = {
     CoreManager.set('JAVASCRIPT_KEY', javaScriptKey);
     CoreManager.set('MASTER_KEY', masterKey);
     CoreManager.set('USE_MASTER_KEY', false);
+    CoreManager.setIfNeeded('EventEmitter', EventEmitter);
+
+    Parse.LiveQuery = new LiveQuery();
+    CoreManager.setIfNeeded('LiveQuery', Parse.LiveQuery);
   },
 
   /**
@@ -422,7 +426,6 @@ const Parse: ParseType = {
   isEncryptedUserEnabled () {
     return this.encryptedUser;
   },
-
 };
 
 if (process.env.PARSE_BUILD === 'browser') {

--- a/src/__tests__/LiveQueryClient-test.js
+++ b/src/__tests__/LiveQueryClient-test.js
@@ -35,6 +35,7 @@ const mockLocalDatastore = {
 jest.setMock('../LocalDatastore', mockLocalDatastore);
 
 const CoreManager = require('../CoreManager');
+const EventEmitter = require('../EventEmitter');
 const LiveQueryClient = require('../LiveQueryClient').default;
 const ParseObject = require('../ParseObject').default;
 const ParseQuery = require('../ParseQuery').default;
@@ -46,6 +47,7 @@ CoreManager.setLocalDatastore(mockLocalDatastore);
 describe('LiveQueryClient', () => {
   beforeEach(() => {
     mockLocalDatastore.isEnabled = false;
+    CoreManager.setEventEmitter(EventEmitter);
   });
 
   it('serverURL required', () => {

--- a/src/__tests__/ParseLiveQuery-test.js
+++ b/src/__tests__/ParseLiveQuery-test.js
@@ -9,18 +9,22 @@ jest.dontMock('../EventEmitter');
 jest.dontMock('../promiseUtils');
 
 // Forces the loading
-const LiveQuery = require('../ParseLiveQuery').default;
+const ParseLiveQuery = require('../ParseLiveQuery').default;
 const CoreManager = require('../CoreManager');
+const EventEmitter = require('../EventEmitter');
 const ParseQuery = require('../ParseQuery').default;
 const LiveQuerySubscription = require('../LiveQuerySubscription').default;
 const mockLiveQueryClient = {
   open: jest.fn(),
   close: jest.fn(),
 };
+CoreManager.setEventEmitter(EventEmitter);
+const LiveQuery = new ParseLiveQuery()
 
 describe('ParseLiveQuery', () => {
   beforeEach(() => {
     const controller = CoreManager.getLiveQueryController();
+    CoreManager.setLiveQuery(LiveQuery);
     controller._clearCachedDefaultClient();
     CoreManager.set('InstallationController', {
       currentInstallationId() {

--- a/src/__tests__/ParseQuery-test.js
+++ b/src/__tests__/ParseQuery-test.js
@@ -1,6 +1,7 @@
 jest.dontMock('../CoreManager');
 jest.dontMock('../encode');
 jest.dontMock('../decode');
+jest.dontMock('../EventEmitter');
 jest.dontMock('../ParseError');
 jest.dontMock('../ParseGeoPoint');
 jest.dontMock('../ParseQuery');
@@ -40,6 +41,7 @@ const mockLocalDatastore = {
 jest.setMock('../LocalDatastore', mockLocalDatastore);
 
 let CoreManager = require('../CoreManager');
+const EventEmitter = require('../EventEmitter');
 const ParseError = require('../ParseError').default;
 const ParseGeoPoint = require('../ParseGeoPoint').default;
 let ParseObject = require('../ParseObject');
@@ -52,6 +54,7 @@ const MockRESTController = {
 };
 
 const QueryController = CoreManager.getQueryController();
+CoreManager.setEventEmitter(EventEmitter);
 
 import { DEFAULT_PIN } from '../LocalDatastoreUtils';
 


### PR DESCRIPTION
## Pull Request

- Report security issues [confidentially](https://github.com/parse-community/Parse-SDK-JS/security/policy).
- Any contribution is under this [license](https://github.com/parse-community/Parse-SDK-JS/blob/alpha/LICENSE).
- Link this pull request to an [issue](https://github.com/parse-community/Parse-SDK-JS/issues?q=is%3Aissue).

## Issue
<!-- Add the link to the issue that this PR closes. -->
A lot of JS frameworks that uses Parse throws errors when trying to use event emitter.

```
 Uncaught TypeError: Super expression must either be null or a function
    _inherits Babel
    Subscription LiveQuerySubscription.js:149
```
Closes: https://github.com/parse-community/Parse-SDK-JS/issues/1412

## Approach
<!-- Describe the changes in this PR. -->
```
Parse.CoreManager.setEventEmitter(MY_EMITTER_CLASS);
Parse.initialize(...)
```
* Decouple EventEmitter from LiveQuery classes
* Decouple LiveQuery from LiveQueryClient
* Run test suite against react-native 
* Prevent overriding the custom event emitter

## Alternative
We could write our own EventEmitter in vanilla instead of `node:events` and polyfilling

## Tasks
<!-- Delete tasks that don't apply. -->

- [x] Add tests
- [x] Add changes to documentation (guides, repository pages, code comments)
