### PR TITLE
feat: Add Bytes type to `Parse.Schema`

### DIFF
--- a/integration/test/ParseSchemaTest.js
+++ b/integration/test/ParseSchemaTest.js
@@ -72,6 +72,7 @@ describe('Schema', () => {
       .addString('stringField')
       .addNumber('numberField')
       .addBoolean('booleanField')
+      .addBytes('bytesField')
       .addDate('dateField')
       .addFile('fileField')
       .addGeoPoint('geoPointField')
@@ -91,6 +92,7 @@ describe('Schema', () => {
         assert.equal(result.fields.stringField.type, 'String');
         assert.equal(result.fields.numberField.type, 'Number');
         assert.equal(result.fields.booleanField.type, 'Boolean');
+        assert.equal(result.fields.bytesField.type, 'Bytes');
         assert.equal(result.fields.dateField.type, 'Date');
         assert.equal(result.fields.fileField.type, 'File');
         assert.equal(result.fields.geoPointField.type, 'GeoPoint');
@@ -182,6 +184,7 @@ describe('Schema', () => {
         required: true,
         defaultValue: '2000-01-01T00:00:00.000Z',
       })
+      .addBytes('bytesField', { required: true, defaultValue: 'ParseA==' })
       .addFile('fileField', { required: true, defaultValue: file })
       .addGeoPoint('geoPointField', { required: true, defaultValue: point })
       .addPolygon('polygonField', { required: true, defaultValue: polygon })
@@ -204,6 +207,11 @@ describe('Schema', () => {
       stringField: { type: 'String', required: true, defaultValue: 'world' },
       numberField: { type: 'Number', required: true, defaultValue: 10 },
       booleanField: { type: 'Boolean', required: true, defaultValue: false },
+      bytesField: {
+        type: 'Bytes',
+        required: true,
+        defaultValue: { __type: 'Bytes', base64: 'ParseA==' },
+      },
       dateField: {
         type: 'Date',
         required: true,
@@ -245,6 +253,7 @@ describe('Schema', () => {
       stringField: 'world',
       numberField: 10,
       booleanField: false,
+      bytesField: { __type: 'Bytes', base64: 'ParseA==' },
       dateField: { __type: 'Date', iso: '2000-01-01T00:00:00.000Z' },
       dateStringField: { __type: 'Date', iso: '2000-01-01T00:00:00.000Z' },
       fileField: file.toJSON(),

--- a/src/ParseSchema.js
+++ b/src/ParseSchema.js
@@ -12,6 +12,7 @@ const FIELD_TYPES = [
   'String',
   'Number',
   'Boolean',
+  'Bytes',
   'Date',
   'File',
   'GeoPoint',
@@ -242,6 +243,14 @@ class ParseSchema {
         };
       }
     }
+    if (type === 'Bytes') {
+      if (options && options.defaultValue) {
+        fieldOptions.defaultValue = {
+          __type: 'Bytes',
+          base64: options.defaultValue,
+        };
+      }
+    }
     this._fields[name] = fieldOptions;
     return this;
   }
@@ -301,6 +310,17 @@ class ParseSchema {
    */
   addBoolean(name: string, options: FieldOptions) {
     return this.addField(name, 'Boolean', options);
+  }
+
+  /**
+   * Adding Bytes Field
+   *
+   * @param {string} name Name of the field that will be created on Parse
+   * @param {object} options See {@link https://parseplatform.org/Parse-SDK-JS/api/master/Parse.Schema.html#addField addField}
+   * @returns {Parse.Schema} Returns the schema, so you can chain this call.
+   */
+  addBytes(name: string, options: FieldOptions) {
+    return this.addField(name, 'Bytes', options);
   }
 
   /**

--- a/src/__tests__/ParseSchema-test.js
+++ b/src/__tests__/ParseSchema-test.js
@@ -57,6 +57,7 @@ describe('ParseSchema', () => {
       .addString('stringField')
       .addNumber('numberField')
       .addBoolean('booleanField')
+      .addBytes('bytesField')
       .addDate('dateField')
       .addFile('fileField')
       .addGeoPoint('geoPointField')
@@ -70,6 +71,7 @@ describe('ParseSchema', () => {
     expect(schema._fields.stringField.type).toEqual('String');
     expect(schema._fields.numberField.type).toEqual('Number');
     expect(schema._fields.booleanField.type).toEqual('Boolean');
+    expect(schema._fields.bytesField.type).toEqual('Bytes');
     expect(schema._fields.dateField.type).toEqual('Date');
     expect(schema._fields.fileField.type).toEqual('File');
     expect(schema._fields.geoPointField.type).toEqual('GeoPoint');
@@ -103,6 +105,10 @@ describe('ParseSchema', () => {
         required: true,
         defaultValue: 'hello',
       })
+      .addBytes('bytesField', {
+        required: true,
+        defaultValue: 'ParseA==',
+      })
       .addDate('dateField', {
         required: true,
         defaultValue: '2000-01-01T00:00:00.000Z',
@@ -129,6 +135,14 @@ describe('ParseSchema', () => {
       defaultValue: {
         __type: 'Date',
         iso: new Date('2000-01-01T00:00:00.000Z'),
+      },
+    });
+    expect(schema._fields.bytesField).toEqual({
+      type: 'Bytes',
+      required: true,
+      defaultValue: {
+        __type: 'Bytes',
+        base64: 'ParseA==',
       },
     });
   });


### PR DESCRIPTION
## Pull Request

- Report security issues [confidentially](https://github.com/parse-community/Parse-SDK-JS/security/policy).
- Any contribution is under this [license](https://github.com/parse-community/Parse-SDK-JS/blob/alpha/LICENSE).
- Link this pull request to an [issue](https://github.com/parse-community/Parse-SDK-JS/issues?q=is%3Aissue).

## Issue
<!-- Add the link to the issue that this PR closes. -->
Uncaught (in promise) Error: Bytes is not a valid type.

Closes: https://github.com/parse-community/Parse-SDK-JS/issues/1503

- [x] Add tests
- [x] Add changes to documentation (guides, repository pages, code comments)
