### PR TITLE
docs: Generate documentation for TypeScript files

### DIFF
--- a/jsdoc-conf.json
+++ b/jsdoc-conf.json
@@ -1,10 +1,14 @@
 {
   "plugins": ["node_modules/jsdoc-babel", "plugins/markdown"],
   "babel": {
-      "plugins": ["@babel/plugin-transform-flow-comments"]
+    "babelrc": false,
+    "extensions": ["js", "ts", "jsx", "tsx"],
+    "plugins": ["@babel/plugin-transform-flow-comments"],
+    "presets": ["@babel/preset-typescript"]
   },
   "source": {
     "include":  ["./README.md"],
+    "includePattern": "\\.(jsx|js|ts|tsx)$",
     "excludePattern": "(^|\\/|\\\\)_"
   },
   "templates": {


### PR DESCRIPTION
## Pull Request

- Report security issues [confidentially](https://github.com/parse-community/Parse-SDK-JS/security/policy).
- Any contribution is under this [license](https://github.com/parse-community/Parse-SDK-JS/blob/alpha/LICENSE).
- Link this pull request to an [issue](https://github.com/parse-community/Parse-SDK-JS/issues?q=is%3Aissue).

## Issue
<!-- Add the link to the issue that this PR closes. -->
Documentation missing for `Parse.ts` and `ParseSession.ts`
https://parseplatform.org/Parse-SDK-JS/api/5.0.0/

