### PR TITLE
fix: Connection failure in `Parse.Object.saveEventually` and `Parse.Object.destroyEventually` not handled on custom `Parse.Error.CONNECTION_FAILURE` message

### DIFF
--- a/src/ParseObject.js
+++ b/src/ParseObject.js
@@ -1219,7 +1219,7 @@ class ParseObject {
     try {
       await this.save(null, options);
     } catch (e) {
-      if (e.message === 'XMLHttpRequest failed: "Unable to connect to the Parse API"') {
+      if (e.code === ParseError.CONNECTION_FAILED) {
         await EventuallyQueue.save(this, options);
         EventuallyQueue.poll();
       }
@@ -1363,7 +1363,7 @@ class ParseObject {
     try {
       await this.destroy(options);
     } catch (e) {
-      if (e.message === 'XMLHttpRequest failed: "Unable to connect to the Parse API"') {
+      if (e.code === ParseError.CONNECTION_FAILED) {
         await EventuallyQueue.destroy(this, options);
         EventuallyQueue.poll();
       }


### PR DESCRIPTION
## Pull Request

- Report security issues [confidentially](https://github.com/parse-community/Parse-SDK-JS/security/policy).
- Any contribution is under this [license](https://github.com/parse-community/Parse-SDK-JS/blob/alpha/LICENSE).
- Link this pull request to an [issue](https://github.com/parse-community/Parse-SDK-JS/issues?q=is%3Aissue).

## Issue
<!-- Add the link to the issue that this PR closes. -->
Use error codes instead of hard coded messages for connection failures. With the addition of custom Error messages, changing the default connection failure message would cause an error.

Related: https://github.com/parse-community/Parse-SDK-JS/pull/2014

## Tasks
<!-- Delete tasks that don't apply. -->

- [x] Add tests
- [x] Add changes to documentation (guides, repository pages, code comments)
