### PR TITLE
feat: Allow custom server connection fail message

### DIFF
--- a/integration/test/ParseServerTest.js
+++ b/integration/test/ParseServerTest.js
@@ -16,7 +16,7 @@ describe('ParseServer', () => {
     const object = new TestObject({ foo: 'bar' });
     await parseServer.handleShutdown();
     await new Promise((resolve) => parseServer.server.close(resolve));
-    await expectAsync(object.save()).toBeRejectedWithError('XMLHttpRequest failed: "Unable to connect to the Parse API"');
+    await expectAsync(object.save()).toBeRejectedWithError('The connection to the Parse servers failed.');
     await reconfigureServer({});
     await object.save();
     assert(object.id);

--- a/integration/test/ParseServerTest.js
+++ b/integration/test/ParseServerTest.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const assert = require('assert');
+const Parse = require('../../node');
 
 describe('ParseServer', () => {
   it('can reconfigure server', async () => {
@@ -19,5 +20,20 @@ describe('ParseServer', () => {
     await reconfigureServer({});
     await object.save();
     assert(object.id);
+  });
+
+  it('can shutdown with custom message', async () => {
+    const defaultMessage = Parse.CoreManager.get('CONNECTION_FAILED_MESSAGE');
+    const message = 'Server is down!';
+    Parse.CoreManager.set('CONNECTION_FAILED_MESSAGE', message);
+    const parseServer = await reconfigureServer();
+    const object = new TestObject({ foo: 'bar' });
+    await parseServer.handleShutdown();
+    await new Promise((resolve) => parseServer.server.close(resolve));
+    await expectAsync(object.save()).toBeRejectedWithError(message);
+    await reconfigureServer({});
+    await object.save();
+    assert(object.id);
+    Parse.CoreManager.set('CONNECTION_FAILED_MESSAGE', defaultMessage);
   });
 });

--- a/src/CoreManager.js
+++ b/src/CoreManager.js
@@ -177,6 +177,7 @@ const config: Config & { [key: string]: mixed } = {
     !!process.versions.node &&
     !process.versions.electron,
   REQUEST_ATTEMPT_LIMIT: 5,
+  CONNECTION_FAILED_MESSAGE: 'XMLHttpRequest failed: "Unable to connect to the Parse API"',
   REQUEST_BATCH_SIZE: 20,
   REQUEST_HEADERS: {},
   SERVER_URL: 'https://api.parse.com/1',

--- a/src/CoreManager.js
+++ b/src/CoreManager.js
@@ -177,7 +177,7 @@ const config: Config & { [key: string]: mixed } = {
     !!process.versions.node &&
     !process.versions.electron,
   REQUEST_ATTEMPT_LIMIT: 5,
-  CONNECTION_FAILED_MESSAGE: 'XMLHttpRequest failed: "Unable to connect to the Parse API"',
+  CONNECTION_FAILED_MESSAGE: 'The connection to the Parse servers failed.',
   REQUEST_BATCH_SIZE: 20,
   REQUEST_HEADERS: {},
   SERVER_URL: 'https://api.parse.com/1',

--- a/src/EventuallyQueue.js
+++ b/src/EventuallyQueue.js
@@ -275,7 +275,7 @@ const EventuallyQueue = {
         await object.save(queueObject.object, queueObject.serverOptions);
         await this.remove(queueObject.queueId);
       } catch (e) {
-        if (e.message !== 'XMLHttpRequest failed: "Unable to connect to the Parse API"') {
+        if (e.message !== CoreManager.get('CONNECTION_FAILED_MESSAGE')) {
           await this.remove(queueObject.queueId);
         }
       }
@@ -285,7 +285,7 @@ const EventuallyQueue = {
         await object.destroy(queueObject.serverOptions);
         await this.remove(queueObject.queueId);
       } catch (e) {
-        if (e.message !== 'XMLHttpRequest failed: "Unable to connect to the Parse API"') {
+        if (e.message !== CoreManager.get('CONNECTION_FAILED_MESSAGE')) {
           await this.remove(queueObject.queueId);
         }
       }

--- a/src/ParseObject.js
+++ b/src/ParseObject.js
@@ -1219,7 +1219,7 @@ class ParseObject {
     try {
       await this.save(null, options);
     } catch (e) {
-      if (e.message === 'XMLHttpRequest failed: "Unable to connect to the Parse API"') {
+      if (e.message === CoreManager.get('CONNECTION_FAILED_MESSAGE')) {
         await EventuallyQueue.save(this, options);
         EventuallyQueue.poll();
       }
@@ -1363,7 +1363,7 @@ class ParseObject {
     try {
       await this.destroy(options);
     } catch (e) {
-      if (e.message === 'XMLHttpRequest failed: "Unable to connect to the Parse API"') {
+      if (e.message === CoreManager.get('CONNECTION_FAILED_MESSAGE')) {
         await EventuallyQueue.destroy(this, options);
         EventuallyQueue.poll();
       }

--- a/src/RESTController.js
+++ b/src/RESTController.js
@@ -132,7 +132,7 @@ const RESTController = {
             const delay = Math.round(Math.random() * 125 * Math.pow(2, attempts));
             setTimeout(dispatch, delay);
           } else if (xhr.status === 0) {
-            promise.reject('Unable to connect to the Parse API');
+            promise.reject(new ParseError(ParseError.CONNECTION_FAILED, CoreManager.get('CONNECTION_FAILED_MESSAGE')));
           } else {
             // After the retry limit is reached, fail
             promise.reject(xhr);
@@ -316,10 +316,7 @@ const RESTController = {
       }
     } else {
       const message = response.message ? response.message : response;
-      error = new ParseError(
-        ParseError.CONNECTION_FAILED,
-        'XMLHttpRequest failed: ' + JSON.stringify(message)
-      );
+      error = new ParseError(ParseError.CONNECTION_FAILED, message);
     }
     return Promise.reject(error);
   },

--- a/src/__tests__/EventuallyQueue-test.js
+++ b/src/__tests__/EventuallyQueue-test.js
@@ -241,7 +241,7 @@ describe('EventuallyQueue', () => {
     jest.spyOn(object, 'destroy').mockImplementationOnce(() => {
       throw new ParseError(
         ParseError.CONNECTION_FAILED,
-        'XMLHttpRequest failed: "Unable to connect to the Parse API"'
+        'The connection to the Parse servers failed.'
       );
     });
     jest.spyOn(EventuallyQueue, 'remove').mockImplementationOnce(() => {});
@@ -332,7 +332,7 @@ describe('EventuallyQueue', () => {
     jest.spyOn(object, 'save').mockImplementationOnce(() => {
       throw new ParseError(
         ParseError.CONNECTION_FAILED,
-        'XMLHttpRequest failed: "Unable to connect to the Parse API"'
+        'The connection to the Parse servers failed.'
       );
     });
     jest.spyOn(EventuallyQueue, 'remove').mockImplementationOnce(() => {});

--- a/src/__tests__/ParseObject-test.js
+++ b/src/__tests__/ParseObject-test.js
@@ -1585,6 +1585,22 @@ describe('ParseObject', () => {
     expect(EventuallyQueue.poll).toHaveBeenCalledTimes(1);
   });
 
+  it('can save the object eventually on network failure with custom connection message', async () => {
+    const defaultMessage = CoreManager.get('CONNECTION_FAILED_MESSAGE');
+    const message = 'Server is down!';
+    CoreManager.set('CONNECTION_FAILED_MESSAGE', message);
+    const p = new ParseObject('Person');
+    jest.spyOn(EventuallyQueue, 'save').mockImplementationOnce(() => Promise.resolve());
+    jest.spyOn(EventuallyQueue, 'poll').mockImplementationOnce(() => {});
+    jest.spyOn(p, 'save').mockImplementationOnce(() => {
+      throw new ParseError(ParseError.CONNECTION_FAILED, message);
+    });
+    await p.saveEventually();
+    expect(EventuallyQueue.save).toHaveBeenCalledTimes(1);
+    expect(EventuallyQueue.poll).toHaveBeenCalledTimes(1);
+    CoreManager.set('CONNECTION_FAILED_MESSAGE', defaultMessage);
+  });
+
   it('should not save the object eventually on error', async () => {
     const p = new ParseObject('Person');
     jest.spyOn(EventuallyQueue, 'save').mockImplementationOnce(() => Promise.resolve());
@@ -2922,6 +2938,22 @@ describe('ObjectController', () => {
     await p.destroyEventually();
     expect(EventuallyQueue.destroy).toHaveBeenCalledTimes(1);
     expect(EventuallyQueue.poll).toHaveBeenCalledTimes(1);
+  });
+
+  it('can destroy the object eventually on network failure with custom connection message', async () => {
+    const defaultMessage = CoreManager.get('CONNECTION_FAILED_MESSAGE');
+    const message = 'Server is down!';
+    CoreManager.set('CONNECTION_FAILED_MESSAGE', message);
+    const p = new ParseObject('Person');
+    jest.spyOn(EventuallyQueue, 'destroy').mockImplementationOnce(() => Promise.resolve());
+    jest.spyOn(EventuallyQueue, 'poll').mockImplementationOnce(() => {});
+    jest.spyOn(p, 'destroy').mockImplementationOnce(() => {
+      throw new ParseError(ParseError.CONNECTION_FAILED, message);
+    });
+    await p.destroyEventually();
+    expect(EventuallyQueue.destroy).toHaveBeenCalledTimes(1);
+    expect(EventuallyQueue.poll).toHaveBeenCalledTimes(1);
+    CoreManager.set('CONNECTION_FAILED_MESSAGE', defaultMessage);
   });
 
   it('should not destroy object eventually on error', async () => {

--- a/src/__tests__/ParseObject-test.js
+++ b/src/__tests__/ParseObject-test.js
@@ -1577,7 +1577,7 @@ describe('ParseObject', () => {
     jest.spyOn(p, 'save').mockImplementationOnce(() => {
       throw new ParseError(
         ParseError.CONNECTION_FAILED,
-        'XMLHttpRequest failed: "Unable to connect to the Parse API"'
+        'The connection to the Parse servers failed.'
       );
     });
     await p.saveEventually();
@@ -2932,7 +2932,7 @@ describe('ObjectController', () => {
     jest.spyOn(p, 'destroy').mockImplementationOnce(() => {
       throw new ParseError(
         ParseError.CONNECTION_FAILED,
-        'XMLHttpRequest failed: "Unable to connect to the Parse API"'
+        'The connection to the Parse servers failed.'
       );
     });
     await p.destroyEventually();

--- a/src/__tests__/RESTController-test.js
+++ b/src/__tests__/RESTController-test.js
@@ -73,7 +73,7 @@ describe('RESTController', () => {
     );
     RESTController.ajax('POST', 'users', {}).then(null, err => {
       expect(err.code).toBe(100);
-      expect(err.message).toBe('XMLHttpRequest failed: "Unable to connect to the Parse API"');
+      expect(err.message).toBe('The connection to the Parse servers failed.');
       done();
     });
     jest.runAllTimers();
@@ -104,7 +104,7 @@ describe('RESTController', () => {
       null,
       err => {
         expect(err.code).toBe(100);
-        expect(err.message).toBe('XMLHttpRequest failed: "Unable to connect to the Parse API"');
+        expect(err.message).toBe('The connection to the Parse servers failed.');
       }
     );
     await flushPromises();


### PR DESCRIPTION
## Pull Request

- Report security issues [confidentially](https://github.com/parse-community/Parse-SDK-JS/security/policy).
- Any contribution is under this [license](https://github.com/parse-community/Parse-SDK-JS/blob/alpha/LICENSE).
- Link this pull request to an [issue](https://github.com/parse-community/Parse-SDK-JS/issues?q=is%3Aissue).

## Issue
<!-- Add the link to the issue that this PR closes. -->
Allows users to change the default connection failed message. Developers will be able to display more helpful messages. This is a breaking change for developers that use `Parse._ajax` which is unlikely since ajax is used internally.

Closes: https://github.com/parse-community/Parse-SDK-JS/issues/1469

## Approach
<!-- Describe the changes in this PR. -->
* Add `CONNECTION_FAILED_MESSAGE` to CoreManager
* Return `Parse.Error` in `RESTController.ajax`
* Update EventuallyQueue API to support custom messages

## Tasks
<!-- Delete tasks that don't apply. -->

- [x] Add tests
