### PR TITLE
fix: Error in web context when `window.indexedDB` API is available but protected

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@babel/runtime-corejs3": "7.22.15",
         "idb-keyval": "6.2.1",
         "react-native-crypto-js": "1.0.0",
-        "uuid": "^9.0.1",
+        "uuid": "9.0.1",
         "ws": "8.13.0",
         "xmlhttprequest": "1.8.0"
       },

--- a/src/IndexedDBStorageController.js
+++ b/src/IndexedDBStorageController.js
@@ -6,28 +6,33 @@
 import { createStore, del, set, get, clear, keys } from 'idb-keyval';
 
 if (typeof window !== 'undefined' && window.indexedDB) {
-  const ParseStore = createStore('parseDB', 'parseStore');
+  try {
+    const ParseStore = createStore('parseDB', 'parseStore');
 
-  const IndexedDBStorageController = {
-    async: 1,
-    getItemAsync(path: string) {
-      return get(path, ParseStore);
-    },
-    setItemAsync(path: string, value: string) {
-      return set(path, value, ParseStore);
-    },
-    removeItemAsync(path: string) {
-      return del(path, ParseStore);
-    },
-    getAllKeysAsync() {
-      return keys(ParseStore);
-    },
-    clear() {
-      return clear(ParseStore);
-    },
-  };
+    const IndexedDBStorageController = {
+      async: 1,
+      getItemAsync(path: string) {
+        return get(path, ParseStore);
+      },
+      setItemAsync(path: string, value: string) {
+        return set(path, value, ParseStore);
+      },
+      removeItemAsync(path: string) {
+        return del(path, ParseStore);
+      },
+      getAllKeysAsync() {
+        return keys(ParseStore);
+      },
+      clear() {
+        return clear(ParseStore);
+      },
+    };
 
-  module.exports = IndexedDBStorageController;
+    module.exports = IndexedDBStorageController;
+  } catch (_) {
+    // IndexedDB not accessible
+    module.exports = undefined;
+  }
 } else {
   // IndexedDB not supported
   module.exports = undefined;

--- a/src/Parse.ts
+++ b/src/Parse.ts
@@ -2,6 +2,7 @@ import decode from './decode';
 import encode from './encode';
 import CryptoController from './CryptoController';
 import EventuallyQueue from './EventuallyQueue';
+import IndexedDBStorageController from './IndexedDBStorageController';
 import InstallationController from './InstallationController';
 import * as ParseOp from './ParseOp';
 import RESTController from './RESTController';
@@ -183,6 +184,10 @@ const Parse: ParseType = {
 
     Parse.LiveQuery = new LiveQuery();
     CoreManager.setIfNeeded('LiveQuery', Parse.LiveQuery);
+
+    if (process.env.PARSE_BUILD === 'browser') {
+      Parse.IndexedDB = CoreManager.setIfNeeded('IndexedDBStorageController', IndexedDBStorageController);
+    }
   },
 
   /**
@@ -427,10 +432,6 @@ const Parse: ParseType = {
     return this.encryptedUser;
   },
 };
-
-if (process.env.PARSE_BUILD === 'browser') {
-  Parse.IndexedDB = require('./IndexedDBStorageController');
-}
 
 CoreManager.setCryptoController(CryptoController);
 CoreManager.setInstallationController(InstallationController);

--- a/src/__tests__/Parse-test.js
+++ b/src/__tests__/Parse-test.js
@@ -237,6 +237,7 @@ describe('Parse module', () => {
       expect(Parse.IndexedDB).toBeUndefined();
       process.env.PARSE_BUILD = 'browser';
       const ParseInstance = require('../Parse');
+      ParseInstance.initialize('test', 'test');
       expect(ParseInstance.IndexedDB).toBeDefined();
       CoreManager.setStorageController(ParseInstance.IndexedDB);
       const currentStorage = CoreManager.getStorageController();

--- a/src/__tests__/Storage-test.js
+++ b/src/__tests__/Storage-test.js
@@ -207,11 +207,14 @@ describe('IndexDB StorageController', () => {
   });
 
   it('handle indexedDB is not accessible', async () => {
-    jest.spyOn(idbKeyVal, 'createStore')
-      .mockImplementationOnce(() => { throw new Error('Protected'); });
-    const dbController = require('../IndexedDBStorageController');
-    expect(idbKeyVal.createStore).toHaveBeenCalled();
-    expect(dbController).toBeUndefined();
+    jest.isolateModules(() => {
+      global.indexedDB = mockIndexedDB;
+      jest.spyOn(idbKeyVal, 'createStore')
+        .mockImplementationOnce(() => { throw new Error('Protected'); });
+      const dbController = require('../IndexedDBStorageController');
+      expect(dbController).toBeUndefined();
+      expect(idbKeyVal.createStore).toHaveBeenCalled();
+    });
   });
 });
 

--- a/src/__tests__/Storage-test.js
+++ b/src/__tests__/Storage-test.js
@@ -12,6 +12,7 @@ global.indexedDB = mockIndexedDB;
 jest.mock('idb-keyval', () => {
   return mockIndexedDB;
 });
+const idbKeyVal = require('idb-keyval');
 
 const BrowserStorageController = require('../StorageController.browser');
 
@@ -203,6 +204,14 @@ describe('IndexDB StorageController', () => {
     const dbController = require('../IndexedDBStorageController');
     expect(dbController).toBeUndefined();
     global.indexedDB = mockIndexedDB;
+  });
+
+  it('handle indexedDB is not accessible', async () => {
+    jest.spyOn(idbKeyVal, 'createStore')
+      .mockImplementationOnce(() => { throw new Error('Protected'); });
+    const dbController = require('../IndexedDBStorageController');
+    expect(idbKeyVal.createStore).toHaveBeenCalled();
+    expect(dbController).toBeUndefined();
   });
 });
 


### PR DESCRIPTION
## Pull Request

- Report security issues [confidentially](https://github.com/parse-community/Parse-SDK-JS/security/policy).
- Any contribution is under this [license](https://github.com/parse-community/Parse-SDK-JS/blob/alpha/LICENSE).
- Link this pull request to an [issue](https://github.com/parse-community/Parse-SDK-JS/issues?q=is%3Aissue).

## Issue
<!-- Add the link to the issue that this PR closes. -->
In a web context where window.indexedDB is protected from use but does exists, Parse SDK throws an error on initial import

Closes: https://github.com/parse-community/Parse-SDK-JS/issues/2038

## Approach
<!-- Describe the changes in this PR. -->
* Lazy Load `Parse.IndexedDB`
* Allow for custom IndexDB StorageController
* Handle errors on initialize

## Tasks
<!-- Delete tasks that don't apply. -->

- [x] Add tests
- [x] Add changes to documentation (guides, repository pages, code comments)
