### PR TITLE
docs: Fix incorrect return type in `Parse.Object.getACL`

### DIFF
--- a/src/ParseObject.js
+++ b/src/ParseObject.js
@@ -1057,7 +1057,7 @@ class ParseObject {
   /**
    * Returns the ACL for this object.
    *
-   * @returns {Parse.ACL} An instance of Parse.ACL.
+   * @returns {Parse.ACL|null} An instance of Parse.ACL.
    * @see Parse.Object#get
    */
   getACL(): ?ParseACL {


### PR DESCRIPTION
## Pull Request

- Report security issues [confidentially](https://github.com/parse-community/Parse-SDK-JS/security/policy).
- Any contribution is under this [license](https://github.com/parse-community/Parse-SDK-JS/blob/alpha/LICENSE).
- Link this pull request to an [issue](https://github.com/parse-community/Parse-SDK-JS/issues?q=is%3Aissue).

## Issue
<!-- Add the link to the issue that this PR closes. -->
Fixing `getACL` type to match PHP SDK [getACL](https://github.com/parse-community/parse-php-sdk/blob/master/src/Parse/ParseObject.php#L1555)

Closes: https://github.com/parse-community/Parse-SDK-JS/issues/1949

I also ran into an issue testing `npm run docs`

```
FATAL: Unable to load template: Cannot find module 'taffydb'
Require stack:
- /Users/dplewis/Documents/GitHub/Parse-SDK-JS/node_modules/@parse/minami/publish.js
- /Users/dplewis/Documents/GitHub/Parse-SDK-JS/node_modules/jsdoc/cli.js
- /Users/dplewis/Documents/GitHub/Parse-SDK-JS/node_modules/jsdoc/jsdoc.js
```

## Tasks
<!-- Delete tasks that don't apply. -->

- [X] Add changes to documentation (guides, repository pages, code comments)
