### PR TITLE
fix: Calling `Parse.Object.relation.add` multiple times on an on object does not work

### DIFF
--- a/integration/test/ParseRelationTest.js
+++ b/integration/test/ParseRelationTest.js
@@ -43,6 +43,26 @@ describe('Parse Relation', () => {
       });
   });
 
+  it('can do consecutive adds (#2056)', async () => {
+    const ChildObject = Parse.Object.extend('ChildObject');
+    const childObjects = [];
+    for (let i = 0; i < 2; i++) {
+      childObjects.push(new ChildObject({ x: i }));
+    }
+    const parent = new Parse.Object('ParentObject');
+    await parent.save();
+    await Parse.Object.saveAll(childObjects);
+    for (const child of childObjects) {
+      parent.relation('child').add(child);
+    }
+    await parent.save();
+    const results = await parent.relation('child').query().find();
+    assert.equal(results.length, 2);
+    const expectedIds = new Set(childObjects.map(r => r.id));
+    const foundIds = new Set(results.map(r => r.id));
+    assert.deepEqual(expectedIds, foundIds);
+  });
+
   it('can query relation without schema', done => {
     const ChildObject = Parse.Object.extend('ChildObject');
     const childObjects = [];

--- a/integration/test/ParseRelationTest.js
+++ b/integration/test/ParseRelationTest.js
@@ -43,7 +43,7 @@ describe('Parse Relation', () => {
       });
   });
 
-  it('can do consecutive adds (#2056)', async () => {
+  it('can do consecutive adds', async () => {
     const ChildObject = Parse.Object.extend('ChildObject');
     const childObjects = [];
     for (let i = 0; i < 2; i++) {

--- a/src/ParseRelation.js
+++ b/src/ParseRelation.js
@@ -50,12 +50,9 @@ class ParseRelation {
         if (this.parent.id !== parent.id) {
           throw new Error('Internal Error. Relation retrieved from two different Objects.');
         }
-      } else if (parent.id) {
-        this.parent = parent;
       }
-    } else {
-      this.parent = parent;
     }
+    this.parent = parent;
   }
 
   /**


### PR DESCRIPTION
## Pull Request

- Report security issues [confidentially](https://github.com/parse-community/Parse-SDK-JS/security/policy).
- Any contribution is under this [license](https://github.com/parse-community/Parse-SDK-JS/blob/alpha/LICENSE).
- Link this pull request to an [issue](https://github.com/parse-community/Parse-SDK-JS/issues?q=is%3Aissue).

## Issue
<!-- Add the link to the issue that this PR closes. -->

Closes: #2056

## Approach
`_ensureParentAndKey` writes a fresh parent reference to the relation object.

## Tasks
<!-- Delete tasks that don't apply. -->

- [x] Add tests
- [ ] Add changes to documentation (guides, repository pages, code comments)
