### PR TITLE
test: Add missing test for `Parse.User.verifyPassword` option `ignoreEmailVerification`

### DIFF
--- a/src/RESTController.js
+++ b/src/RESTController.js
@@ -249,15 +249,9 @@ const RESTController = {
         throw new Error('Cannot use the Master Key, it has not been provided.');
       }
     }
-
-    if (options.ignoreEmailVerification !== undefined) {
-      payload.ignoreEmailVerification = options.ignoreEmailVerification;
-    }
-
     if (CoreManager.get('FORCE_REVOCABLE_SESSION')) {
       payload._RevocableSession = '1';
     }
-
     const installationId = options.installationId;
     let installationIdPromise;
     if (installationId && typeof installationId === 'string') {

--- a/src/RESTController.js
+++ b/src/RESTController.js
@@ -249,9 +249,15 @@ const RESTController = {
         throw new Error('Cannot use the Master Key, it has not been provided.');
       }
     }
+
+    if (options.ignoreEmailVerification !== undefined) {
+      payload.ignoreEmailVerification = options.ignoreEmailVerification;
+    }
+
     if (CoreManager.get('FORCE_REVOCABLE_SESSION')) {
       payload._RevocableSession = '1';
     }
+
     const installationId = options.installationId;
     let installationIdPromise;
     if (installationId && typeof installationId === 'string') {

--- a/src/__tests__/RESTController-test.js
+++ b/src/__tests__/RESTController-test.js
@@ -647,6 +647,39 @@ describe('RESTController', () => {
     });
   });
 
+  it('can handle ignoreEmailVerification option', async () => {
+    const xhr = {
+      setRequestHeader: jest.fn(),
+      open: jest.fn(),
+      send: jest.fn(),
+    };
+    RESTController._setXHR(function () {
+      return xhr;
+    });
+    RESTController.request(
+      'GET',
+      'verifyPassword',
+      { username: 'parseuser', password: 'parsepass' },
+      { ignoreEmailVerification: true }
+    );
+    await flushPromises();
+    expect(xhr.open.mock.calls[0]).toEqual([
+      'POST',
+      'https://api.parse.com/1/verifyPassword',
+      true,
+    ]);
+    expect(JSON.parse(xhr.send.mock.calls[0][0])).toEqual({
+      _method: 'GET',
+      _ApplicationId: 'A',
+      _JavaScriptKey: 'B',
+      _ClientVersion: 'V',
+      _InstallationId: 'iid',
+      ignoreEmailVerification: true,
+      username: 'parseuser',
+      password: 'parsepass',
+    });
+  });
+
   it('can handle wechat request', async () => {
     const XHR = require('../Xhr.weapp');
     const xhr = new XHR();


### PR DESCRIPTION
## Pull Request

- Report security issues [confidentially](https://github.com/parse-community/Parse-SDK-JS/security/policy).
- Any contribution is under this [license](https://github.com/parse-community/Parse-SDK-JS/blob/alpha/LICENSE).
- Link this pull request to an [issue](https://github.com/parse-community/Parse-SDK-JS/issues?q=is%3Aissue).

## Issue
<!-- Add the link to the issue that this PR closes. -->
https://github.com/parse-community/Parse-SDK-JS/pull/2076 introduced a new feature for verifiying user passwords with a `ignoreEmailVerification` option. A unit test is missing.

Closes: https://github.com/parse-community/Parse-SDK-JS/issues/2101

## Approach
<!-- Describe the changes in this PR. -->
Add test

## Tasks
<!-- Delete tasks that don't apply. -->

- [x] Add tests
- [x] Add changes to documentation (guides, repository pages, code comments)
