### PR TITLE
test: Fix EventuallyQueue flaky tests

### DIFF
--- a/integration/test/ParseEventuallyQueueTest.js
+++ b/integration/test/ParseEventuallyQueueTest.js
@@ -195,7 +195,8 @@ describe('Parse EventuallyQueue', () => {
     const object = new TestObject({ hash: 'saveSecret' });
     await new Promise((resolve) => parseServer.server.close(resolve));
     await object.saveEventually();
-    let length = await Parse.EventuallyQueue.length();
+
+    const length = await Parse.EventuallyQueue.length();
     assert(Parse.EventuallyQueue.isPolling());
     assert.strictEqual(length, 1);
 
@@ -203,14 +204,6 @@ describe('Parse EventuallyQueue', () => {
     while (Parse.EventuallyQueue.isPolling()) {
       await sleep(100);
     }
-    assert.strictEqual(Parse.EventuallyQueue.isPolling(), false);
-
-    while (await Parse.EventuallyQueue.length()) {
-      await sleep(100);
-    }
-    length = await Parse.EventuallyQueue.length();
-    assert.strictEqual(length, 0);
-
     const query = new Parse.Query(TestObject);
     query.equalTo('hash', 'saveSecret');
     let results = await query.find();
@@ -233,10 +226,9 @@ describe('Parse EventuallyQueue', () => {
     object.setACL(acl);
 
     await new Promise((resolve) => parseServer.server.close(resolve));
-
     await object.saveEventually();
 
-    let length = await Parse.EventuallyQueue.length();
+    const length = await Parse.EventuallyQueue.length();
     assert(Parse.EventuallyQueue.isPolling());
     assert.strictEqual(length, 1);
 
@@ -245,15 +237,6 @@ describe('Parse EventuallyQueue', () => {
     while (Parse.EventuallyQueue.isPolling()) {
       await sleep(100);
     }
-    assert.strictEqual(Parse.EventuallyQueue.isPolling(), false);
-
-    length = await Parse.EventuallyQueue.length();
-    while (length) {
-      await sleep(100);
-    }
-    length = await Parse.EventuallyQueue.length();
-    assert.strictEqual(length, 0);
-
     const query = new Parse.Query('TestObject');
     query.equalTo('hash', 'saveSecret');
     let results = await query.find();
@@ -269,7 +252,8 @@ describe('Parse EventuallyQueue', () => {
     await object.save();
     await new Promise((resolve) => parseServer.server.close(resolve));
     await object.destroyEventually();
-    let length = await Parse.EventuallyQueue.length();
+    const length = await Parse.EventuallyQueue.length();
+
     assert(Parse.EventuallyQueue.isPolling());
     assert.strictEqual(length, 1);
 
@@ -277,13 +261,6 @@ describe('Parse EventuallyQueue', () => {
     while (Parse.EventuallyQueue.isPolling()) {
       await sleep(100);
     }
-    assert.strictEqual(Parse.EventuallyQueue.isPolling(), false);
-    while (await Parse.EventuallyQueue.length()) {
-      await sleep(100);
-    }
-    length = await Parse.EventuallyQueue.length();
-    assert.strictEqual(length, 0);
-
     const query = new Parse.Query(TestObject);
     query.equalTo('hash', 'deleteSecret');
     let results = await query.find();

--- a/integration/test/helper.js
+++ b/integration/test/helper.js
@@ -84,6 +84,7 @@ const defaultConfiguration = {
   revokeSessionOnPasswordReset: false,
   allowCustomObjectId: false,
   allowClientClassCreation: true,
+  encodeParseObjectInCloudFunction: true,
   emailAdapter: MockEmailAdapterWithOptions({
     fromAddress: 'parse@example.com',
     apiKey: 'k',


### PR DESCRIPTION
## Pull Request

- Report security issues [confidentially](https://github.com/parse-community/Parse-SDK-JS/security/policy).
- Any contribution is under this [license](https://github.com/parse-community/Parse-SDK-JS/blob/alpha/LICENSE).
- Link this pull request to an [issue](https://github.com/parse-community/Parse-SDK-JS/issues?q=is%3Aissue).

## Issue
<!-- Add the link to the issue that this PR closes. -->

https://github.com/parse-community/Parse-SDK-JS/actions/runs/8675139200/job/23788227888?pr=2100

## Approach
<!-- Describe the changes in this PR. -->
Remove possible race condition on checking length while queue is processing.

Ran 100 times locally and all tests passed

Remove `encodeParseObjectInCloudFunction` default true warning

## Tasks
<!-- Delete tasks that don't apply. -->

- [ ] Add tests
- [ ] Add changes to documentation (guides, repository pages, code comments)
