### PR TITLE
feat: Add support for setting `Parse.ACL` from JSON

### DIFF
--- a/integration/test/ParseACLTest.js
+++ b/integration/test/ParseACLTest.js
@@ -8,11 +8,10 @@ describe('Parse.ACL', () => {
     Parse.User.enableUnsafeCurrentUser();
   });
 
-  it('can handle invalid acl', () => {
+  it('acl must be valid', () => {
     const user = new Parse.User();
-    user.setACL(`Ceci n'est pas un ACL.`)
-    assert.equal(user.getACL(), null);
-    assert.equal(user.get('ACL'), null);
+    assert.equal(user.setACL(`Ceci n'est pas un ACL.`), false);
+    console.log(user.getACL());
   });
 
   it('can refresh object with acl', async () => {

--- a/integration/test/ParseACLTest.js
+++ b/integration/test/ParseACLTest.js
@@ -8,9 +8,11 @@ describe('Parse.ACL', () => {
     Parse.User.enableUnsafeCurrentUser();
   });
 
-  it('acl must be valid', () => {
+  it('can handle invalid acl', () => {
     const user = new Parse.User();
-    assert.equal(user.setACL(`Ceci n'est pas un ACL.`), false);
+    user.setACL(`Ceci n'est pas un ACL.`)
+    assert.equal(user.getACL(), null);
+    assert.equal(user.get('ACL'), null);
   });
 
   it('can refresh object with acl', async () => {
@@ -25,6 +27,20 @@ describe('Parse.ACL', () => {
 
     const o = await object.fetch();
     assert(o);
+  });
+
+  it('can set ACL from json', async () => {
+    Parse.User.enableUnsafeCurrentUser();
+    const user = new Parse.User();
+    const object = new TestObject();
+    user.set('username', 'torn');
+    user.set('password', 'acl');
+    await user.signUp();
+    const acl = new Parse.ACL(user);
+    object.setACL(acl);
+    const json = object.toJSON();
+    await object.save(json);
+    assert.equal(acl.equals(object.getACL()), true);
   });
 
   it('disables public get access', async () => {

--- a/integration/test/ParseACLTest.js
+++ b/integration/test/ParseACLTest.js
@@ -11,7 +11,6 @@ describe('Parse.ACL', () => {
   it('acl must be valid', () => {
     const user = new Parse.User();
     assert.equal(user.setACL(`Ceci n'est pas un ACL.`), false);
-    console.log(user.getACL());
   });
 
   it('can refresh object with acl', async () => {

--- a/src/ParseObject.js
+++ b/src/ParseObject.js
@@ -603,6 +603,10 @@ class ParseObject {
    * @returns {*}
    */
   get(attr: string): mixed {
+    if (attr === 'ACL') {
+      const acl = this.attributes[attr];
+      return acl instanceof ParseACL ? acl : null;
+    }
     return this.attributes[attr];
   }
 
@@ -1043,9 +1047,6 @@ class ParseObject {
    * @see Parse.Object#set
    */
   validate(attrs: AttributeMap): ParseError | boolean {
-    if (attrs.hasOwnProperty('ACL') && !(attrs.ACL instanceof ParseACL)) {
-      return new ParseError(ParseError.OTHER_CAUSE, 'ACL must be a Parse ACL.');
-    }
     for (const key in attrs) {
       if (!/^[A-Za-z][0-9A-Za-z_.]*$/.test(key)) {
         return new ParseError(ParseError.INVALID_KEY_NAME);

--- a/src/ParseObject.js
+++ b/src/ParseObject.js
@@ -1319,7 +1319,6 @@ class ParseObject {
         return Promise.reject(validationError);
       }
     }
-
     const saveOptions = {};
     if (options.hasOwnProperty('useMasterKey')) {
       saveOptions.useMasterKey = !!options.useMasterKey;

--- a/src/__tests__/ParseObject-test.js
+++ b/src/__tests__/ParseObject-test.js
@@ -909,12 +909,9 @@ describe('ParseObject', () => {
 
   it('validates attributes on save()', async () => {
     const o = new ParseObject('Listing');
-    try {
-      await o.save({ '$$$': 'o_O' });
-      expect(true).toBe(false);
-    } catch (e) {
-      expect(e.code).toBe(ParseError.INVALID_KEY_NAME);
-    }
+    await expect(o.save({ '$$$': 'o_O' })).rejects.toEqual(
+      new ParseError(ParseError.INVALID_KEY_NAME)
+    );
   });
 
   it('ignores validation if ignoreValidation option is passed to set()', () => {

--- a/src/__tests__/ParseObject-test.js
+++ b/src/__tests__/ParseObject-test.js
@@ -907,6 +907,16 @@ describe('ParseObject', () => {
     });
   });
 
+  it('validates attributes on save()', async () => {
+    const o = new ParseObject('Listing');
+    try {
+      await o.save({ '$$$': 'o_O' });
+      expect(true).toBe(false);
+    } catch (e) {
+      expect(e.code).toBe(ParseError.INVALID_KEY_NAME);
+    }
+  });
+
   it('ignores validation if ignoreValidation option is passed to set()', () => {
     const o = new ParseObject('Listing');
     expect(o.set('$$$', 'o_O', { ignoreValidation: true })).toBe(o);


### PR DESCRIPTION
## Pull Request

- Report security issues [confidentially](https://github.com/parse-community/Parse-SDK-JS/security/policy).
- Any contribution is under this [license](https://github.com/parse-community/Parse-SDK-JS/blob/alpha/LICENSE).
- Link this pull request to an [issue](https://github.com/parse-community/Parse-SDK-JS/issues?q=is%3Aissue).

## Issue
<!-- Add the link to the issue that this PR closes. -->
Setting ACL from JSON throws `ACL must be Parse.ACL` error. ACL should be handled the same as other special fields like id, createdAt, updatedAt

Closes: https://github.com/parse-community/Parse-SDK-JS/issues/2096, https://github.com/parse-community/Parse-SDK-JS/issues/2028

## Approach
<!-- Describe the changes in this PR. -->
* Properly handles invalid ACL by returning null instead of error

## Tasks
<!-- Delete tasks that don't apply. -->

- [x] Add tests
- [x] Add changes to documentation (guides, repository pages, code comments)
