### PR TITLE
fix: Data lost when calling `saveEventually`, `destroyEventually` with invalid session token

### DIFF
--- a/integration/test/helper.js
+++ b/integration/test/helper.js
@@ -166,7 +166,8 @@ beforeAll(async () => {
 });
 
 afterEach(async () => {
-  await Parse.User.logOut();
+  // TODO: Fix logout on invalid session token
+  await Parse.User.logOut().catch((e) => console.error(e));
   // Connection close events are not immediate on node 10+... wait a bit
   await sleep(0);
   if (Object.keys(openConnections).length > 0) {

--- a/src/ParseObject.js
+++ b/src/ParseObject.js
@@ -1219,7 +1219,7 @@ class ParseObject {
     try {
       await this.save(null, options);
     } catch (e) {
-      if (e.message === 'XMLHttpRequest failed: "Unable to connect to the Parse API"') {
+      if (e.code === ParseError.CONNECTION_FAILED) {
         await EventuallyQueue.save(this, options);
         EventuallyQueue.poll();
       }
@@ -1363,7 +1363,7 @@ class ParseObject {
     try {
       await this.destroy(options);
     } catch (e) {
-      if (e.message === 'XMLHttpRequest failed: "Unable to connect to the Parse API"') {
+      if (e.code === ParseError.CONNECTION_FAILED) {
         await EventuallyQueue.destroy(this, options);
         EventuallyQueue.poll();
       }

--- a/src/ParseUser.js
+++ b/src/ParseUser.js
@@ -4,6 +4,7 @@
 
 import CoreManager from './CoreManager';
 import isRevocableSession from './isRevocableSession';
+import EventuallyQueue from './EventuallyQueue';
 import ParseError from './ParseError';
 import ParseObject from './ParseObject';
 import ParseSession from './ParseSession';
@@ -1014,6 +1015,7 @@ const DefaultController = {
       userData = crypto.encrypt(json, CoreManager.get('ENCRYPTED_KEY'));
     }
     return Storage.setItemAsync(path, userData).then(() => {
+      EventuallyQueue.poll();
       return user;
     });
   },

--- a/src/__tests__/EventuallyQueue-test.js
+++ b/src/__tests__/EventuallyQueue-test.js
@@ -401,6 +401,13 @@ describe('EventuallyQueue', () => {
     expect(EventuallyQueue.isPolling()).toBe(true);
   });
 
+  it('can check processing status', () => {
+    const processing = EventuallyQueue.isProcessing();
+    EventuallyQueue._setProcessing(!processing);
+    expect(EventuallyQueue.isProcessing()).toBe(!processing);
+    EventuallyQueue._setProcessing(processing);
+  });
+
   it('can poll server', async () => {
     jest.spyOn(EventuallyQueue, 'sendQueue').mockImplementationOnce(() => {});
     RESTController._setXHR(mockXHR([{ status: 200, response: { status: 'ok' } }]));


### PR DESCRIPTION
## Pull Request

- Report security issues [confidentially](https://github.com/parse-community/Parse-SDK-JS/security/policy).
- Any contribution is under this [license](https://github.com/parse-community/Parse-SDK-JS/blob/alpha/LICENSE).
- Link this pull request to an [issue](https://github.com/parse-community/Parse-SDK-JS/issues?q=is%3Aissue).

## Issue
<!-- Add the link to the issue that this PR closes. -->
When sessionToken is invalid during saveEventually / destroyEventually the data is lost.

Closes: https://github.com/parse-community/Parse-SDK-JS/issues/2008

## Approach
<!-- Describe the changes in this PR. -->
* Keep data local on invalid sessionToken
* Retry eventually queue when the user changes

## Tasks
<!-- Delete tasks that don't apply. -->

- [x] Add tests
