### PR TITLE
feat: Allow overriding `Parse.Error` message with custom message via new Core Manager option `PARSE_ERRORS`

### DIFF
--- a/src/CoreManager.js
+++ b/src/CoreManager.js
@@ -194,6 +194,7 @@ const config: Config & { [key: string]: mixed } = {
   ENCRYPTED_USER: false,
   IDEMPOTENCY: false,
   ALLOW_CUSTOM_OBJECT_ID: false,
+  PARSE_ERRORS: [],
 };
 
 function requireMethods(name: string, methods: Array<string>, controller: any) {

--- a/src/EventuallyQueue.js
+++ b/src/EventuallyQueue.js
@@ -5,6 +5,7 @@
  */
 
 import CoreManager from './CoreManager';
+import ParseError from './ParseError';
 import ParseObject from './ParseObject';
 import ParseQuery from './ParseQuery';
 import Storage from './Storage';
@@ -275,7 +276,7 @@ const EventuallyQueue = {
         await object.save(queueObject.object, queueObject.serverOptions);
         await this.remove(queueObject.queueId);
       } catch (e) {
-        if (e.message !== 'XMLHttpRequest failed: "Unable to connect to the Parse API"') {
+        if (e.code !== ParseError.CONNECTION_FAILED) {
           await this.remove(queueObject.queueId);
         }
       }
@@ -285,7 +286,7 @@ const EventuallyQueue = {
         await object.destroy(queueObject.serverOptions);
         await this.remove(queueObject.queueId);
       } catch (e) {
-        if (e.message !== 'XMLHttpRequest failed: "Unable to connect to the Parse API"') {
+        if (e.code !== ParseError.CONNECTION_FAILED) {
           await this.remove(queueObject.queueId);
         }
       }

--- a/src/ParseError.js
+++ b/src/ParseError.js
@@ -3,7 +3,7 @@ import CoreManager from './CoreManager';
 /**
  * Constructs a new Parse.Error object with the given code and message.
  *
- * Parse.CoreManager.set('PARSE_ERRORS', [{ code, message }]) can be use to override error messages for error codes except CONNECTION_FAILED (100).
+ * Parse.CoreManager.set('PARSE_ERRORS', [{ code, message }]) can be use to override error messages.
  *
  * @alias Parse.Error
  */
@@ -17,7 +17,7 @@ class ParseError extends Error {
     this.code = code;
     let customMessage = message;
     CoreManager.get('PARSE_ERRORS').forEach((error) => {
-      if (error.code === code && error.code !== ParseError.CONNECTION_FAILED) {
+      if (error.code === code && error.code) {
         customMessage = error.message;
       }
     });

--- a/src/ParseError.js
+++ b/src/ParseError.js
@@ -1,5 +1,9 @@
+import CoreManager from './CoreManager';
+
 /**
  * Constructs a new Parse.Error object with the given code and message.
+ *
+ * Parse.CoreManager.set('PARSE_ERRORS', [{ code, message }]) can be use to override error messages for error codes except CONNECTION_FAILED (100).
  *
  * @alias Parse.Error
  */
@@ -11,9 +15,15 @@ class ParseError extends Error {
   constructor(code, message) {
     super(message);
     this.code = code;
+    let customMessage = message;
+    CoreManager.get('PARSE_ERRORS').forEach((error) => {
+      if (error.code === code && error.code !== ParseError.CONNECTION_FAILED) {
+        customMessage = error.message;
+      }
+    });
     Object.defineProperty(this, 'message', {
       enumerable: true,
-      value: message,
+      value: customMessage,
     });
   }
 

--- a/src/__tests__/ParseError-test.js
+++ b/src/__tests__/ParseError-test.js
@@ -30,14 +30,4 @@ describe('ParseError', () => {
     });
     CoreManager.set('PARSE_ERRORS', []);
   });
-
-  it('cannot override connection failed message', () => {
-    CoreManager.set('PARSE_ERRORS', [{ code: 100, message: 'Cannot connect to server' }]);
-    const error = new ParseError(100, 'some error message');
-    expect(JSON.parse(JSON.stringify(error))).toEqual({
-      message: 'some error message',
-      code: 100,
-    });
-    CoreManager.set('PARSE_ERRORS', []);
-  });
 });

--- a/src/__tests__/ParseError-test.js
+++ b/src/__tests__/ParseError-test.js
@@ -1,6 +1,8 @@
 jest.dontMock('../ParseError');
+jest.dontMock('../CoreManager');
 
 const ParseError = require('../ParseError').default;
+const CoreManager = require('../CoreManager');
 
 describe('ParseError', () => {
   it('have sensible string representation', () => {
@@ -17,5 +19,25 @@ describe('ParseError', () => {
       message: 'some error message',
       code: 123,
     });
+  });
+
+  it('can override message', () => {
+    CoreManager.set('PARSE_ERRORS', [{ code: 123, message: 'Oops.' }]);
+    const error = new ParseError(123, 'some error message');
+    expect(JSON.parse(JSON.stringify(error))).toEqual({
+      message: 'Oops.',
+      code: 123,
+    });
+    CoreManager.set('PARSE_ERRORS', []);
+  });
+
+  it('cannot override connection failed message', () => {
+    CoreManager.set('PARSE_ERRORS', [{ code: 100, message: 'Cannot connect to server' }]);
+    const error = new ParseError(100, 'some error message');
+    expect(JSON.parse(JSON.stringify(error))).toEqual({
+      message: 'some error message',
+      code: 100,
+    });
+    CoreManager.set('PARSE_ERRORS', []);
   });
 });


### PR DESCRIPTION
## Pull Request

- Report security issues [confidentially](https://github.com/parse-community/Parse-SDK-JS/security/policy).
- Any contribution is under this [license](https://github.com/parse-community/Parse-SDK-JS/blob/alpha/LICENSE).
- Link this pull request to an [issue](https://github.com/parse-community/Parse-SDK-JS/issues?q=is%3Aissue).

## Issue
<!-- Add the link to the issue that this PR closes. -->
Allow developers to override error messages for error codes

Closes: https://github.com/parse-community/Parse-SDK-JS/issues/1469

## Approach
<!-- Describe the changes in this PR. -->
Override error message in the `Parse.Error` constructor. Properly handle connection errors in EventuallyQueue API.

```
Parse.CoreManager.set('PARSE_ERRORS', [{ code, message }])
```

## Tasks
<!-- Delete tasks that don't apply. -->

- [x] Add tests
- [x] Add changes to documentation (guides, repository pages, code comments)
