### PR TITLE
ci: Remove manual caching for `actions/setup-node`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,13 +60,7 @@ jobs:
       uses: actions/setup-node@v3
       with:
         node-version: ${{ matrix.NODE_VERSION }}
-    - name: Cache Node.js modules
-      uses: actions/cache@v3
-      with:
-        path: ~/.npm
-        key: ${{ runner.os }}-node-${{ matrix.NODE_VERSION }}-${{ hashFiles('**/package-lock.json') }}
-        restore-keys: |
-            ${{ runner.os }}-node-${{ matrix.NODE_VERSION }}-
+        cache: npm
     - run: npm ci
     - run: npm run lint
     - run: npm test -- --maxWorkers=4

--- a/.github/workflows/release-automated.yml
+++ b/.github/workflows/release-automated.yml
@@ -19,13 +19,8 @@ jobs:
         with:
           node-version: 18
           registry-url: https://registry.npmjs.org/
-      - name: Cache Node.js modules
-        uses: actions/cache@v2
-        with:
-          path: ~/.npm
-          key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
-          restore-keys: |
-              ${{ runner.os }}-node-
+          cache: npm
+
       - run: npm ci
       - run: npx semantic-release
         env:
@@ -35,7 +30,7 @@ jobs:
       - name: Determine tag on current commit
         id: tag
         run: echo "::set-output name=current_tag::$(git describe --tags --abbrev=0 --exact-match || echo '')"
-  
+
   docs-publish:
     needs: release
     if: needs.release.outputs.current_tag != '' && github.ref == 'refs/heads/release'
@@ -49,13 +44,7 @@ jobs:
         uses: actions/setup-node@v1
         with:
           node-version: 16
-      - name: Cache Node.js modules
-        uses: actions/cache@v2
-        with:
-          path: ~/.npm
-          key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
-          restore-keys: |
-              ${{ runner.os }}-node-
+          cache: npm
       - name: Generate Docs
         run: |
           npm ci

--- a/.github/workflows/release-automated.yml
+++ b/.github/workflows/release-automated.yml
@@ -20,7 +20,6 @@ jobs:
           node-version: 18
           registry-url: https://registry.npmjs.org/
           cache: npm
-
       - run: npm ci
       - run: npx semantic-release
         env:

--- a/.github/workflows/release-manual-docs.yml
+++ b/.github/workflows/release-manual-docs.yml
@@ -4,7 +4,7 @@ on:
     inputs:
       tag:
         default: ''
-        description: 'Version tag:' 
+        description: 'Version tag:'
 jobs:
   docs-publish:
     if: github.event.inputs.tag != ''
@@ -18,13 +18,7 @@ jobs:
         uses: actions/setup-node@v1
         with:
           node-version: 16
-      - name: Cache Node.js modules
-        uses: actions/cache@v2
-        with:
-          path: ~/.npm
-          key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
-          restore-keys: |
-              ${{ runner.os }}-node-
+          cache: npm
       - name: Generate Docs
         run: |
           npm ci


### PR DESCRIPTION
`actions/setup-node` has caching built-in and uses `actions/cache` under the hood. This can be used to simplify workflow files.

Ref:
https://github.com/actions/setup-node#caching-global-packages-data
