### PR TITLE
feat: Add support for excluding keys in `ParseQuery.findAll`

### DIFF
--- a/integration/test/ParseQueryTest.js
+++ b/integration/test/ParseQueryTest.js
@@ -1621,6 +1621,23 @@ describe('Parse Query', () => {
     assert.equal(result.get('slice'), 'pizza');
   });
 
+  it('can exclude keys in findAll', async () => {
+    const object = new TestObject({
+      hello: 'world',
+      foo: 'bar',
+      slice: 'pizza',
+    });
+    await object.save();
+
+    const query = new Parse.Query(TestObject);
+    query.exclude('foo');
+    query.equalTo('objectId', object.id);
+    const [result] = await query.findAll();
+    assert.equal(result.get('foo'), undefined);
+    assert.equal(result.get('hello'), 'world');
+    assert.equal(result.get('slice'), 'pizza');
+  });
+
   it('uses subclasses when creating objects', done => {
     const ParentObject = Parse.Object.extend({ className: 'ParentObject' });
     let ChildObject = Parse.Object.extend('ChildObject', {

--- a/src/ParseQuery.js
+++ b/src/ParseQuery.js
@@ -948,13 +948,10 @@ class ParseQuery {
 
     const query = new ParseQuery(this.className);
     query._limit = options.batchSize || 100;
-    query._include = this._include.map(i => {
-      return i;
-    });
+    query._include = [...this._include];
+    query._exclude = [...this._exclude];
     if (this._select) {
-      query._select = this._select.map(s => {
-        return s;
-      });
+      query._select = [...this._select];
     }
     query._hint = this._hint;
     query._where = {};

--- a/src/__tests__/ParseQuery-test.js
+++ b/src/__tests__/ParseQuery-test.js
@@ -1814,6 +1814,7 @@ describe('ParseQuery', () => {
       q.select('size', 'name');
       q.includeAll();
       q.hint('_id_');
+      q.exclude('foo')
 
       await q.findAll();
       expect(findMock).toHaveBeenCalledTimes(1);
@@ -1824,6 +1825,7 @@ describe('ParseQuery', () => {
         order: 'objectId',
         keys: 'size,name',
         include: '*',
+        excludeKeys: 'foo',
         hint: '_id_',
         where: {
           size: {


### PR DESCRIPTION
## Pull Request

- Report security issues [confidentially](https://github.com/parse-community/Parse-SDK-JS/security/policy).
- Any contribution is under this [license](https://github.com/parse-community/Parse-SDK-JS/blob/alpha/LICENSE).
- Link this pull request to an [issue](https://github.com/parse-community/Parse-SDK-JS/issues?q=is%3Aissue).

## Issue
<!-- Add the link to the issue that this PR closes. -->
Thanks @sadortun!

Closes: https://github.com/parse-community/Parse-SDK-JS/issues/1990

- [x] Add tests
- [x] Add changes to documentation (guides, repository pages, code comments)
