### PR TITLE
refactor: Copy `ignoreEmailVerification` from option to data

### DIFF
--- a/src/ParseUser.js
+++ b/src/ParseUser.js
@@ -546,10 +546,11 @@ class ParseUser extends ParseObject {
   /**
    * Verify whether a given password is the password of the current user.
    *
-   * @param {string} password A password to be verified
-   * @param {object} options
-   * @returns {Promise} A promise that is fulfilled with a user
-   *  when the password is correct.
+   * @param {string} password The password to be verified.
+   * @param {object} options The options.
+   * @param {boolean} [options.ignoreEmailVerification=false] Set to `true` to bypass email verification and verify
+   * the password regardless of whether the email has been verified. This requires the master key.
+   * @returns {Promise} A promise that is fulfilled with a user when the password is correct.
    */
   verifyPassword(password: string, options?: RequestOptions): Promise<ParseUser> {
     const username = this.getUsername() || '';
@@ -865,13 +866,14 @@ class ParseUser extends ParseObject {
 
   /**
    * Verify whether a given password is the password of the current user.
-   *
-   * @param {string} username  A username to be used for identificaiton
-   * @param {string} password A password to be verified
-   * @param {object} options
    * @static
-   * @returns {Promise} A promise that is fulfilled with a user
-   *  when the password is correct.
+   *
+   * @param {string} username  The username of the user whose password should be verified.
+   * @param {string} password The password to be verified.
+   * @param {object} options The options.
+   * @param {boolean} [options.ignoreEmailVerification=false] Set to `true` to bypass email verification and verify
+   * the password regardless of whether the email has been verified. This requires the master key.
+   * @returns {Promise} A promise that is fulfilled with a user when the password is correct.
    */
   static verifyPassword(username: string, password: string, options?: RequestOptions) {
     if (typeof username !== 'string') {

--- a/src/ParseUser.js
+++ b/src/ParseUser.js
@@ -1262,7 +1262,12 @@ const DefaultController = {
 
   verifyPassword(username: string, password: string, options: RequestOptions) {
     const RESTController = CoreManager.getRESTController();
-    return RESTController.request('GET', 'verifyPassword', { username, password }, options);
+    const data = {
+      username,
+      password,
+      ...(options.ignoreEmailVerification !== undefined && { ignoreEmailVerification: options.ignoreEmailVerification }),
+    };
+    return RESTController.request('GET', 'verifyPassword', data, options);
   },
 
   requestEmailVerification(email: string, options: RequestOptions) {

--- a/src/RESTController.js
+++ b/src/RESTController.js
@@ -250,10 +250,6 @@ const RESTController = {
       }
     }
 
-    if (options.ignoreEmailVerification !== undefined) {
-      payload.ignoreEmailVerification = options.ignoreEmailVerification;
-    }
-
     if (CoreManager.get('FORCE_REVOCABLE_SESSION')) {
       payload._RevocableSession = '1';
     }


### PR DESCRIPTION
## Pull Request

- Report security issues [confidentially](https://github.com/parse-community/Parse-SDK-JS/security/policy).
- Any contribution is under this [license](https://github.com/parse-community/Parse-SDK-JS/blob/alpha/LICENSE).
- Link this pull request to an [issue](https://github.com/parse-community/Parse-SDK-JS/issues?q=is%3Aissue).

## Issue
<!-- Add the link to the issue that this PR closes. -->

Refactor how `ignoreEmailVerification` data is set, due to https://github.com/parse-community/Parse-SDK-JS/pull/2103#issuecomment-2053676630.

## Approach

Copy `ignoreEmailVerification` from option to data already in `Parse.User` instead of later in `RESTController`.

## TODO
- [x] Docs

