### PR TITLE
fix: `ParseUser.linkWith` doesn't remove anonymous auth data

### DIFF
--- a/integration/test/ParseUserTest.js
+++ b/integration/test/ParseUserTest.js
@@ -979,11 +979,11 @@ describe('Parse User', () => {
     await Parse.FacebookUtils.link(user);
 
     expect(Parse.FacebookUtils.isLinked(user)).toBe(true);
-    expect(Parse.AnonymousUtils.isLinked(user)).toBe(true);
+    expect(Parse.AnonymousUtils.isLinked(user)).toBe(false);
     await Parse.FacebookUtils.unlink(user);
 
     expect(Parse.FacebookUtils.isLinked(user)).toBe(false);
-    expect(Parse.AnonymousUtils.isLinked(user)).toBe(true);
+    expect(Parse.AnonymousUtils.isLinked(user)).toBe(false);
   });
 
   it('can link with twitter', async () => {


### PR DESCRIPTION
## Pull Request

- Report security issues [confidentially](https://github.com/parse-community/Parse-SDK-JS/security/policy).
- Any contribution is under this [license](https://github.com/parse-community/Parse-SDK-JS/blob/alpha/LICENSE).
- Link this pull request to an [issue](https://github.com/parse-community/Parse-SDK-JS/issues?q=is%3Aissue).

## Issue
<!-- Add the link to the issue that this PR closes. -->
Calling user.linkWith() doesn't remove the "anonymous" field from the authData object field, causing Parse.AnonymousUtils to still report the user as an Anonymous user.

Closes: https://github.com/parse-community/Parse-SDK-JS/issues/1353

- [x] Add tests
- [x] Add changes to documentation (guides, repository pages, code comments)
