### PR TITLE
docs: Generate API documentation for release branch

### DIFF
--- a/release_docs.sh
+++ b/release_docs.sh
@@ -1,5 +1,7 @@
 #!/bin/sh -e
 set -x
+# GITHUB_ACTIONS=true SOURCE_TAG=test ./release_docs.sh
+
 if [ "${GITHUB_ACTIONS}" = "" ];
 then
   echo "Cannot release docs without GITHUB_ACTIONS set"

--- a/release_docs.sh
+++ b/release_docs.sh
@@ -5,6 +5,11 @@ then
   echo "Cannot release docs without GITHUB_ACTIONS set"
   exit 0;
 fi
+if [ "${SOURCE_TAG}" = "" ];
+then
+  echo "Cannot release docs without SOURCE_TAG set"
+  exit 0;
+fi
 REPO="https://github.com/parse-community/Parse-SDK-JS"
 
 rm -rf docs
@@ -13,16 +18,16 @@ cd docs
 git pull origin gh-pages
 cd ..
 
-DEST="master"
+RELEASE="release"
+VERSION="${SOURCE_TAG}"
 
-if [ "${SOURCE_TAG}" != "" ];
-then
-  DEST="${SOURCE_TAG}"
-  # change the default page to the latest
-  echo "<meta http-equiv='refresh' content='0; url=/Parse-SDK-JS/api/${DEST}'>" > "docs/api/index.html"
-fi
+# change the default page to the latest
+echo "<meta http-equiv='refresh' content='0; url=/Parse-SDK-JS/api/${VERSION}'>" > "docs/api/index.html"
 
 npm run docs
 
-mkdir -p "docs/api/${DEST}"
-cp -R out/* "docs/api/${DEST}"
+mkdir -p "docs/api/${RELEASE}"
+cp -R out/* "docs/api/${RELEASE}"
+
+mkdir -p "docs/api/${VERSION}"
+cp -R out/* "docs/api/${VERSION}"


### PR DESCRIPTION
## Pull Request

- Report security issues [confidentially](https://github.com/parse-community/Parse-SDK-JS/security/policy).
- Any contribution is under this [license](https://github.com/parse-community/Parse-SDK-JS/blob/alpha/LICENSE).
- Link this pull request to an [issue](https://github.com/parse-community/Parse-SDK-JS/issues?q=is%3Aissue).

## Issue
<!-- Add the link to the issue that this PR closes. -->
Currently there is no permanent link to the documentation for the latest api. There is release version specific links but those can get stale as new releases are publish. This can be mitigated if https://github.com/parse-community/minami/pull/1 is released

Closes: https://github.com/parse-community/Parse-SDK-JS/issues/2034

## Approach
<!-- Describe the changes in this PR. -->
Adds support for links that match the latest release.

Example: https://parseplatform.org/Parse-SDK-JS/api/release/Parse.html#.initialize

## Task

Waiting for https://github.com/parse-community/minami/pull/3 to be merged and released to test.