### PR TITLE
fix: Local datastore throws error when `Parse.Query.notEqualTo` is set to `null`

### DIFF
--- a/integration/test/ParseLocalDatastoreTest.js
+++ b/integration/test/ParseLocalDatastoreTest.js
@@ -1376,6 +1376,16 @@ function runTest(controller) {
       assert.equal(results.length, 9);
     });
 
+    it(`${controller.name} can perform notEqualTo null queries`, async () => {
+      const nullObject = new Parse.Object({ className: 'BoxedNumber', number: null });
+      await nullObject.save();
+      const query = new Parse.Query('BoxedNumber');
+      query.notEqualTo('number', null);
+      query.fromLocalDatastore();
+      const results = await query.find();
+      assert.equal(results.length, 10);
+    });
+
     it(`${controller.name} can perform containedIn queries`, async () => {
       const query = new Parse.Query('BoxedNumber');
       query.containedIn('number', [3, 5, 7, 9, 11]);

--- a/src/OfflineQuery.js
+++ b/src/OfflineQuery.js
@@ -315,11 +315,11 @@ function matchesKeyConstraints(className, object, objects, key, constraints) {
   for (const condition in constraints) {
     compareTo = constraints[condition];
 
-    if (compareTo.__type) {
+    if (compareTo?.__type) {
       compareTo = decode(compareTo);
     }
     // is it a $relativeTime? convert to date
-    if (compareTo['$relativeTime']) {
+    if (compareTo?.['$relativeTime']) {
       const parserResult = relativeTimeToDate(compareTo['$relativeTime']);
       if (parserResult.status !== 'success') {
         throw new ParseError(


### PR DESCRIPTION
## Pull Request

- Report security issues [confidentially](https://github.com/parse-community/Parse-SDK-JS/security/policy).
- Any contribution is under this [license](https://github.com/parse-community/Parse-SDK-JS/blob/alpha/LICENSE).
- Link this pull request to an [issue](https://github.com/parse-community/Parse-SDK-JS/issues?q=is%3Aissue).

## Issue
<!-- Add the link to the issue that this PR closes. -->

<img width="456" alt="Screenshot 2024-04-12 at 7 39 05 PM" src="https://github.com/parse-community/Parse-SDK-JS/assets/9830365/ef380c15-c488-4997-8626-619f3823c35c">

Similar to https://github.com/parse-community/parse-server/issues/8834

## Approach
<!-- Describe the changes in this PR. -->
Properly handle null comparison operators

## Tasks
<!-- Delete tasks that don't apply. -->

- [x] Add tests
- [x] Add changes to documentation (guides, repository pages, code comments)
