### PR TITLE
fix: Docs fail with `Cannot find module 'taffydb'`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,6 +25,15 @@ jobs:
       - run: npm ci
       - name: Check types
         run: npm run test:types
+  check-docs:
+    name: Check Docs
+    timeout-minutes: 5
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - run: npm ci
+      - name: Check Docs
+        run: npm run docs
   build:
     runs-on: ubuntu-latest
     timeout-minutes: 30

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "4.3.0-alpha.1",
       "license": "Apache-2.0",
       "dependencies": {
-        "@babel/runtime-corejs3": "^7.22.15",
+        "@babel/runtime-corejs3": "7.22.15",
         "idb-keyval": "6.2.1",
         "react-native-crypto-js": "1.0.0",
         "uuid": "9.0.0",
@@ -27,7 +27,7 @@
         "@babel/preset-react": "7.22.5",
         "@babel/preset-typescript": "7.22.5",
         "@definitelytyped/dtslint": "0.0.163",
-        "@parse/minami": "1.0.0",
+        "@parse/minami": "git+https://github.com/parse-community/minami#main",
         "@saithodev/semantic-release-backmerge": "2.1.3",
         "@semantic-release/changelog": "6.0.3",
         "@semantic-release/commit-analyzer": "9.0.2",
@@ -4315,9 +4315,12 @@
     },
     "node_modules/@parse/minami": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@parse/minami/-/minami-1.0.0.tgz",
-      "integrity": "sha512-Rw+p0WdOOypFPVJsmhyiI+Q056ZxdP2iAtObnU1DZrsvKZTf5x0B/0SjIt0hUgWp+COjqi/p17VdBU9IAD/NJg==",
-      "dev": true
+      "resolved": "git+ssh://git@github.com/parse-community/minami.git#2e8529b1276c3559b0ec919932e7a83d7a440c0a",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "taffydb": "2.7.3"
+      }
     },
     "node_modules/@parse/node-apn": {
       "version": "5.1.3",
@@ -25947,6 +25950,12 @@
         "acorn-node": "^1.2.0"
       }
     },
+    "node_modules/taffydb": {
+      "version": "2.7.3",
+      "resolved": "https://registry.npmjs.org/taffydb/-/taffydb-2.7.3.tgz",
+      "integrity": "sha512-GQ3gtYFSOAxSMN/apGtDKKkbJf+8izz5YfbGqIsUc7AMiQOapARZ76dhilRY2h39cynYxBFdafQo5HUL5vgkrg==",
+      "dev": true
+    },
     "node_modules/tar": {
       "version": "6.1.15",
       "resolved": "https://registry.npmjs.org/tar/-/tar-6.1.15.tgz",
@@ -30923,10 +30932,12 @@
       "dev": true
     },
     "@parse/minami": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@parse/minami/-/minami-1.0.0.tgz",
-      "integrity": "sha512-Rw+p0WdOOypFPVJsmhyiI+Q056ZxdP2iAtObnU1DZrsvKZTf5x0B/0SjIt0hUgWp+COjqi/p17VdBU9IAD/NJg==",
-      "dev": true
+      "version": "git+ssh://git@github.com/parse-community/minami.git#2e8529b1276c3559b0ec919932e7a83d7a440c0a",
+      "dev": true,
+      "from": "@parse/minami@git+https://github.com/parse-community/minami#main",
+      "requires": {
+        "taffydb": "2.7.3"
+      }
     },
     "@parse/node-apn": {
       "version": "5.1.3",
@@ -47780,6 +47791,12 @@
       "requires": {
         "acorn-node": "^1.2.0"
       }
+    },
+    "taffydb": {
+      "version": "2.7.3",
+      "resolved": "https://registry.npmjs.org/taffydb/-/taffydb-2.7.3.tgz",
+      "integrity": "sha512-GQ3gtYFSOAxSMN/apGtDKKkbJf+8izz5YfbGqIsUc7AMiQOapARZ76dhilRY2h39cynYxBFdafQo5HUL5vgkrg==",
+      "dev": true
     },
     "tar": {
       "version": "6.1.15",

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "@babel/preset-react": "7.22.5",
     "@babel/preset-typescript": "7.22.5",
     "@definitelytyped/dtslint": "0.0.163",
-    "@parse/minami": "1.0.0",
+    "@parse/minami": "git+https://github.com/parse-community/minami#main",
     "@saithodev/semantic-release-backmerge": "2.1.3",
     "@semantic-release/changelog": "6.0.3",
     "@semantic-release/commit-analyzer": "9.0.2",


### PR DESCRIPTION
## Pull Request

- Report security issues [confidentially](https://github.com/parse-community/Parse-SDK-JS/security/policy).
- Any contribution is under this [license](https://github.com/parse-community/Parse-SDK-JS/blob/alpha/LICENSE).
- Link this pull request to an [issue](https://github.com/parse-community/Parse-SDK-JS/issues?q=is%3Aissue).

## Issue
<!-- Add the link to the issue that this PR closes. -->

```
FATAL: Unable to load template: Cannot find module 'taffydb'
Require stack:
- /Users/dplewis/Documents/GitHub/Parse-SDK-JS/node_modules/@parse/minami/publish.js
- /Users/dplewis/Documents/GitHub/Parse-SDK-JS/node_modules/jsdoc/cli.js
- /Users/dplewis/Documents/GitHub/Parse-SDK-JS/node_modules/jsdoc/jsdoc.js
```

Ref: https://github.com/parse-community/Parse-SDK-JS/issues/2034

## Approach
<!-- Describe the changes in this PR. -->
* Update @parse/minami
* Update CI to check docs generates

## Tasks
<!-- Delete tasks that don't apply. -->

- [x] Add tests
- [x] Add changes to documentation (guides, repository pages, code comments)
