### PR TITLE
fix: `Parse.Object.saveEventually` fails if server is restarting while calling it

### DIFF
--- a/src/EventuallyQueue.js
+++ b/src/EventuallyQueue.js
@@ -117,7 +117,7 @@ const EventuallyQueue = {
     queueData[index] = {
       queueId,
       action,
-      object: object.toJSON(),
+      object: object._getSaveJSON(),
       serverOptions,
       id: object.id,
       className: object.className,

--- a/src/__tests__/EventuallyQueue-test.js
+++ b/src/__tests__/EventuallyQueue-test.js
@@ -25,6 +25,9 @@ class MockObject {
   toJSON() {
     return this.attributes;
   }
+  _getSaveJSON() {
+      return this.attributes;
+  }
   static extend(className) {
     class MockSubclass {
       constructor() {


### PR DESCRIPTION
## Pull Request

- Report security issues [confidentially](https://github.com/parse-community/Parse-SDK-JS/security/policy).
- Any contribution is under this [license](https://github.com/parse-community/Parse-SDK-JS/blob/alpha/LICENSE).
- Link this pull request to an [issue](https://github.com/parse-community/Parse-SDK-JS/issues?q=is%3Aissue).

## Issue

Closes: [2028](https://github.com/parse-community/Parse-SDK-JS/issues/2028)

As issue describes, save fails due to the ACL object being stored to JSON and back causing the following error when connection is back:

```
Error: ACL must be a Parse ACL.
    at ParseObjectSubclass.value (ParseObject.js:1259:16)
    at ParseObjectSubclass.value (ParseObject.js:1578:31)
    at EventuallyQueue.js:386:27
```


## Approach

This is a quick fix using the saveJson format instead when storing the object locally. There might be a better representation of the object in a string store if someone can tell me what that is.




