### PR TITLE
refactor: Convert ParseObject to TypeScript

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,10 +25,10 @@ jobs:
       - run: npm ci
       - name: Build Types
         run: npm run build:types
-      # - name: Lint Types
-      #   run: npm run lint:types
-      # - name: Test Types
-      #   run: npm run test:types
+      - name: Lint Types
+        run: npm run lint:types
+      - name: Test Types
+        run: npm run test:types
   check-docs:
     name: Check Docs
     timeout-minutes: 5

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,14 +17,18 @@ jobs:
         with:
           version: 2
   check-types:
-    name: Check types
+    name: Check Types
     timeout-minutes: 5
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
       - run: npm ci
-      - name: Check types
-        run: npm run test:types
+      - name: Build Types
+        run: npm run build:types
+      # - name: Lint Types
+      #   run: npm run lint:types
+      # - name: Test Types
+      #   run: npm run test:types
   check-docs:
     name: Check Docs
     timeout-minutes: 5

--- a/package.json
+++ b/package.json
@@ -107,6 +107,7 @@
     "posttest:mongodb": "mongodb-runner stop --all",
     "lint": "eslint --cache src/ integration/",
     "lint:fix": "eslint --fix --cache src/ integration/",
+    "lint:types": "dtslint types",
     "watch": "cross-env PARSE_BUILD=${PARSE_BUILD} gulp watch",
     "watch:browser": "cross-env PARSE_BUILD=browser npm run watch",
     "watch:node": "cross-env PARSE_BUILD=node npm run watch",

--- a/src/CoreManager.ts
+++ b/src/CoreManager.ts
@@ -53,7 +53,7 @@ type ObjectController = {
     object: ParseObject | Array<ParseObject>,
     forceFetch: boolean,
     options: RequestOptions
-  ) => Promise<any>,
+  ) => Promise<Array<ParseObject | undefined> | ParseObject | undefined>,
   save: (object: ParseObject | Array<ParseObject | ParseFile> | null, options: RequestOptions) => Promise<ParseObject | Array<ParseObject> | ParseFile>,
   destroy: (object: ParseObject | Array<ParseObject>, options: RequestOptions) => Promise<ParseObject | Array<ParseObject>>,
 };
@@ -86,7 +86,7 @@ type QueryController = {
 type EventuallyQueue = {
   save: (object: ParseObject, serverOptions: SaveOptions) => Promise<any>,
   destroy: (object: ParseObject, serverOptions: RequestOptions) => Promise<any>,
-  poll: (ms: number) => void
+  poll: (ms?: number) => void
 };
 type RESTController = {
   request: (method: string, path: string, data?: any, options?: RequestOptions) => Promise<any>,
@@ -598,7 +598,7 @@ const CoreManager = {
     return config['HooksController']!;
   },
 
-  setParseOp(op: ParseOp) {
+  setParseOp(op: typeof ParseOp) {
     config['ParseOp'] = op;
   },
 
@@ -606,7 +606,7 @@ const CoreManager = {
     return config['ParseOp']!;
   },
 
-  setParseObject(object: ParseObject) {
+  setParseObject(object: typeof ParseObject) {
     config['ParseObject'] = object;
   },
 
@@ -614,15 +614,15 @@ const CoreManager = {
     return config['ParseObject']!;
   },
 
-  setParseQuery(query: ParseQuery) {
+  setParseQuery(query: typeof ParseQuery) {
     config['ParseQuery'] = query;
   },
 
-  getParseQuery() {
-    return config['ParseQuery']!
+  getParseQuery(): ParseQuery {
+    return config['ParseQuery']!;
   },
 
-  setParseRole(role: ParseRole) {
+  setParseRole(role: typeof ParseRole) {
     config['ParseRole'] = role;
   },
 
@@ -630,7 +630,7 @@ const CoreManager = {
     return config['ParseRole']!;
   },
 
-  setParseUser(user: ParseUser) {
+  setParseUser(user: typeof ParseUser) {
     config['ParseUser'] = user;
   },
 

--- a/src/EventuallyQueue.js
+++ b/src/EventuallyQueue.js
@@ -303,7 +303,7 @@ const EventuallyQueue = {
    * @param [ms] Milliseconds to ping the server. Default 2000ms
    * @static
    */
-  poll(ms: number = 2000) {
+  poll(ms?: number = 2000) {
     if (polling) {
       return;
     }

--- a/src/InstallationController.ts
+++ b/src/InstallationController.ts
@@ -49,7 +49,7 @@ const InstallationController = {
       installationData.className = '_Installation';
       const current = ParseInstallation.fromJSON(installationData);
       currentInstallationCache = current;
-      return current;
+      return current as ParseInstallation;
     }
     const installationId = await this.currentInstallationId();
     const installation = new ParseInstallation();

--- a/src/Parse.ts
+++ b/src/Parse.ts
@@ -91,7 +91,7 @@ interface ParseType {
   _initialize(applicationId: string, javaScriptKey: string, masterKey?: string): void,
   setAsyncStorage(storage: any): void,
   setLocalDatastoreController(controller: any): void,
-  getServerHealth(): Promise<any>
+  getServerHealth(): Promise<any>,
 
   applicationId: string,
   javaScriptKey: string,

--- a/src/ParseInstallation.ts
+++ b/src/ParseInstallation.ts
@@ -189,7 +189,7 @@ class ParseInstallation extends ParseObject {
    * Parse.Installation.DEVICE_TYPES.WEB
    * </pre
    *
-   * @property {Object} DEVICE_TYPES
+   * @property {object} DEVICE_TYPES
    * @static
    */
   static get DEVICE_TYPES(): DeviceInterface {
@@ -202,7 +202,7 @@ class ParseInstallation extends ParseObject {
    * @param {...any} args
    * @returns {Promise}
    */
-  async save(...args: Array<any>): Promise<ParseInstallation> {
+  async save(...args: Array<any>): Promise<this> {
     await super.save.apply(this, args);
     await CoreManager.getInstallationController().updateInstallationOnDisk(this);
     return this;

--- a/src/ParseObject.ts
+++ b/src/ParseObject.ts
@@ -1,7 +1,3 @@
-/**
- * @flow
- */
-
 import CoreManager from './CoreManager';
 import canBeSerialized from './canBeSerialized';
 import decode from './decode';
@@ -13,7 +9,7 @@ import ParseError from './ParseError';
 import ParseFile from './ParseFile';
 import { when, continueWhile, resolvingPromise } from './promiseUtils';
 import { DEFAULT_PIN, PIN_PREFIX } from './LocalDatastoreUtils';
-
+import uuidv4 from './uuid';
 import {
   opFromJSON,
   Op,
@@ -34,12 +30,11 @@ import unsavedChildren from './unsavedChildren';
 import type { AttributeMap, OpsMap } from './ObjectStateMutations';
 import type { RequestOptions, FullOptions } from './RESTController';
 
-const uuidv4 = require('./uuid');
-
 export type Pointer = {
   __type: string,
   className: string,
-  objectId: string,
+  objectId?: string,
+  _localId?: string,
 };
 
 type SaveParams = {
@@ -51,7 +46,15 @@ type SaveParams = {
 export type SaveOptions = FullOptions & {
   cascadeSave?: boolean,
   context?: AttributeMap,
+  batchSize?: number,
 };
+
+type FetchOptions = {
+  useMasterKey?: boolean,
+  sessionToken?: string,
+  include?: string | string[],
+  context?: AttributeMap,
+}
 
 // Mapping of class names to constructors, so we can populate objects from the
 // server with appropriate subclasses of ParseObject
@@ -103,8 +106,8 @@ class ParseObject {
    * @param {object} options The options for this object instance.
    */
   constructor(
-    className: ?string | { className: string, [attr: string]: mixed },
-    attributes?: { [attr: string]: mixed },
+    className?: string | { className: string, [attr: string]: any },
+    attributes?: { [attr: string]: any },
     options?: { ignoreValidation: boolean }
   ) {
     // Enable legacy initializers
@@ -128,7 +131,7 @@ class ParseObject {
         }
       }
       if (attributes && typeof attributes === 'object') {
-        options = attributes;
+        options = attributes as any;
       }
     }
     if (toSet && !this.set(toSet, options)) {
@@ -141,8 +144,8 @@ class ParseObject {
    *
    * @property {string} id
    */
-  id: ?string;
-  _localId: ?string;
+  id?: string;
+  _localId?: string;
   _objCount: number;
   className: string;
 
@@ -159,7 +162,7 @@ class ParseObject {
    * @property {Date} createdAt
    * @returns {Date}
    */
-  get createdAt(): ?Date {
+  get createdAt(): Date | undefined {
     return this._getServerData().createdAt;
   }
 
@@ -169,7 +172,7 @@ class ParseObject {
    * @property {Date} updatedAt
    * @returns {Date}
    */
-  get updatedAt(): ?Date {
+  get updatedAt(): Date | undefined {
     return this._getServerData().updatedAt;
   }
 
@@ -278,7 +281,7 @@ class ParseObject {
   }
 
   _toFullJSON(seen?: Array<any>, offline?: boolean): AttributeMap {
-    const json: { [key: string]: mixed } = this.toJSON(seen, offline);
+    const json: { [key: string]: any } = this.toJSON(seen, offline);
     json.__type = 'Object';
     json.className = this.className;
     return json;
@@ -344,7 +347,12 @@ class ParseObject {
     }
     const stateController = CoreManager.getObjectStateController();
     stateController.initializeState(this._getStateIdentifier());
-    const decoded = {};
+    const decoded: Partial<{
+      createdAt?: Date,
+      updatedAt?: Date,
+      ACL?: any,
+      [key: string]: any,
+    }> = {};
     for (const attr in serverData) {
       if (attr === 'ACL') {
         decoded[attr] = new ParseACL(serverData[attr]);
@@ -393,7 +401,11 @@ class ParseObject {
   }
 
   _handleSaveResponse(response: AttributeMap, status: number) {
-    const changes = {};
+    const changes: Partial<{
+      createdAt: string,
+      updatedAt: string,
+      [key: string]: any
+    }> = {};
     let attr;
     const stateController = CoreManager.getObjectStateController();
     const pending = stateController.popPendingState(this._getStateIdentifier());
@@ -460,7 +472,7 @@ class ParseObject {
   toJSON(seen: Array<any> | void, offline?: boolean): AttributeMap {
     const seenEntry = this.id ? this.className + ':' + this.id : this;
     seen = seen || [seenEntry];
-    const json = {};
+    const json: AttributeMap = {};
     const attrs = this.attributes;
     for (const attr in attrs) {
       if ((attr === 'createdAt' || attr === 'updatedAt') && attrs[attr].toJSON) {
@@ -482,7 +494,7 @@ class ParseObject {
    * @param {object} other - An other object ot compare
    * @returns {boolean}
    */
-  equals(other: mixed): boolean {
+  equals(other: any): boolean {
     if (this === other) {
       return true;
     }
@@ -596,7 +608,7 @@ class ParseObject {
    * @param {string} attr The string name of an attribute.
    * @returns {*}
    */
-  get(attr: string): mixed {
+  get(attr: string): any {
     return this.attributes[attr];
   }
 
@@ -683,7 +695,7 @@ class ParseObject {
    *     The only supported option is <code>error</code>.
    * @returns {(ParseObject|boolean)} true if the set succeeded.
    */
-  set(key: mixed, value: mixed, options?: mixed): ParseObject | boolean {
+  set(key: any, value?: any, options?: any): ParseObject | boolean {
     let changes = {};
     const newOps = {};
     if (key && typeof key === 'object') {
@@ -697,8 +709,8 @@ class ParseObject {
 
     options = options || {};
     let readonly = [];
-    if (typeof this.constructor.readOnlyAttributes === 'function') {
-      readonly = readonly.concat(this.constructor.readOnlyAttributes());
+    if (typeof (this.constructor as any).readOnlyAttributes === 'function') {
+      readonly = readonly.concat((this.constructor as any).readOnlyAttributes());
     }
     for (const k in changes) {
       if (k === 'createdAt' || k === 'updatedAt') {
@@ -781,7 +793,7 @@ class ParseObject {
    * @param options
    * @returns {(ParseObject | boolean)}
    */
-  unset(attr: string, options?: { [opt: string]: mixed }): ParseObject | boolean {
+  unset(attr: string, options?: { [opt: string]: any }): ParseObject | boolean {
     options = options || {};
     options.unset = true;
     return this.set(attr, null, options);
@@ -831,7 +843,7 @@ class ParseObject {
    * @param item {} The item to add.
    * @returns {(ParseObject | boolean)}
    */
-  add(attr: string, item: mixed): ParseObject | boolean {
+  add(attr: string, item: any): ParseObject | boolean {
     return this.set(attr, new AddOp([item]));
   }
 
@@ -843,7 +855,7 @@ class ParseObject {
    * @param items {Object[]} The items to add.
    * @returns {(ParseObject | boolean)}
    */
-  addAll(attr: string, items: Array<mixed>): ParseObject | boolean {
+  addAll(attr: string, items: Array<any>): ParseObject | boolean {
     return this.set(attr, new AddOp(items));
   }
 
@@ -856,7 +868,7 @@ class ParseObject {
    * @param item {} The object to add.
    * @returns {(ParseObject | boolean)}
    */
-  addUnique(attr: string, item: mixed): ParseObject | boolean {
+  addUnique(attr: string, item: any): ParseObject | boolean {
     return this.set(attr, new AddUniqueOp([item]));
   }
 
@@ -869,7 +881,7 @@ class ParseObject {
    * @param items {Object[]} The objects to add.
    * @returns {(ParseObject | boolean)}
    */
-  addAllUnique(attr: string, items: Array<mixed>): ParseObject | boolean {
+  addAllUnique(attr: string, items: Array<any>): ParseObject | boolean {
     return this.set(attr, new AddUniqueOp(items));
   }
 
@@ -881,7 +893,7 @@ class ParseObject {
    * @param item {} The object to remove.
    * @returns {(ParseObject | boolean)}
    */
-  remove(attr: string, item: mixed): ParseObject | boolean {
+  remove(attr: string, item: any): ParseObject | boolean {
     return this.set(attr, new RemoveOp([item]));
   }
 
@@ -893,7 +905,7 @@ class ParseObject {
    * @param items {Object[]} The object to remove.
    * @returns {(ParseObject | boolean)}
    */
-  removeAll(attr: string, items: Array<mixed>): ParseObject | boolean {
+  removeAll(attr: string, items: Array<any>): ParseObject | boolean {
     return this.set(attr, new RemoveOp(items));
   }
 
@@ -906,7 +918,7 @@ class ParseObject {
    * @param attr {String} The key.
    * @returns {Parse.Op | undefined} The operation, or undefined if none.
    */
-  op(attr: string): ?Op {
+  op(attr: string): Op | undefined {
     const pending = this._getPendingOps();
     for (let i = pending.length; i--;) {
       if (pending[i][attr]) {
@@ -921,10 +933,10 @@ class ParseObject {
    * @returns {Parse.Object}
    */
   clone(): any {
-    const clone = new this.constructor(this.className);
+    const clone = new (this.constructor as new (...args: ConstructorParameters<typeof ParseObject>) => this)(this.className);
     let attributes = this.attributes;
-    if (typeof this.constructor.readOnlyAttributes === 'function') {
-      const readonly = this.constructor.readOnlyAttributes() || [];
+    if (typeof (this.constructor as any).readOnlyAttributes === 'function') {
+      const readonly = (this.constructor as any).readOnlyAttributes() || [];
       // Attributes are frozen, so we have to rebuild an object,
       // rather than delete readonly keys
       const copy = {};
@@ -947,7 +959,7 @@ class ParseObject {
    * @returns {Parse.Object}
    */
   newInstance(): any {
-    const clone = new this.constructor(this.className);
+    const clone = new (this.constructor as new (...args: ConstructorParameters<typeof ParseObject>) => this)(this.className);
     clone.id = this.id;
     if (singleInstance) {
       // Just return an object with the right id
@@ -1055,7 +1067,7 @@ class ParseObject {
    * @returns {Parse.ACL|null} An instance of Parse.ACL.
    * @see Parse.Object#get
    */
-  getACL(): ?ParseACL {
+  getACL(): ParseACL | null {
     const acl = this.get('ACL');
     if (acl instanceof ParseACL) {
       return acl;
@@ -1071,7 +1083,7 @@ class ParseObject {
    * @returns {(ParseObject | boolean)} Whether the set passed validation.
    * @see Parse.Object#set
    */
-  setACL(acl: ParseACL, options?: mixed): ParseObject | boolean {
+  setACL(acl: ParseACL, options?: any): ParseObject | boolean {
     return this.set('ACL', acl, options);
   }
 
@@ -1104,8 +1116,8 @@ class ParseObject {
     const attributes = this.attributes;
     const erasable = {};
     let readonly = ['createdAt', 'updatedAt'];
-    if (typeof this.constructor.readOnlyAttributes === 'function') {
-      readonly = readonly.concat(this.constructor.readOnlyAttributes());
+    if (typeof (this.constructor as any).readOnlyAttributes === 'function') {
+      readonly = readonly.concat((this.constructor as any).readOnlyAttributes());
     }
     for (const attr in attributes) {
       if (readonly.indexOf(attr) < 0) {
@@ -1132,9 +1144,9 @@ class ParseObject {
    * @returns {Promise} A promise that is fulfilled when the fetch
    *     completes.
    */
-  fetch(options: RequestOptions): Promise {
+  fetch(options: FetchOptions): Promise<any> {
     options = options || {};
-    const fetchOptions = {};
+    const fetchOptions: FetchOptions = {};
     if (options.hasOwnProperty('useMasterKey')) {
       fetchOptions.useMasterKey = options.useMasterKey;
     }
@@ -1151,7 +1163,7 @@ class ParseObject {
           if (Array.isArray(key)) {
             fetchOptions.include = fetchOptions.include.concat(key);
           } else {
-            fetchOptions.include.push(key);
+            (fetchOptions.include as string[]).push(key);
           }
         });
       } else {
@@ -1180,7 +1192,7 @@ class ParseObject {
    * @returns {Promise} A promise that is fulfilled when the fetch
    *     completes.
    */
-  fetchWithInclude(keys: String | Array<string | Array<string>>, options: RequestOptions): Promise {
+  fetchWithInclude(keys: String | Array<string | Array<string>>, options: RequestOptions): Promise<any> {
     options = options || {};
     options.include = keys;
     return this.fetch(options);
@@ -1210,7 +1222,7 @@ class ParseObject {
    * @returns {Promise} A promise that is fulfilled when the save
    * completes.
    */
-  async saveEventually(options: SaveOptions): Promise {
+  async saveEventually(options: SaveOptions): Promise<this> {
     try {
       await this.save(null, options);
     } catch (e) {
@@ -1286,10 +1298,10 @@ class ParseObject {
    * completes.
    */
   save(
-    arg1: ?string | { [attr: string]: mixed },
-    arg2: SaveOptions | mixed,
+    arg1: undefined | string | { [attr: string]: any } | null,
+    arg2: SaveOptions | any,
     arg3?: SaveOptions
-  ): Promise {
+  ): Promise<this> {
     let attrs;
     let options;
     if (typeof arg1 === 'object' || typeof arg1 === 'undefined') {
@@ -1314,7 +1326,7 @@ class ParseObject {
         return Promise.reject(validationError);
       }
     }
-    const saveOptions = {};
+    const saveOptions: SaveOptions = {};
     if (options.hasOwnProperty('useMasterKey')) {
       saveOptions.useMasterKey = !!options.useMasterKey;
     }
@@ -1356,7 +1368,7 @@ class ParseObject {
    * @returns {Promise} A promise that is fulfilled when the destroy
    *     completes.
    */
-  async destroyEventually(options: RequestOptions): Promise {
+  async destroyEventually(options: RequestOptions): Promise<this> {
     try {
       await this.destroy(options);
     } catch (e) {
@@ -1382,9 +1394,9 @@ class ParseObject {
    * @returns {Promise} A promise that is fulfilled when the destroy
    *     completes.
    */
-  destroy(options: RequestOptions): Promise {
+  destroy(options: RequestOptions): Promise<void | ParseObject> {
     options = options || {};
-    const destroyOptions = {};
+    const destroyOptions: RequestOptions = {};
     if (options.hasOwnProperty('useMasterKey')) {
       destroyOptions.useMasterKey = options.useMasterKey;
     }
@@ -1397,7 +1409,7 @@ class ParseObject {
     if (!this.id) {
       return Promise.resolve();
     }
-    return CoreManager.getObjectController().destroy(this, destroyOptions);
+    return CoreManager.getObjectController().destroy(this, destroyOptions) as Promise<ParseObject>;
   }
 
   /**
@@ -1549,7 +1561,7 @@ class ParseObject {
    * @returns {Parse.Object[]}
    */
   static fetchAll(list: Array<ParseObject>, options: RequestOptions = {}) {
-    const queryOptions = {};
+    const queryOptions: RequestOptions = {};
     if (options.hasOwnProperty('useMasterKey')) {
       queryOptions.useMasterKey = options.useMasterKey;
     }
@@ -1659,10 +1671,10 @@ class ParseObject {
    * @static
    * @returns {Parse.Object[]}
    */
-  static fetchAllIfNeeded(list: Array<ParseObject>, options) {
+  static fetchAllIfNeeded(list: Array<ParseObject>, options: FetchOptions) {
     options = options || {};
 
-    const queryOptions = {};
+    const queryOptions: FetchOptions = {};
     if (options.hasOwnProperty('useMasterKey')) {
       queryOptions.useMasterKey = options.useMasterKey;
     }
@@ -1675,7 +1687,7 @@ class ParseObject {
     return CoreManager.getObjectController().fetch(list, false, queryOptions);
   }
 
-  static handleIncludeOptions(options) {
+  static handleIncludeOptions(options: { include?: string | string[] }) {
     let include = [];
     if (Array.isArray(options.include)) {
       options.include.forEach(key => {
@@ -1686,7 +1698,7 @@ class ParseObject {
         }
       });
     } else {
-      include.push(options.include);
+      include.push(options.include!);
     }
     return include;
   }
@@ -1737,8 +1749,8 @@ class ParseObject {
    * @returns {Promise} A promise that is fulfilled when the destroyAll
    * completes.
    */
-  static destroyAll(list: Array<ParseObject>, options = {}) {
-    const destroyOptions = {};
+  static destroyAll(list: Array<ParseObject>, options: SaveOptions = {}) {
+    const destroyOptions: SaveOptions = {};
     if (options.hasOwnProperty('useMasterKey')) {
       destroyOptions.useMasterKey = options.useMasterKey;
     }
@@ -1772,8 +1784,8 @@ class ParseObject {
    * @static
    * @returns {Parse.Object[]}
    */
-  static saveAll(list: Array<ParseObject>, options: RequestOptions = {}) {
-    const saveOptions = {};
+  static saveAll(list: Array<ParseObject>, options: SaveOptions = {}) {
+    const saveOptions: SaveOptions = {};
     if (options.hasOwnProperty('useMasterKey')) {
       saveOptions.useMasterKey = options.useMasterKey;
     }
@@ -1803,7 +1815,7 @@ class ParseObject {
    * @static
    * @returns {Parse.Object} A Parse.Object reference.
    */
-  static createWithoutData(id: string) {
+  static createWithoutData(id: string): ParseObject {
     const obj = new this();
     obj.id = id;
     return obj;
@@ -1819,13 +1831,13 @@ class ParseObject {
    * @static
    * @returns {Parse.Object} A Parse.Object reference
    */
-  static fromJSON(json: any, override?: boolean, dirty?: boolean) {
+  static fromJSON(json: any, override?: boolean, dirty?: boolean): ParseObject {
     if (!json.className) {
       throw new Error('Cannot create an object without a className');
     }
     const constructor = classMap[json.className];
     const o = constructor ? new constructor(json.className) : new ParseObject(json.className);
-    const otherAttributes = {};
+    const otherAttributes: AttributeMap = {};
     for (const attr in json) {
       if (attr !== 'className' && attr !== '__type') {
         otherAttributes[attr] = json[attr];
@@ -1947,7 +1959,7 @@ class ParseObject {
     }
 
     let parentProto = ParseObject.prototype;
-    if (this.hasOwnProperty('__super__') && this.__super__) {
+    if (this.hasOwnProperty('__super__') && (this as any).__super__) {
       parentProto = this.prototype;
     }
     let ParseObjectSubclass = function (attributes, options) {
@@ -1973,15 +1985,15 @@ class ParseObject {
     if (classMap[adjustedClassName]) {
       ParseObjectSubclass = classMap[adjustedClassName];
     } else {
-      ParseObjectSubclass.extend = function (name, protoProps, classProps) {
+      (ParseObjectSubclass as any).extend = function (name, protoProps, classProps) {
         if (typeof name === 'string') {
           return ParseObject.extend.call(ParseObjectSubclass, name, protoProps, classProps);
         }
         return ParseObject.extend.call(ParseObjectSubclass, adjustedClassName, name, protoProps);
       };
-      ParseObjectSubclass.createWithoutData = ParseObject.createWithoutData;
-      ParseObjectSubclass.className = adjustedClassName;
-      ParseObjectSubclass.__super__ = parentProto;
+      (ParseObjectSubclass as any).createWithoutData = ParseObject.createWithoutData;
+      (ParseObjectSubclass as any).className = adjustedClassName;
+      (ParseObjectSubclass as any).__super__ = parentProto;
       ParseObjectSubclass.prototype = Object.create(parentProto, {
         constructor: {
           value: ParseObjectSubclass,
@@ -2192,7 +2204,7 @@ const DefaultController = {
     target: ParseObject | Array<ParseObject>,
     forceFetch: boolean,
     options: RequestOptions
-  ): Promise<Array<void> | ParseObject> {
+  ): Promise<Array<ParseObject | undefined> | ParseObject | undefined> {
     const localDatastore = CoreManager.getLocalDatastore();
     if (Array.isArray(target)) {
       if (target.length < 1) {
@@ -2273,7 +2285,7 @@ const DefaultController = {
         );
       }
       const RESTController = CoreManager.getRESTController();
-      const params = {};
+      const params: RequestOptions = {};
       if (options && options.include) {
         params.include = options.include.join();
       }
@@ -2290,13 +2302,13 @@ const DefaultController = {
         return target;
       });
     }
-    return Promise.resolve();
+    return Promise.resolve(undefined);
   },
 
   async destroy(
     target: ParseObject | Array<ParseObject>,
     options: RequestOptions
-  ): Promise<Array<void> | ParseObject> {
+  ): Promise<ParseObject | Array<ParseObject>>{
     const batchSize =
       options && options.batchSize ? options.batchSize : CoreManager.get('REQUEST_BATCH_SIZE');
     const localDatastore = CoreManager.getLocalDatastore();
@@ -2373,7 +2385,7 @@ const DefaultController = {
     return Promise.resolve(target);
   },
 
-  save(target: ParseObject | Array<ParseObject | ParseFile>, options: RequestOptions) {
+  save(target: ParseObject | Array<ParseObject | ParseFile>, options: RequestOptions): Promise<ParseObject | Array<ParseObject> | ParseFile> {
     const batchSize =
       options && options.batchSize ? options.batchSize : CoreManager.get('REQUEST_BATCH_SIZE');
     const localDatastore = CoreManager.getLocalDatastore();

--- a/src/ParseSession.ts
+++ b/src/ParseSession.ts
@@ -3,7 +3,6 @@ import isRevocableSession from './isRevocableSession';
 import ParseObject from './ParseObject';
 import ParseUser from './ParseUser';
 
-import type { AttributeMap } from './ObjectStateMutations';
 import type { RequestOptions, FullOptions } from './RESTController';
 
 /**

--- a/types/CoreManager.d.ts
+++ b/types/CoreManager.d.ts
@@ -59,7 +59,7 @@ type InstallationController = {
     updateInstallationOnDisk: (installation: ParseInstallation) => Promise<void>;
 };
 type ObjectController = {
-    fetch: (object: ParseObject | Array<ParseObject>, forceFetch: boolean, options: RequestOptions) => Promise<any>;
+    fetch: (object: ParseObject | Array<ParseObject>, forceFetch: boolean, options: RequestOptions) => Promise<Array<ParseObject | undefined> | ParseObject | undefined>;
     save: (object: ParseObject | Array<ParseObject | ParseFile> | null, options: RequestOptions) => Promise<ParseObject | Array<ParseObject> | ParseFile>;
     destroy: (object: ParseObject | Array<ParseObject>, options: RequestOptions) => Promise<ParseObject | Array<ParseObject>>;
 };
@@ -98,7 +98,7 @@ type QueryController = {
 type EventuallyQueue = {
     save: (object: ParseObject, serverOptions: SaveOptions) => Promise<any>;
     destroy: (object: ParseObject, serverOptions: RequestOptions) => Promise<any>;
-    poll: (ms: number) => void;
+    poll: (ms?: number) => void;
 };
 type RESTController = {
     request: (method: string, path: string, data?: any, options?: RequestOptions) => Promise<any>;
@@ -284,15 +284,15 @@ declare const CoreManager: {
     getLiveQueryController(): LiveQueryControllerType;
     setHooksController(controller: HooksController): void;
     getHooksController(): HooksController;
-    setParseOp(op: ParseOp): void;
+    setParseOp(op: any): void;
     getParseOp(): any;
-    setParseObject(object: ParseObject): void;
+    setParseObject(object: typeof ParseObject): void;
     getParseObject(): ParseObject;
-    setParseQuery(query: ParseQuery): void;
-    getParseQuery(): any;
-    setParseRole(role: ParseRole): void;
+    setParseQuery(query: any): void;
+    getParseQuery(): ParseQuery;
+    setParseRole(role: any): void;
     getParseRole(): ParseRole;
-    setParseUser(user: ParseUser): void;
+    setParseUser(user: any): void;
     getParseUser(): ParseUser;
 };
 export default CoreManager;

--- a/types/ParseInstallation.d.ts
+++ b/types/ParseInstallation.d.ts
@@ -129,7 +129,7 @@ declare class ParseInstallation extends ParseObject {
      * Parse.Installation.DEVICE_TYPES.WEB
      * </pre
      *
-     * @property {Object} DEVICE_TYPES
+     * @property {object} DEVICE_TYPES
      * @static
      */
     static get DEVICE_TYPES(): DeviceInterface;
@@ -139,7 +139,7 @@ declare class ParseInstallation extends ParseObject {
      * @param {...any} args
      * @returns {Promise}
      */
-    save(...args: Array<any>): Promise<ParseInstallation>;
+    save(...args: Array<any>): Promise<this>;
     /**
      * Get the current Parse.Installation from disk. If doesn't exists, create an new installation.
      *

--- a/types/ParseObject.d.ts
+++ b/types/ParseObject.d.ts
@@ -1,14 +1,31 @@
-// @ts-nocheck
-type Pointer = {
+import ParseACL from './ParseACL';
+import ParseError from './ParseError';
+import { Op } from './ParseOp';
+import ParseRelation from './ParseRelation';
+import type { AttributeMap, OpsMap } from './ObjectStateMutations';
+import type { RequestOptions, FullOptions } from './RESTController';
+export type Pointer = {
     __type: string;
     className: string;
-    objectId: string;
+    objectId?: string;
+    _localId?: string;
+};
+type SaveParams = {
+    method: string;
+    path: string;
+    body: AttributeMap;
 };
 export type SaveOptions = FullOptions & {
     cascadeSave?: boolean;
     context?: AttributeMap;
+    batchSize?: number;
 };
-export default ParseObject;
+type FetchOptions = {
+    useMasterKey?: boolean;
+    sessionToken?: string;
+    include?: string | string[];
+    context?: AttributeMap;
+};
 /**
  * Creates a new model with defined attributes.
  *
@@ -28,7 +45,609 @@ export default ParseObject;
  * @alias Parse.Object
  */
 declare class ParseObject {
+    /**
+     * @param {string} className The class name for the object
+     * @param {object} attributes The initial set of data to store in the object.
+     * @param {object} options The options for this object instance.
+     */
+    constructor(className?: string | {
+        className: string;
+        [attr: string]: any;
+    }, attributes?: {
+        [attr: string]: any;
+    }, options?: {
+        ignoreValidation: boolean;
+    });
+    /**
+     * The ID of this object, unique within its class.
+     *
+     * @property {string} id
+     */
+    id?: string;
+    _localId?: string;
+    _objCount: number;
+    className: string;
+    get attributes(): AttributeMap;
+    /**
+     * The first time this object was saved on the server.
+     *
+     * @property {Date} createdAt
+     * @returns {Date}
+     */
+    get createdAt(): Date | undefined;
+    /**
+     * The last time this object was updated on the server.
+     *
+     * @property {Date} updatedAt
+     * @returns {Date}
+     */
+    get updatedAt(): Date | undefined;
+    /**
+     * Returns a local or server Id used uniquely identify this object
+     *
+     * @returns {string}
+     */
+    _getId(): string;
+    /**
+     * Returns a unique identifier used to pull data from the State Controller.
+     *
+     * @returns {Parse.Object|object}
+     */
+    _getStateIdentifier(): ParseObject | {
+        id: string;
+        className: string;
+    };
+    _getServerData(): AttributeMap;
+    _clearServerData(): void;
+    _getPendingOps(): Array<OpsMap>;
+    /**
+     * @param {Array<string>} [keysToClear] - if specified, only ops matching
+     * these fields will be cleared
+     */
+    _clearPendingOps(keysToClear?: Array<string>): void;
+    _getDirtyObjectAttributes(): AttributeMap;
+    _toFullJSON(seen?: Array<any>, offline?: boolean): AttributeMap;
+    _getSaveJSON(): AttributeMap;
+    _getSaveParams(): SaveParams;
+    _finishFetch(serverData: AttributeMap): void;
+    _setExisted(existed: boolean): void;
+    _migrateId(serverId: string): void;
+    _handleSaveResponse(response: AttributeMap, status: number): void;
+    _handleSaveError(): void;
     static _getClassMap(): {};
+    initialize(): void;
+    /**
+     * Returns a JSON version of the object suitable for saving to Parse.
+     *
+     * @param seen
+     * @param offline
+     * @returns {object}
+     */
+    toJSON(seen: Array<any> | void, offline?: boolean): AttributeMap;
+    /**
+     * Determines whether this ParseObject is equal to another ParseObject
+     *
+     * @param {object} other - An other object ot compare
+     * @returns {boolean}
+     */
+    equals(other: any): boolean;
+    /**
+     * Returns true if this object has been modified since its last
+     * save/refresh.  If an attribute is specified, it returns true only if that
+     * particular attribute has been modified since the last save/refresh.
+     *
+     * @param {string} attr An attribute name (optional).
+     * @returns {boolean}
+     */
+    dirty(attr?: string): boolean;
+    /**
+     * Returns an array of keys that have been modified since last save/refresh
+     *
+     * @returns {string[]}
+     */
+    dirtyKeys(): Array<string>;
+    /**
+     * Returns true if the object has been fetched.
+     *
+     * @returns {boolean}
+     */
+    isDataAvailable(): boolean;
+    /**
+     * Gets a Pointer referencing this Object.
+     *
+     * @returns {Pointer}
+     */
+    toPointer(): Pointer;
+    /**
+     * Gets a Pointer referencing this Object.
+     *
+     * @returns {Pointer}
+     */
+    toOfflinePointer(): Pointer;
+    /**
+     * Gets the value of an attribute.
+     *
+     * @param {string} attr The string name of an attribute.
+     * @returns {*}
+     */
+    get(attr: string): any;
+    /**
+     * Gets a relation on the given class for the attribute.
+     *
+     * @param {string} attr The attribute to get the relation for.
+     * @returns {Parse.Relation}
+     */
+    relation(attr: string): ParseRelation;
+    /**
+     * Gets the HTML-escaped value of an attribute.
+     *
+     * @param {string} attr The string name of an attribute.
+     * @returns {string}
+     */
+    escape(attr: string): string;
+    /**
+     * Returns <code>true</code> if the attribute contains a value that is not
+     * null or undefined.
+     *
+     * @param {string} attr The string name of the attribute.
+     * @returns {boolean}
+     */
+    has(attr: string): boolean;
+    /**
+     * Sets a hash of model attributes on the object.
+     *
+     * <p>You can call it with an object containing keys and values, with one
+     * key and value, or dot notation.  For example:<pre>
+     *   gameTurn.set({
+     *     player: player1,
+     *     diceRoll: 2
+     *   }, {
+     *     error: function(gameTurnAgain, error) {
+     *       // The set failed validation.
+     *     }
+     *   });
+     *
+     *   game.set("currentPlayer", player2, {
+     *     error: function(gameTurnAgain, error) {
+     *       // The set failed validation.
+     *     }
+     *   });
+     *
+     *   game.set("finished", true);</pre></p>
+     *
+     *   game.set("player.score", 10);</pre></p>
+     *
+     * @param {(string|object)} key The key to set.
+     * @param {(string|object)} value The value to give it.
+     * @param {object} options A set of options for the set.
+     *     The only supported option is <code>error</code>.
+     * @returns {(ParseObject|boolean)} true if the set succeeded.
+     */
+    set(key: any, value?: any, options?: any): ParseObject | boolean;
+    /**
+     * Remove an attribute from the model. This is a noop if the attribute doesn't
+     * exist.
+     *
+     * @param {string} attr The string name of an attribute.
+     * @param options
+     * @returns {(ParseObject | boolean)}
+     */
+    unset(attr: string, options?: {
+        [opt: string]: any;
+    }): ParseObject | boolean;
+    /**
+     * Atomically increments the value of the given attribute the next time the
+     * object is saved. If no amount is specified, 1 is used by default.
+     *
+     * @param attr {String} The key.
+     * @param amount {Number} The amount to increment by (optional).
+     * @returns {(ParseObject|boolean)}
+     */
+    increment(attr: string, amount?: number): ParseObject | boolean;
+    /**
+     * Atomically decrements the value of the given attribute the next time the
+     * object is saved. If no amount is specified, 1 is used by default.
+     *
+     * @param attr {String} The key.
+     * @param amount {Number} The amount to decrement by (optional).
+     * @returns {(ParseObject | boolean)}
+     */
+    decrement(attr: string, amount?: number): ParseObject | boolean;
+    /**
+     * Atomically add an object to the end of the array associated with a given
+     * key.
+     *
+     * @param attr {String} The key.
+     * @param item {} The item to add.
+     * @returns {(ParseObject | boolean)}
+     */
+    add(attr: string, item: any): ParseObject | boolean;
+    /**
+     * Atomically add the objects to the end of the array associated with a given
+     * key.
+     *
+     * @param attr {String} The key.
+     * @param items {Object[]} The items to add.
+     * @returns {(ParseObject | boolean)}
+     */
+    addAll(attr: string, items: Array<any>): ParseObject | boolean;
+    /**
+     * Atomically add an object to the array associated with a given key, only
+     * if it is not already present in the array. The position of the insert is
+     * not guaranteed.
+     *
+     * @param attr {String} The key.
+     * @param item {} The object to add.
+     * @returns {(ParseObject | boolean)}
+     */
+    addUnique(attr: string, item: any): ParseObject | boolean;
+    /**
+     * Atomically add the objects to the array associated with a given key, only
+     * if it is not already present in the array. The position of the insert is
+     * not guaranteed.
+     *
+     * @param attr {String} The key.
+     * @param items {Object[]} The objects to add.
+     * @returns {(ParseObject | boolean)}
+     */
+    addAllUnique(attr: string, items: Array<any>): ParseObject | boolean;
+    /**
+     * Atomically remove all instances of an object from the array associated
+     * with a given key.
+     *
+     * @param attr {String} The key.
+     * @param item {} The object to remove.
+     * @returns {(ParseObject | boolean)}
+     */
+    remove(attr: string, item: any): ParseObject | boolean;
+    /**
+     * Atomically remove all instances of the objects from the array associated
+     * with a given key.
+     *
+     * @param attr {String} The key.
+     * @param items {Object[]} The object to remove.
+     * @returns {(ParseObject | boolean)}
+     */
+    removeAll(attr: string, items: Array<any>): ParseObject | boolean;
+    /**
+     * Returns an instance of a subclass of Parse.Op describing what kind of
+     * modification has been performed on this field since the last time it was
+     * saved. For example, after calling object.increment("x"), calling
+     * object.op("x") would return an instance of Parse.Op.Increment.
+     *
+     * @param attr {String} The key.
+     * @returns {Parse.Op | undefined} The operation, or undefined if none.
+     */
+    op(attr: string): Op | undefined;
+    /**
+     * Creates a new model with identical attributes to this one.
+     *
+     * @returns {Parse.Object}
+     */
+    clone(): any;
+    /**
+     * Creates a new instance of this object. Not to be confused with clone()
+     *
+     * @returns {Parse.Object}
+     */
+    newInstance(): any;
+    /**
+     * Returns true if this object has never been saved to Parse.
+     *
+     * @returns {boolean}
+     */
+    isNew(): boolean;
+    /**
+     * Returns true if this object was created by the Parse server when the
+     * object might have already been there (e.g. in the case of a Facebook
+     * login)
+     *
+     * @returns {boolean}
+     */
+    existed(): boolean;
+    /**
+     * Returns true if this object exists on the Server
+     *
+     * @param {object} options
+     * Valid options are:<ul>
+     *   <li>useMasterKey: In Cloud Code and Node only, causes the Master Key to
+     *     be used for this request.
+     *   <li>sessionToken: A valid session token, used for making a request on
+     *       behalf of a specific user.
+     * </ul>
+     * @returns {Promise<boolean>} A boolean promise that is fulfilled if object exists.
+     */
+    exists(options?: RequestOptions): Promise<boolean>;
+    /**
+     * Checks if the model is currently in a valid state.
+     *
+     * @returns {boolean}
+     */
+    isValid(): boolean;
+    /**
+     * You should not call this function directly unless you subclass
+     * <code>Parse.Object</code>, in which case you can override this method
+     * to provide additional validation on <code>set</code> and
+     * <code>save</code>.  Your implementation should return
+     *
+     * @param {object} attrs The current data to validate.
+     * @returns {Parse.Error|boolean} False if the data is valid.  An error object otherwise.
+     * @see Parse.Object#set
+     */
+    validate(attrs: AttributeMap): ParseError | boolean;
+    /**
+     * Returns the ACL for this object.
+     *
+     * @returns {Parse.ACL|null} An instance of Parse.ACL.
+     * @see Parse.Object#get
+     */
+    getACL(): ParseACL | null;
+    /**
+     * Sets the ACL to be used for this object.
+     *
+     * @param {Parse.ACL} acl An instance of Parse.ACL.
+     * @param {object} options
+     * @returns {(ParseObject | boolean)} Whether the set passed validation.
+     * @see Parse.Object#set
+     */
+    setACL(acl: ParseACL, options?: any): ParseObject | boolean;
+    /**
+     * Clears any (or specific) changes to this object made since the last call to save()
+     *
+     * @param {string} [keys] - specify which fields to revert
+     */
+    revert(...keys: Array<string>): void;
+    /**
+     * Clears all attributes on a model
+     *
+     * @returns {(ParseObject | boolean)}
+     */
+    clear(): ParseObject | boolean;
+    /**
+     * Fetch the model from the server. If the server's representation of the
+     * model differs from its current attributes, they will be overriden.
+     *
+     * @param {object} options
+     * Valid options are:<ul>
+     *   <li>useMasterKey: In Cloud Code and Node only, causes the Master Key to
+     *     be used for this request.
+     *   <li>sessionToken: A valid session token, used for making a request on
+     *       behalf of a specific user.
+     *   <li>include: The name(s) of the key(s) to include. Can be a string, an array of strings,
+     *       or an array of array of strings.
+     *   <li>context: A dictionary that is accessible in Cloud Code `beforeFind` trigger.
+     * </ul>
+     * @returns {Promise} A promise that is fulfilled when the fetch
+     *     completes.
+     */
+    fetch(options: FetchOptions): Promise<any>;
+    /**
+     * Fetch the model from the server. If the server's representation of the
+     * model differs from its current attributes, they will be overriden.
+     *
+     * Includes nested Parse.Objects for the provided key. You can use dot
+     * notation to specify which fields in the included object are also fetched.
+     *
+     * @param {string | Array<string | Array<string>>} keys The name(s) of the key(s) to include.
+     * @param {object} options
+     * Valid options are:<ul>
+     *   <li>useMasterKey: In Cloud Code and Node only, causes the Master Key to
+     *     be used for this request.
+     *   <li>sessionToken: A valid session token, used for making a request on
+     *       behalf of a specific user.
+     * </ul>
+     * @returns {Promise} A promise that is fulfilled when the fetch
+     *     completes.
+     */
+    fetchWithInclude(keys: String | Array<string | Array<string>>, options: RequestOptions): Promise<any>;
+    /**
+     * Saves this object to the server at some unspecified time in the future,
+     * even if Parse is currently inaccessible.
+     *
+     * Use this when you may not have a solid network connection, and don't need to know when the save completes.
+     * If there is some problem with the object such that it can't be saved, it will be silently discarded.
+     *
+     * Objects saved with this method will be stored locally in an on-disk cache until they can be delivered to Parse.
+     * They will be sent immediately if possible. Otherwise, they will be sent the next time a network connection is
+     * available. Objects saved this way will persist even after the app is closed, in which case they will be sent the
+     * next time the app is opened.
+     *
+     * @param {object} [options]
+     * Used to pass option parameters to method if arg1 and arg2 were both passed as strings.
+     * Valid options are:
+     * <ul>
+     * <li>sessionToken: A valid session token, used for making a request on
+     * behalf of a specific user.
+     * <li>cascadeSave: If `false`, nested objects will not be saved (default is `true`).
+     * <li>context: A dictionary that is accessible in Cloud Code `beforeSave` and `afterSave` triggers.
+     * </ul>
+     * @returns {Promise} A promise that is fulfilled when the save
+     * completes.
+     */
+    saveEventually(options: SaveOptions): Promise<this>;
+    /**
+     * Set a hash of model attributes, and save the model to the server.
+     * updatedAt will be updated when the request returns.
+     * You can either call it as:<pre>
+     * object.save();</pre>
+     * or<pre>
+     * object.save(attrs);</pre>
+     * or<pre>
+     * object.save(null, options);</pre>
+     * or<pre>
+     * object.save(attrs, options);</pre>
+     * or<pre>
+     * object.save(key, value);</pre>
+     * or<pre>
+     * object.save(key, value, options);</pre>
+     *
+     * Example 1: <pre>
+     * gameTurn.save({
+     * player: "Jake Cutter",
+     * diceRoll: 2
+     * }).then(function(gameTurnAgain) {
+     * // The save was successful.
+     * }, function(error) {
+     * // The save failed.  Error is an instance of Parse.Error.
+     * });</pre>
+     *
+     * Example 2: <pre>
+     * gameTurn.save("player", "Jake Cutter");</pre>
+     *
+     * @param {string | object | null} [arg1]
+     * Valid options are:<ul>
+     * <li>`Object` - Key/value pairs to update on the object.</li>
+     * <li>`String` Key - Key of attribute to update (requires arg2 to also be string)</li>
+     * <li>`null` - Passing null for arg1 allows you to save the object with options passed in arg2.</li>
+     * </ul>
+     * @param {string | object} [arg2]
+     * <ul>
+     * <li>`String` Value - If arg1 was passed as a key, arg2 is the value that should be set on that key.</li>
+     * <li>`Object` Options - Valid options are:
+     * <ul>
+     * <li>useMasterKey: In Cloud Code and Node only, causes the Master Key to
+     * be used for this request.
+     * <li>sessionToken: A valid session token, used for making a request on
+     * behalf of a specific user.
+     * <li>cascadeSave: If `false`, nested objects will not be saved (default is `true`).
+     * <li>context: A dictionary that is accessible in Cloud Code `beforeSave` and `afterSave` triggers.
+     * </ul>
+     * </li>
+     * </ul>
+     * @param {object} [arg3]
+     * Used to pass option parameters to method if arg1 and arg2 were both passed as strings.
+     * Valid options are:
+     * <ul>
+     * <li>useMasterKey: In Cloud Code and Node only, causes the Master Key to
+     * be used for this request.
+     * <li>sessionToken: A valid session token, used for making a request on
+     * behalf of a specific user.
+     * <li>cascadeSave: If `false`, nested objects will not be saved (default is `true`).
+     * <li>context: A dictionary that is accessible in Cloud Code `beforeSave` and `afterSave` triggers.
+     * </ul>
+     * @returns {Promise} A promise that is fulfilled when the save
+     * completes.
+     */
+    save(arg1: undefined | string | {
+        [attr: string]: any;
+    } | null, arg2: SaveOptions | any, arg3?: SaveOptions): Promise<this>;
+    /**
+     * Deletes this object from the server at some unspecified time in the future,
+     * even if Parse is currently inaccessible.
+     *
+     * Use this when you may not have a solid network connection,
+     * and don't need to know when the delete completes. If there is some problem with the object
+     * such that it can't be deleted, the request will be silently discarded.
+     *
+     * Delete instructions made with this method will be stored locally in an on-disk cache until they can be transmitted
+     * to Parse. They will be sent immediately if possible. Otherwise, they will be sent the next time a network connection
+     * is available. Delete requests will persist even after the app is closed, in which case they will be sent the
+     * next time the app is opened.
+     *
+     * @param {object} [options]
+     * Valid options are:<ul>
+     *   <li>sessionToken: A valid session token, used for making a request on
+     *       behalf of a specific user.
+     *   <li>context: A dictionary that is accessible in Cloud Code `beforeDelete` and `afterDelete` triggers.
+     * </ul>
+     * @returns {Promise} A promise that is fulfilled when the destroy
+     *     completes.
+     */
+    destroyEventually(options: RequestOptions): Promise<this>;
+    /**
+     * Destroy this model on the server if it was already persisted.
+     *
+     * @param {object} options
+     * Valid options are:<ul>
+     *   <li>useMasterKey: In Cloud Code and Node only, causes the Master Key to
+     *     be used for this request.
+     *   <li>sessionToken: A valid session token, used for making a request on
+     *       behalf of a specific user.
+     *   <li>context: A dictionary that is accessible in Cloud Code `beforeDelete` and `afterDelete` triggers.
+     * </ul>
+     * @returns {Promise} A promise that is fulfilled when the destroy
+     *     completes.
+     */
+    destroy(options: RequestOptions): Promise<void | ParseObject>;
+    /**
+     * Asynchronously stores the object and every object it points to in the local datastore,
+     * recursively, using a default pin name: _default.
+     *
+     * If those other objects have not been fetched from Parse, they will not be stored.
+     * However, if they have changed data, all the changes will be retained.
+     *
+     * <pre>
+     * await object.pin();
+     * </pre>
+     *
+     * To retrieve object:
+     * <code>query.fromLocalDatastore()</code> or <code>query.fromPin()</code>
+     *
+     * @returns {Promise} A promise that is fulfilled when the pin completes.
+     */
+    pin(): Promise<void>;
+    /**
+     * Asynchronously removes the object and every object it points to in the local datastore,
+     * recursively, using a default pin name: _default.
+     *
+     * <pre>
+     * await object.unPin();
+     * </pre>
+     *
+     * @returns {Promise} A promise that is fulfilled when the unPin completes.
+     */
+    unPin(): Promise<void>;
+    /**
+     * Asynchronously returns if the object is pinned
+     *
+     * <pre>
+     * const isPinned = await object.isPinned();
+     * </pre>
+     *
+     * @returns {Promise<boolean>} A boolean promise that is fulfilled if object is pinned.
+     */
+    isPinned(): Promise<boolean>;
+    /**
+     * Asynchronously stores the objects and every object they point to in the local datastore, recursively.
+     *
+     * If those other objects have not been fetched from Parse, they will not be stored.
+     * However, if they have changed data, all the changes will be retained.
+     *
+     * <pre>
+     * await object.pinWithName(name);
+     * </pre>
+     *
+     * To retrieve object:
+     * <code>query.fromLocalDatastore()</code> or <code>query.fromPinWithName(name)</code>
+     *
+     * @param {string} name Name of Pin.
+     * @returns {Promise} A promise that is fulfilled when the pin completes.
+     */
+    pinWithName(name: string): Promise<void>;
+    /**
+     * Asynchronously removes the object and every object it points to in the local datastore, recursively.
+     *
+     * <pre>
+     * await object.unPinWithName(name);
+     * </pre>
+     *
+     * @param {string} name Name of Pin.
+     * @returns {Promise} A promise that is fulfilled when the unPin completes.
+     */
+    unPinWithName(name: string): Promise<void>;
+    /**
+     * Asynchronously loads data from the local datastore into this object.
+     *
+     * <pre>
+     * await object.fetchFromLocalDatastore();
+     * </pre>
+     *
+     * You can create an unfetched pointer with <code>Parse.Object.createWithoutData()</code>
+     * and then call <code>fetchFromLocalDatastore()</code> on it.
+     *
+     * @returns {Promise} A promise that is fulfilled when the fetch completes.
+     */
+    fetchFromLocalDatastore(): Promise<ParseObject>;
     static _clearAllState(): void;
     /**
      * Fetches the given list of Parse.Object.
@@ -56,7 +675,7 @@ declare class ParseObject {
      * @static
      * @returns {Parse.Object[]}
      */
-    static fetchAll(list: Array<ParseObject>, options?: RequestOptions): Parse.Object[];
+    static fetchAll(list: Array<ParseObject>, options?: RequestOptions): Promise<ParseObject | ParseObject[]>;
     /**
      * Fetches the given list of Parse.Object.
      *
@@ -86,7 +705,7 @@ declare class ParseObject {
      * @static
      * @returns {Parse.Object[]}
      */
-    static fetchAllWithInclude(list: Array<ParseObject>, keys: String | Array<string | Array<string>>, options: RequestOptions): Parse.Object[];
+    static fetchAllWithInclude(list: Array<ParseObject>, keys: String | Array<string | Array<string>>, options: RequestOptions): Promise<ParseObject | ParseObject[]>;
     /**
      * Fetches the given list of Parse.Object if needed.
      * If any error is encountered, stops and calls the error handler.
@@ -117,7 +736,7 @@ declare class ParseObject {
      * @static
      * @returns {Parse.Object[]}
      */
-    static fetchAllIfNeededWithInclude(list: Array<ParseObject>, keys: String | Array<string | Array<string>>, options: RequestOptions): Parse.Object[];
+    static fetchAllIfNeededWithInclude(list: Array<ParseObject>, keys: String | Array<string | Array<string>>, options: RequestOptions): Promise<ParseObject | ParseObject[]>;
     /**
      * Fetches the given list of Parse.Object if needed.
      * If any error is encountered, stops and calls the error handler.
@@ -136,8 +755,10 @@ declare class ParseObject {
      * @static
      * @returns {Parse.Object[]}
      */
-    static fetchAllIfNeeded(list: Array<ParseObject>, options: object): Parse.Object[];
-    static handleIncludeOptions(options: any): any[];
+    static fetchAllIfNeeded(list: Array<ParseObject>, options: FetchOptions): Promise<ParseObject | ParseObject[]>;
+    static handleIncludeOptions(options: {
+        include?: string | string[];
+    }): any[];
     /**
      * Destroy the given list of models on the server if it was already persisted.
      *
@@ -184,7 +805,7 @@ declare class ParseObject {
      * @returns {Promise} A promise that is fulfilled when the destroyAll
      * completes.
      */
-    static destroyAll(list: Array<ParseObject>, options?: object): Promise<any>;
+    static destroyAll(list: Array<ParseObject>, options?: SaveOptions): Promise<ParseObject | ParseObject[]>;
     /**
      * Saves the given list of Parse.Object.
      * If any error is encountered, stops and calls the error handler.
@@ -203,7 +824,7 @@ declare class ParseObject {
      * @static
      * @returns {Parse.Object[]}
      */
-    static saveAll(list: Array<ParseObject>, options?: RequestOptions): Parse.Object[];
+    static saveAll(list: Array<ParseObject>, options?: SaveOptions): Promise<any>;
     /**
      * Creates a reference to a subclass of Parse.Object with the given id. This
      * does not exist on Parse.Object, only on subclasses.
@@ -218,7 +839,7 @@ declare class ParseObject {
      * @static
      * @returns {Parse.Object} A Parse.Object reference.
      */
-    static createWithoutData(id: string): Parse.Object;
+    static createWithoutData(id: string): ParseObject;
     /**
      * Creates a new instance of a Parse Object from a JSON representation.
      *
@@ -229,7 +850,7 @@ declare class ParseObject {
      * @static
      * @returns {Parse.Object} A Parse.Object reference
      */
-    static fromJSON(json: any, override?: boolean, dirty?: boolean): Parse.Object;
+    static fromJSON(json: any, override?: boolean, dirty?: boolean): ParseObject;
     /**
      * Registers a subclass of Parse.Object with a specific class name.
      * When objects of that class are retrieved from a query, they will be
@@ -283,7 +904,7 @@ declare class ParseObject {
      *     this method.
      * @returns {Parse.Object} A new subclass of Parse.Object.
      */
-    static extend(className: any, protoProps: any, classProps: any): Parse.Object;
+    static extend(className: any, protoProps: any, classProps: any): any;
     /**
      * Enable single instance objects, where any local objects with the same Id
      * share the same attributes, and stay synchronized with each other.
@@ -390,618 +1011,5 @@ declare class ParseObject {
      * @static
      */
     static unPinAllObjectsWithName(name: string): Promise<void>;
-    /**
-     * @param {string} className The class name for the object
-     * @param {object} attributes The initial set of data to store in the object.
-     * @param {object} options The options for this object instance.
-     */
-    constructor(className: string | {
-        [attr: string]: mixed;
-        className: string;
-    }, attributes?: {
-        [attr: string]: mixed;
-    }, options?: {
-        ignoreValidation: boolean;
-    }, ...args: any[]);
-    _objCount: number;
-    className: string;
-    /**
-     * The ID of this object, unique within its class.
-     *
-     * @property {string} id
-     */
-    id: string | null;
-    _localId: string | null;
-    get attributes(): AttributeMap;
-    /**
-     * The first time this object was saved on the server.
-     *
-     * @property {Date} createdAt
-     * @returns {Date}
-     */
-    get createdAt(): Date;
-    /**
-     * The last time this object was updated on the server.
-     *
-     * @property {Date} updatedAt
-     * @returns {Date}
-     */
-    get updatedAt(): Date;
-    /**
-     * Returns a local or server Id used uniquely identify this object
-     *
-     * @returns {string}
-     */
-    _getId(): string;
-    /**
-     * Returns a unique identifier used to pull data from the State Controller.
-     *
-     * @returns {Parse.Object|object}
-     */
-    _getStateIdentifier(): ParseObject | {
-        id: string;
-        className: string;
-    };
-    _getServerData(): AttributeMap;
-    _clearServerData(): void;
-    _getPendingOps(): Array<OpsMap>;
-    /**
-     * @param {Array<string>} [keysToClear] - if specified, only ops matching
-     * these fields will be cleared
-     */
-    _clearPendingOps(keysToClear?: Array<string>): void;
-    _getDirtyObjectAttributes(): AttributeMap;
-    _toFullJSON(seen?: Array<any>, offline?: boolean): AttributeMap;
-    _getSaveJSON(): AttributeMap;
-    _getSaveParams(): SaveParams;
-    _finishFetch(serverData: AttributeMap): void;
-    _setExisted(existed: boolean): void;
-    _migrateId(serverId: string): void;
-    _handleSaveResponse(response: AttributeMap, status: number): void;
-    _handleSaveError(): void;
-    initialize(): void;
-    /**
-     * Returns a JSON version of the object suitable for saving to Parse.
-     *
-     * @param seen
-     * @param offline
-     * @returns {object}
-     */
-    toJSON(seen: Array<any> | void, offline?: boolean): AttributeMap;
-    /**
-     * Determines whether this ParseObject is equal to another ParseObject
-     *
-     * @param {object} other - An other object ot compare
-     * @returns {boolean}
-     */
-    equals(other: mixed): boolean;
-    /**
-     * Returns true if this object has been modified since its last
-     * save/refresh.  If an attribute is specified, it returns true only if that
-     * particular attribute has been modified since the last save/refresh.
-     *
-     * @param {string} attr An attribute name (optional).
-     * @returns {boolean}
-     */
-    dirty(attr?: string): boolean;
-    /**
-     * Returns an array of keys that have been modified since last save/refresh
-     *
-     * @returns {string[]}
-     */
-    dirtyKeys(): Array<string>;
-    /**
-     * Returns true if the object has been fetched.
-     *
-     * @returns {boolean}
-     */
-    isDataAvailable(): boolean;
-    /**
-     * Gets a Pointer referencing this Object.
-     *
-     * @returns {Pointer}
-     */
-    toPointer(): Pointer;
-    /**
-     * Gets a Pointer referencing this Object.
-     *
-     * @returns {Pointer}
-     */
-    toOfflinePointer(): Pointer;
-    /**
-     * Gets the value of an attribute.
-     *
-     * @param {string} attr The string name of an attribute.
-     * @returns {*}
-     */
-    get(attr: string): mixed;
-    /**
-     * Gets a relation on the given class for the attribute.
-     *
-     * @param {string} attr The attribute to get the relation for.
-     * @returns {Parse.Relation}
-     */
-    relation(attr: string): ParseRelation;
-    /**
-     * Gets the HTML-escaped value of an attribute.
-     *
-     * @param {string} attr The string name of an attribute.
-     * @returns {string}
-     */
-    escape(attr: string): string;
-    /**
-     * Returns <code>true</code> if the attribute contains a value that is not
-     * null or undefined.
-     *
-     * @param {string} attr The string name of the attribute.
-     * @returns {boolean}
-     */
-    has(attr: string): boolean;
-    /**
-     * Sets a hash of model attributes on the object.
-     *
-     * <p>You can call it with an object containing keys and values, with one
-     * key and value, or dot notation.  For example:<pre>
-     *   gameTurn.set({
-     *     player: player1,
-     *     diceRoll: 2
-     *   }, {
-     *     error: function(gameTurnAgain, error) {
-     *       // The set failed validation.
-     *     }
-     *   });
-     *
-     *   game.set("currentPlayer", player2, {
-     *     error: function(gameTurnAgain, error) {
-     *       // The set failed validation.
-     *     }
-     *   });
-     *
-     *   game.set("finished", true);</pre></p>
-     *
-     *   game.set("player.score", 10);</pre></p>
-     *
-     * @param {(string|object)} key The key to set.
-     * @param {(string|object)} value The value to give it.
-     * @param {object} options A set of options for the set.
-     *     The only supported option is <code>error</code>.
-     * @returns {(ParseObject|boolean)} true if the set succeeded.
-     */
-    set(key: mixed, value: mixed, options?: mixed): ParseObject | boolean;
-    /**
-     * Remove an attribute from the model. This is a noop if the attribute doesn't
-     * exist.
-     *
-     * @param {string} attr The string name of an attribute.
-     * @param options
-     * @returns {(ParseObject | boolean)}
-     */
-    unset(attr: string, options?: {
-        [opt: string]: mixed;
-    }): ParseObject | boolean;
-    /**
-     * Atomically increments the value of the given attribute the next time the
-     * object is saved. If no amount is specified, 1 is used by default.
-     *
-     * @param attr {String} The key.
-     * @param amount {Number} The amount to increment by (optional).
-     * @returns {(ParseObject|boolean)}
-     */
-    increment(attr: string, amount?: number): ParseObject | boolean;
-    /**
-     * Atomically decrements the value of the given attribute the next time the
-     * object is saved. If no amount is specified, 1 is used by default.
-     *
-     * @param attr {String} The key.
-     * @param amount {Number} The amount to decrement by (optional).
-     * @returns {(ParseObject | boolean)}
-     */
-    decrement(attr: string, amount?: number): ParseObject | boolean;
-    /**
-     * Atomically add an object to the end of the array associated with a given
-     * key.
-     *
-     * @param attr {String} The key.
-     * @param item {} The item to add.
-     * @returns {(ParseObject | boolean)}
-     */
-    add(attr: string, item: mixed): ParseObject | boolean;
-    /**
-     * Atomically add the objects to the end of the array associated with a given
-     * key.
-     *
-     * @param attr {String} The key.
-     * @param items {Object[]} The items to add.
-     * @returns {(ParseObject | boolean)}
-     */
-    addAll(attr: string, items: Array<mixed>): ParseObject | boolean;
-    /**
-     * Atomically add an object to the array associated with a given key, only
-     * if it is not already present in the array. The position of the insert is
-     * not guaranteed.
-     *
-     * @param attr {String} The key.
-     * @param item {} The object to add.
-     * @returns {(ParseObject | boolean)}
-     */
-    addUnique(attr: string, item: mixed): ParseObject | boolean;
-    /**
-     * Atomically add the objects to the array associated with a given key, only
-     * if it is not already present in the array. The position of the insert is
-     * not guaranteed.
-     *
-     * @param attr {String} The key.
-     * @param items {Object[]} The objects to add.
-     * @returns {(ParseObject | boolean)}
-     */
-    addAllUnique(attr: string, items: Array<mixed>): ParseObject | boolean;
-    /**
-     * Atomically remove all instances of an object from the array associated
-     * with a given key.
-     *
-     * @param attr {String} The key.
-     * @param item {} The object to remove.
-     * @returns {(ParseObject | boolean)}
-     */
-    remove(attr: string, item: mixed): ParseObject | boolean;
-    /**
-     * Atomically remove all instances of the objects from the array associated
-     * with a given key.
-     *
-     * @param attr {String} The key.
-     * @param items {Object[]} The object to remove.
-     * @returns {(ParseObject | boolean)}
-     */
-    removeAll(attr: string, items: Array<mixed>): ParseObject | boolean;
-    /**
-     * Returns an instance of a subclass of Parse.Op describing what kind of
-     * modification has been performed on this field since the last time it was
-     * saved. For example, after calling object.increment("x"), calling
-     * object.op("x") would return an instance of Parse.Op.Increment.
-     *
-     * @param attr {String} The key.
-     * @returns {Parse.Op | undefined} The operation, or undefined if none.
-     */
-    op(attr: string): Op | null;
-    /**
-     * Creates a new model with identical attributes to this one.
-     *
-     * @returns {Parse.Object}
-     */
-    clone(): any;
-    /**
-     * Creates a new instance of this object. Not to be confused with clone()
-     *
-     * @returns {Parse.Object}
-     */
-    newInstance(): any;
-    /**
-     * Returns true if this object has never been saved to Parse.
-     *
-     * @returns {boolean}
-     */
-    isNew(): boolean;
-    /**
-     * Returns true if this object was created by the Parse server when the
-     * object might have already been there (e.g. in the case of a Facebook
-     * login)
-     *
-     * @returns {boolean}
-     */
-    existed(): boolean;
-    /**
-     * Returns true if this object exists on the Server
-     *
-     * @param {object} options
-     * Valid options are:<ul>
-     *   <li>useMasterKey: In Cloud Code and Node only, causes the Master Key to
-     *     be used for this request.
-     *   <li>sessionToken: A valid session token, used for making a request on
-     *       behalf of a specific user.
-     * </ul>
-     * @returns {Promise<boolean>} A boolean promise that is fulfilled if object exists.
-     */
-    exists(options?: RequestOptions): Promise<boolean>;
-    /**
-     * Checks if the model is currently in a valid state.
-     *
-     * @returns {boolean}
-     */
-    isValid(): boolean;
-    /**
-     * You should not call this function directly unless you subclass
-     * <code>Parse.Object</code>, in which case you can override this method
-     * to provide additional validation on <code>set</code> and
-     * <code>save</code>.  Your implementation should return
-     *
-     * @param {object} attrs The current data to validate.
-     * @returns {Parse.Error|boolean} False if the data is valid.  An error object otherwise.
-     * @see Parse.Object#set
-     */
-    validate(attrs: AttributeMap): ParseError | boolean;
-    /**
-     * Returns the ACL for this object.
-     *
-     * @returns {Parse.ACL} An instance of Parse.ACL.
-     * @see Parse.Object#get
-     */
-    getACL(): ParseACL | null;
-    /**
-     * Sets the ACL to be used for this object.
-     *
-     * @param {Parse.ACL} acl An instance of Parse.ACL.
-     * @param {object} options
-     * @returns {(ParseObject | boolean)} Whether the set passed validation.
-     * @see Parse.Object#set
-     */
-    setACL(acl: ParseACL, options?: mixed): ParseObject | boolean;
-    /**
-     * Clears any (or specific) changes to this object made since the last call to save()
-     *
-     * @param {string} [keys] - specify which fields to revert
-     */
-    revert(...keys?: Array<string>): void;
-    /**
-     * Clears all attributes on a model
-     *
-     * @returns {(ParseObject | boolean)}
-     */
-    clear(): ParseObject | boolean;
-    /**
-     * Fetch the model from the server. If the server's representation of the
-     * model differs from its current attributes, they will be overriden.
-     *
-     * @param {object} options
-     * Valid options are:<ul>
-     *   <li>useMasterKey: In Cloud Code and Node only, causes the Master Key to
-     *     be used for this request.
-     *   <li>sessionToken: A valid session token, used for making a request on
-     *       behalf of a specific user.
-     *   <li>include: The name(s) of the key(s) to include. Can be a string, an array of strings,
-     *       or an array of array of strings.
-     *   <li>context: A dictionary that is accessible in Cloud Code `beforeFind` trigger.
-     * </ul>
-     * @returns {Promise} A promise that is fulfilled when the fetch
-     *     completes.
-     */
-    fetch(options: RequestOptions): Promise<any>;
-    /**
-     * Fetch the model from the server. If the server's representation of the
-     * model differs from its current attributes, they will be overriden.
-     *
-     * Includes nested Parse.Objects for the provided key. You can use dot
-     * notation to specify which fields in the included object are also fetched.
-     *
-     * @param {string | Array<string | Array<string>>} keys The name(s) of the key(s) to include.
-     * @param {object} options
-     * Valid options are:<ul>
-     *   <li>useMasterKey: In Cloud Code and Node only, causes the Master Key to
-     *     be used for this request.
-     *   <li>sessionToken: A valid session token, used for making a request on
-     *       behalf of a specific user.
-     * </ul>
-     * @returns {Promise} A promise that is fulfilled when the fetch
-     *     completes.
-     */
-    fetchWithInclude(keys: String | Array<string | Array<string>>, options: RequestOptions): Promise<any>;
-    /**
-     * Saves this object to the server at some unspecified time in the future,
-     * even if Parse is currently inaccessible.
-     *
-     * Use this when you may not have a solid network connection, and don't need to know when the save completes.
-     * If there is some problem with the object such that it can't be saved, it will be silently discarded.
-     *
-     * Objects saved with this method will be stored locally in an on-disk cache until they can be delivered to Parse.
-     * They will be sent immediately if possible. Otherwise, they will be sent the next time a network connection is
-     * available. Objects saved this way will persist even after the app is closed, in which case they will be sent the
-     * next time the app is opened.
-     *
-     * @param {object} [options]
-     * Used to pass option parameters to method if arg1 and arg2 were both passed as strings.
-     * Valid options are:
-     * <ul>
-     * <li>sessionToken: A valid session token, used for making a request on
-     * behalf of a specific user.
-     * <li>cascadeSave: If `false`, nested objects will not be saved (default is `true`).
-     * <li>context: A dictionary that is accessible in Cloud Code `beforeSave` and `afterSave` triggers.
-     * </ul>
-     * @returns {Promise} A promise that is fulfilled when the save
-     * completes.
-     */
-    saveEventually(options?: SaveOptions): Promise<any>;
-    /**
-     * Set a hash of model attributes, and save the model to the server.
-     * updatedAt will be updated when the request returns.
-     * You can either call it as:<pre>
-     * object.save();</pre>
-     * or<pre>
-     * object.save(attrs);</pre>
-     * or<pre>
-     * object.save(null, options);</pre>
-     * or<pre>
-     * object.save(attrs, options);</pre>
-     * or<pre>
-     * object.save(key, value);</pre>
-     * or<pre>
-     * object.save(key, value, options);</pre>
-     *
-     * Example 1: <pre>
-     * gameTurn.save({
-     * player: "Jake Cutter",
-     * diceRoll: 2
-     * }).then(function(gameTurnAgain) {
-     * // The save was successful.
-     * }, function(error) {
-     * // The save failed.  Error is an instance of Parse.Error.
-     * });</pre>
-     *
-     * Example 2: <pre>
-     * gameTurn.save("player", "Jake Cutter");</pre>
-     *
-     * @param {string | object | null} [arg1]
-     * Valid options are:<ul>
-     * <li>`Object` - Key/value pairs to update on the object.</li>
-     * <li>`String` Key - Key of attribute to update (requires arg2 to also be string)</li>
-     * <li>`null` - Passing null for arg1 allows you to save the object with options passed in arg2.</li>
-     * </ul>
-     * @param {string | object} [arg2]
-     * <ul>
-     * <li>`String` Value - If arg1 was passed as a key, arg2 is the value that should be set on that key.</li>
-     * <li>`Object` Options - Valid options are:
-     * <ul>
-     * <li>useMasterKey: In Cloud Code and Node only, causes the Master Key to
-     * be used for this request.
-     * <li>sessionToken: A valid session token, used for making a request on
-     * behalf of a specific user.
-     * <li>cascadeSave: If `false`, nested objects will not be saved (default is `true`).
-     * <li>context: A dictionary that is accessible in Cloud Code `beforeSave` and `afterSave` triggers.
-     * </ul>
-     * </li>
-     * </ul>
-     * @param {object} [arg3]
-     * Used to pass option parameters to method if arg1 and arg2 were both passed as strings.
-     * Valid options are:
-     * <ul>
-     * <li>useMasterKey: In Cloud Code and Node only, causes the Master Key to
-     * be used for this request.
-     * <li>sessionToken: A valid session token, used for making a request on
-     * behalf of a specific user.
-     * <li>cascadeSave: If `false`, nested objects will not be saved (default is `true`).
-     * <li>context: A dictionary that is accessible in Cloud Code `beforeSave` and `afterSave` triggers.
-     * </ul>
-     * @returns {Promise} A promise that is fulfilled when the save
-     * completes.
-     */
-    save(arg1?: string | {
-        [attr: string]: mixed;
-    }, arg2?: SaveOptions | mixed, arg3?: SaveOptions): Promise<any>;
-    /**
-     * Deletes this object from the server at some unspecified time in the future,
-     * even if Parse is currently inaccessible.
-     *
-     * Use this when you may not have a solid network connection,
-     * and don't need to know when the delete completes. If there is some problem with the object
-     * such that it can't be deleted, the request will be silently discarded.
-     *
-     * Delete instructions made with this method will be stored locally in an on-disk cache until they can be transmitted
-     * to Parse. They will be sent immediately if possible. Otherwise, they will be sent the next time a network connection
-     * is available. Delete requests will persist even after the app is closed, in which case they will be sent the
-     * next time the app is opened.
-     *
-     * @param {object} [options]
-     * Valid options are:<ul>
-     *   <li>sessionToken: A valid session token, used for making a request on
-     *       behalf of a specific user.
-     *   <li>context: A dictionary that is accessible in Cloud Code `beforeDelete` and `afterDelete` triggers.
-     * </ul>
-     * @returns {Promise} A promise that is fulfilled when the destroy
-     *     completes.
-     */
-    destroyEventually(options?: RequestOptions): Promise<any>;
-    /**
-     * Destroy this model on the server if it was already persisted.
-     *
-     * @param {object} options
-     * Valid options are:<ul>
-     *   <li>useMasterKey: In Cloud Code and Node only, causes the Master Key to
-     *     be used for this request.
-     *   <li>sessionToken: A valid session token, used for making a request on
-     *       behalf of a specific user.
-     *   <li>context: A dictionary that is accessible in Cloud Code `beforeDelete` and `afterDelete` triggers.
-     * </ul>
-     * @returns {Promise} A promise that is fulfilled when the destroy
-     *     completes.
-     */
-    destroy(options: RequestOptions): Promise<any>;
-    /**
-     * Asynchronously stores the object and every object it points to in the local datastore,
-     * recursively, using a default pin name: _default.
-     *
-     * If those other objects have not been fetched from Parse, they will not be stored.
-     * However, if they have changed data, all the changes will be retained.
-     *
-     * <pre>
-     * await object.pin();
-     * </pre>
-     *
-     * To retrieve object:
-     * <code>query.fromLocalDatastore()</code> or <code>query.fromPin()</code>
-     *
-     * @returns {Promise} A promise that is fulfilled when the pin completes.
-     */
-    pin(): Promise<void>;
-    /**
-     * Asynchronously removes the object and every object it points to in the local datastore,
-     * recursively, using a default pin name: _default.
-     *
-     * <pre>
-     * await object.unPin();
-     * </pre>
-     *
-     * @returns {Promise} A promise that is fulfilled when the unPin completes.
-     */
-    unPin(): Promise<void>;
-    /**
-     * Asynchronously returns if the object is pinned
-     *
-     * <pre>
-     * const isPinned = await object.isPinned();
-     * </pre>
-     *
-     * @returns {Promise<boolean>} A boolean promise that is fulfilled if object is pinned.
-     */
-    isPinned(): Promise<boolean>;
-    /**
-     * Asynchronously stores the objects and every object they point to in the local datastore, recursively.
-     *
-     * If those other objects have not been fetched from Parse, they will not be stored.
-     * However, if they have changed data, all the changes will be retained.
-     *
-     * <pre>
-     * await object.pinWithName(name);
-     * </pre>
-     *
-     * To retrieve object:
-     * <code>query.fromLocalDatastore()</code> or <code>query.fromPinWithName(name)</code>
-     *
-     * @param {string} name Name of Pin.
-     * @returns {Promise} A promise that is fulfilled when the pin completes.
-     */
-    pinWithName(name: string): Promise<void>;
-    /**
-     * Asynchronously removes the object and every object it points to in the local datastore, recursively.
-     *
-     * <pre>
-     * await object.unPinWithName(name);
-     * </pre>
-     *
-     * @param {string} name Name of Pin.
-     * @returns {Promise} A promise that is fulfilled when the unPin completes.
-     */
-    unPinWithName(name: string): Promise<void>;
-    /**
-     * Asynchronously loads data from the local datastore into this object.
-     *
-     * <pre>
-     * await object.fetchFromLocalDatastore();
-     * </pre>
-     *
-     * You can create an unfetched pointer with <code>Parse.Object.createWithoutData()</code>
-     * and then call <code>fetchFromLocalDatastore()</code> on it.
-     *
-     * @returns {Promise} A promise that is fulfilled when the fetch completes.
-     */
-    fetchFromLocalDatastore(): Promise<ParseObject>;
 }
-import { AttributeMap as AttributeMap_1 } from './ObjectStateMutations';
-import { OpsMap } from './ObjectStateMutations';
-type SaveParams = {
-    method: string;
-    path: string;
-    body: AttributeMap;
-};
-import ParseRelation from './ParseRelation';
-import { Op } from './ParseOp';
-import { RequestOptions } from './RESTController';
-import ParseError from './ParseError';
-import ParseACL from './ParseACL';
+export default ParseObject;


### PR DESCRIPTION
## Pull Request

- Report security issues [confidentially](https://github.com/parse-community/Parse-SDK-JS/security/policy).
- Any contribution is under this [license](https://github.com/parse-community/Parse-SDK-JS/blob/alpha/LICENSE).
- Link this pull request to an [issue](https://github.com/parse-community/Parse-SDK-JS/issues?q=is%3Aissue).

## Issue
<!-- Add the link to the issue that this PR closes. -->
The Type Check CI job is failing.

## Approach
<!-- Describe the changes in this PR. -->
* Convert ParseObject.js to TS
* Fixing lint issues
* Properly handle typing in all current TS files

I updated the Type Check CI Job
1) Ensure the `.d.ts` files generate without errors
2) Lint on those `.d.ts` files (will have errors until project is fully TS)
3) Test `.d.ts` files to find compile errors (will have errors until project is fully TS)
