### PR TITLE
refactor: Fix TypeScript type correctness test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,6 +27,8 @@ jobs:
         run: npm run build:types
       - name: Test Types
         run: npm run test:types
+      - name: Lint Types
+        run: npm run lint:types
   check-docs:
     name: Check Docs
     timeout-minutes: 5

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,8 +27,6 @@ jobs:
         run: npm run build:types
       - name: Test Types
         run: npm run test:types
-      - name: Lint Types
-        run: npm run lint:types
   check-docs:
     name: Check Docs
     timeout-minutes: 5

--- a/src/CoreManager.ts
+++ b/src/CoreManager.ts
@@ -51,7 +51,7 @@ type ObjectController = {
     forceFetch: boolean,
     options: RequestOptions
   ) => Promise<Array<ParseObject | undefined> | ParseObject | undefined>,
-  save: (object: ParseObject | Array<ParseObject | ParseFile> | null, options: RequestOptions) => Promise<ParseObject | Array<ParseObject> | ParseFile>,
+  save: (object: ParseObject | Array<ParseObject | ParseFile> | null, options: RequestOptions) => Promise<ParseObject | Array<ParseObject> | ParseFile | undefined>,
   destroy: (object: ParseObject | Array<ParseObject>, options: RequestOptions) => Promise<ParseObject | Array<ParseObject>>,
 };
 type ObjectStateController = {

--- a/src/ObjectStateMutations.ts
+++ b/src/ObjectStateMutations.ts
@@ -1,15 +1,11 @@
-/**
- * @flow
- */
-
 import encode from './encode';
 import CoreManager from './CoreManager';
 import ParseFile from './ParseFile';
 import ParseRelation from './ParseRelation';
 import TaskQueue from './TaskQueue';
 import { RelationOp } from './ParseOp';
-
 import type { Op } from './ParseOp';
+import type ParseObject from './ParseObject';
 
 export type AttributeMap = { [attr: string]: any };
 export type OpsMap = { [attr: string]: Op };
@@ -43,7 +39,7 @@ export function setServerData(serverData: AttributeMap, attributes: AttributeMap
   }
 }
 
-export function setPendingOp(pendingOps: Array<OpsMap>, attr: string, op: ?Op) {
+export function setPendingOp(pendingOps: Array<OpsMap>, attr: string, op?: Op) {
   const last = pendingOps.length - 1;
   if (op) {
     pendingOps[last][attr] = op;
@@ -84,7 +80,7 @@ export function estimateAttribute(
   pendingOps: Array<OpsMap>,
   object: ParseObject,
   attr: string
-): mixed {
+): any {
   let value = serverData[attr];
   for (let i = 0; i < pendingOps.length; i++) {
     if (pendingOps[i][attr]) {

--- a/src/Parse.ts
+++ b/src/Parse.ts
@@ -43,8 +43,7 @@ import WebSocketController from './WebSocketController';
  * @global
  * @class
  * @hideconstructor
-*/
-
+ */
 interface ParseType {
   ACL: typeof ACL,
   Parse?: ParseType,

--- a/src/ParseGeoPoint.ts
+++ b/src/ParseGeoPoint.ts
@@ -180,9 +180,15 @@ class ParseGeoPoint {
    * Creates a GeoPoint with the user's current location, if available.
    *
    * @param {object} options The options.
-   * @param {boolean} [options.enableHighAccuracy=false] A boolean value that indicates the application would like to receive the best possible results. If true and if the device is able to provide a more accurate position, it will do so. Note that this can result in slower response times or increased power consumption (with a GPS chip on a mobile device for example). On the other hand, if false, the device can take the liberty to save resources by responding more quickly and/or using less power. Default: false.
-   * @param {number} [options.timeout=Infinity] A positive long value representing the maximum length of time (in milliseconds) the device is allowed to take in order to return a position. The default value is Infinity, meaning that getCurrentPosition() won't return until the position is available.
-   * @param {number} [options.maximumAge=0] A positive long value indicating the maximum age in milliseconds of a possible cached position that is acceptable to return. If set to 0, it means that the device cannot use a cached position and must attempt to retrieve the real current position. If set to Infinity the device must return a cached position regardless of its age. Default: 0.
+   * @param {boolean} [options.enableHighAccuracy=false] A boolean value that indicates the application would like to receive the best possible results.
+   *  If true and if the device is able to provide a more accurate position, it will do so.
+   *  Note that this can result in slower response times or increased power consumption (with a GPS chip on a mobile device for example).
+   *  On the other hand, if false, the device can take the liberty to save resources by responding more quickly and/or using less power. Default: false.
+   * @param {number} [options.timeout=Infinity] A positive long value representing the maximum length of time (in milliseconds) the device is allowed to take in order to return a position.
+   *  The default value is Infinity, meaning that getCurrentPosition() won't return until the position is available.
+   * @param {number} [options.maximumAge=0] A positive long value indicating the maximum age in milliseconds of a possible cached position that is acceptable to return.
+   *  If set to 0, it means that the device cannot use a cached position and must attempt to retrieve the real current position.
+   *  If set to Infinity the device must return a cached position regardless of its age. Default: 0.
    * @static
    * @returns {Promise<Parse.GeoPoint>} User's current location
    */

--- a/src/ParseHooks.ts
+++ b/src/ParseHooks.ts
@@ -13,52 +13,52 @@ export function getTriggers() {
   return CoreManager.getHooksController().get('triggers');
 }
 
-export function getFunction(name) {
+export function getFunction(name: string) {
   return CoreManager.getHooksController().get('functions', name);
 }
 
-export function getTrigger(className, triggerName) {
+export function getTrigger(className: string, triggerName: string) {
   return CoreManager.getHooksController().get('triggers', className, triggerName);
 }
 
-export function createFunction(functionName, url) {
+export function createFunction(functionName: string, url: string) {
   return create({ functionName: functionName, url: url });
 }
 
-export function createTrigger(className, triggerName, url) {
+export function createTrigger(className: string, triggerName: string, url: string) {
   return create({ className: className, triggerName: triggerName, url: url });
 }
 
-export function create(hook) {
+export function create(hook: HookDeclaration) {
   return CoreManager.getHooksController().create(hook);
 }
 
-export function updateFunction(functionName, url) {
+export function updateFunction(functionName: string, url: string) {
   return update({ functionName: functionName, url: url });
 }
 
-export function updateTrigger(className, triggerName, url) {
+export function updateTrigger(className: string, triggerName: string, url: string) {
   return update({ className: className, triggerName: triggerName, url: url });
 }
 
-export function update(hook) {
+export function update(hook: HookDeclaration) {
   return CoreManager.getHooksController().update(hook);
 }
 
-export function removeFunction(functionName) {
+export function removeFunction(functionName: string) {
   return remove({ functionName: functionName });
 }
 
-export function removeTrigger(className, triggerName) {
+export function removeTrigger(className: string, triggerName: string) {
   return remove({ className: className, triggerName: triggerName });
 }
 
-export function remove(hook) {
+export function remove(hook: HookDeleteArg) {
   return CoreManager.getHooksController().remove(hook);
 }
 
 const DefaultController = {
-  get(type, functionName, triggerName) {
+  get(type: string, functionName?: string, triggerName?: string) {
     let url = '/hooks/' + type;
     if (functionName) {
       url += '/' + functionName;
@@ -111,7 +111,7 @@ const DefaultController = {
     return this.sendRequest('PUT', url, hook);
   },
 
-  sendRequest(method, url, body) {
+  sendRequest(method: string, url: string, body?: any) {
     return CoreManager.getRESTController()
       .request(method, url, body, { useMasterKey: true })
       .then(res => {

--- a/src/ParseQuery.ts
+++ b/src/ParseQuery.ts
@@ -2171,6 +2171,7 @@ const DefaultController = {
   },
 };
 
+CoreManager.setParseQuery(ParseQuery);
 CoreManager.setQueryController(DefaultController);
 
 export default ParseQuery;

--- a/src/ParseQuery.ts
+++ b/src/ParseQuery.ts
@@ -1,7 +1,3 @@
-/*
- * @flow
- */
-
 import CoreManager from './CoreManager';
 import encode from './encode';
 import { continueWhile } from './promiseUtils';
@@ -14,10 +10,29 @@ import { DEFAULT_PIN } from './LocalDatastoreUtils';
 import type LiveQuerySubscription from './LiveQuerySubscription';
 import type { RequestOptions, FullOptions } from './RESTController';
 
-type BatchOptions = FullOptions & { batchSize?: number };
+type BatchOptions = FullOptions & {
+  batchSize?: number
+  useMasterKey?: boolean,
+  sessionToken?: string,
+  context?: { [key: string]: any },
+  json?: boolean
+};
 
 export type WhereClause = {
-  [attr: string]: mixed,
+  [attr: string]: any,
+};
+
+type QueryOptions = {
+  useMasterKey?: boolean,
+  sessionToken?: string,
+  context?: { [key: string]: any },
+  json?: boolean,
+};
+
+type FullTextQueryOptions = {
+  language?: string,
+  caseSensitive?: boolean,
+  diacriticSensitive?: boolean,
 };
 
 export type QueryJSON = {
@@ -31,7 +46,7 @@ export type QueryJSON = {
   order?: string,
   className?: string,
   count?: number,
-  hint?: mixed,
+  hint?: any,
   explain?: boolean,
   readPreference?: string,
   includeReadPreference?: string,
@@ -60,8 +75,8 @@ function quote(s: string): string {
  * @private
  * @returns {string}
  */
-function _getClassNameFromQueries(queries: Array<ParseQuery>): ?string {
-  let className = null;
+function _getClassNameFromQueries(queries: Array<ParseQuery>): string | null {
+  let className: string | null = null;
   queries.forEach(q => {
     if (!className) {
       className = q.className;
@@ -234,13 +249,13 @@ class ParseQuery {
   _skip: number;
   _count: boolean;
   _order: Array<string>;
-  _readPreference: string;
-  _includeReadPreference: string;
-  _subqueryReadPreference: string;
+  _readPreference: string | null;
+  _includeReadPreference: string | null;
+  _subqueryReadPreference: string | null;
   _queriesLocalDatastore: boolean;
   _localDatastorePinName: any;
-  _extraOptions: { [key: string]: mixed };
-  _hint: mixed;
+  _extraOptions: { [key: string]: any };
+  _hint: any;
   _explain: boolean;
   _xhrRequest: any;
   _comment: string;
@@ -258,10 +273,11 @@ class ParseQuery {
     } else if (objectClass instanceof ParseObject) {
       this.className = objectClass.className;
     } else if (typeof objectClass === 'function') {
-      if (typeof objectClass.className === 'string') {
-        this.className = objectClass.className;
+      const objClass = objectClass as any;
+      if (typeof objClass.className === 'string') {
+        this.className = objClass.className;
       } else {
-        const obj = new objectClass();
+        const obj = new objClass();
         this.className = obj.className;
       }
     } else {
@@ -341,7 +357,7 @@ class ParseQuery {
    * @param value
    * @returns {Parse.Query}
    */
-  _addCondition(key: string, condition: string, value: mixed): ParseQuery {
+  _addCondition(key: string, condition: string, value: any): ParseQuery {
     if (!this._where[key] || typeof this._where[key] === 'string') {
       this._where[key] = {};
     }
@@ -359,7 +375,7 @@ class ParseQuery {
     return '^' + quote(string);
   }
 
-  async _handleOfflineQuery(params: any) {
+  async _handleOfflineQuery(params: QueryJSON) {
     OfflineQuery.validateQuery(this);
     const localDatastore = CoreManager.getLocalDatastore();
     const objects = await localDatastore._serializeObjectsFromPinName(this._localDatastorePinName);
@@ -620,10 +636,10 @@ class ParseQuery {
    * @returns {Promise} A promise that is resolved with the result when
    * the query completes.
    */
-  get(objectId: string, options?: FullOptions): Promise<ParseObject> {
+  get(objectId: string, options?: QueryOptions): Promise<ParseObject> {
     this.equalTo('objectId', objectId);
 
-    const firstOptions = {};
+    const firstOptions: QueryOptions = {};
     if (options && options.hasOwnProperty('useMasterKey')) {
       firstOptions.useMasterKey = options.useMasterKey;
     }
@@ -662,10 +678,10 @@ class ParseQuery {
    * @returns {Promise} A promise that is resolved with the results when
    * the query completes.
    */
-  find(options?: FullOptions): Promise<Array<ParseObject>> {
+  find(options?: QueryOptions): Promise<Array<ParseObject>> {
     options = options || {};
 
-    const findOptions = {};
+    const findOptions: QueryOptions = {};
     if (options.hasOwnProperty('useMasterKey')) {
       findOptions.useMasterKey = options.useMasterKey;
     }
@@ -689,7 +705,7 @@ class ParseQuery {
       if (this._explain) {
         return response.results;
       }
-      const results = response.results.map(data => {
+      const results = response.results?.map(data => {
         // In cases of relations, the server may send back a className
         // on the top level of the payload
         const override = response.className || this.className;
@@ -713,7 +729,7 @@ class ParseQuery {
       const count = response.count;
 
       if (typeof count === 'number') {
-        return { results, count };
+        return { results, count } as any;
       } else {
         return results;
       }
@@ -755,10 +771,10 @@ class ParseQuery {
    * @returns {Promise} A promise that is resolved with the count when
    * the query completes.
    */
-  count(options?: FullOptions): Promise<number> {
+  count(options?: { useMasterKey?: boolean, sessionToken?: string }): Promise<number> {
     options = options || {};
 
-    const findOptions = {};
+    const findOptions: { useMasterKey?: boolean, sessionToken?: string } = {};
     if (options.hasOwnProperty('useMasterKey')) {
       findOptions.useMasterKey = options.useMasterKey;
     }
@@ -789,11 +805,10 @@ class ParseQuery {
    * </ul>
    * @returns {Promise} A promise that is resolved with the query completes.
    */
-  distinct(key: string, options?: FullOptions): Promise<Array<mixed>> {
+  distinct(key: string, options?: { sessionToken?: string }): Promise<Array<any>> {
     options = options || {};
 
-    const distinctOptions = {};
-    distinctOptions.useMasterKey = true;
+    const distinctOptions: { sessionToken?: string, useMasterKey: boolean } = { useMasterKey: true};
 
     if (options.hasOwnProperty('sessionToken')) {
       distinctOptions.sessionToken = options.sessionToken;
@@ -807,7 +822,7 @@ class ParseQuery {
       hint: this._hint,
     };
     return controller.aggregate(this.className, params, distinctOptions).then(results => {
-      return results.results;
+      return results.results!;
     });
   }
 
@@ -821,10 +836,9 @@ class ParseQuery {
    * </ul>
    * @returns {Promise} A promise that is resolved with the query completes.
    */
-  aggregate(pipeline: mixed, options?: FullOptions): Promise<Array<mixed>> {
+  aggregate(pipeline: any, options?: { sessionToken?: string }): Promise<Array<any>> {
     options = options || {};
-    const aggregateOptions = {};
-    aggregateOptions.useMasterKey = true;
+    const aggregateOptions: { sessionToken?: string, useMasterKey: boolean } = { useMasterKey: true };
 
     if (options.hasOwnProperty('sessionToken')) {
       aggregateOptions.sessionToken = options.sessionToken;
@@ -851,7 +865,7 @@ class ParseQuery {
       readPreference: this._readPreference,
     };
     return controller.aggregate(this.className, params, aggregateOptions).then(results => {
-      return results.results;
+      return results.results!;
     });
   }
 
@@ -871,10 +885,8 @@ class ParseQuery {
    * @returns {Promise} A promise that is resolved with the object when
    * the query completes.
    */
-  first(options?: FullOptions): Promise<ParseObject | void> {
-    options = options || {};
-
-    const findOptions = {};
+  first(options: QueryOptions = {}): Promise<ParseObject | void> {
+    const findOptions: QueryOptions = {};
     if (options.hasOwnProperty('useMasterKey')) {
       findOptions.useMasterKey = options.useMasterKey;
     }
@@ -903,7 +915,7 @@ class ParseQuery {
     }
 
     return controller.find(this.className, params, findOptions).then(response => {
-      const objects = response.results;
+      const objects = response.results!;
       if (!objects[0]) {
         return undefined;
       }
@@ -947,7 +959,7 @@ class ParseQuery {
    *     iteration has completed.
    */
   eachBatch(
-    callback: (objs: Array<ParseObject>) => Promise<*>,
+    callback: (objs: Array<ParseObject>) => void,
     options?: BatchOptions
   ): Promise<void> {
     options = options || {};
@@ -985,7 +997,7 @@ class ParseQuery {
 
     query.ascending('objectId');
 
-    const findOptions = {};
+    const findOptions: BatchOptions = {};
     if (options.hasOwnProperty('useMasterKey')) {
       findOptions.useMasterKey = options.useMasterKey;
     }
@@ -1000,7 +1012,7 @@ class ParseQuery {
     }
 
     let finished = false;
-    let previousResults = [];
+    let previousResults: ParseObject[] = [];
     return continueWhile(
       () => {
         return !finished;
@@ -1061,7 +1073,7 @@ class ParseQuery {
    * @param {(string|object)} value String or Object of index that should be used when executing query
    * @returns {Parse.Query} Returns the query, so you can chain this call.
    */
-  hint(value: mixed): ParseQuery {
+  hint(value: any): ParseQuery {
     if (typeof value === 'undefined') {
       delete this._hint;
     }
@@ -1109,7 +1121,7 @@ class ParseQuery {
     callback: (currentObject: ParseObject, index: number, query: ParseQuery) => any,
     options?: BatchOptions
   ): Promise<Array<any>> {
-    const array = [];
+    const array: ParseObject[] = [];
     let index = 0;
     await this.each(object => {
       return Promise.resolve(callback(object, index, this)).then(result => {
@@ -1197,7 +1209,7 @@ class ParseQuery {
     callback: (currentObject: ParseObject, index: number, query: ParseQuery) => boolean,
     options?: BatchOptions
   ): Promise<Array<ParseObject>> {
-    const array = [];
+    const array: ParseObject[] = [];
     let index = 0;
     await this.each(object => {
       return Promise.resolve(callback(object, index, this)).then(flag => {
@@ -1220,16 +1232,16 @@ class ParseQuery {
    * @param value The value that the Parse.Object must contain.
    * @returns {Parse.Query} Returns the query, so you can chain this call.
    */
-  equalTo(key: string | { [key: string]: any }, value: ?mixed): ParseQuery {
+  equalTo(key: string | { [key: string]: any }, value?: any): ParseQuery {
     if (key && typeof key === 'object') {
       Object.entries(key).forEach(([k, val]) => this.equalTo(k, val));
       return this;
     }
     if (typeof value === 'undefined') {
-      return this.doesNotExist(key);
+      return this.doesNotExist(key as string);
     }
 
-    this._where[key] = encode(value, false, true);
+    this._where[key as string] = encode(value, false, true);
     return this;
   }
 
@@ -1241,12 +1253,12 @@ class ParseQuery {
    * @param value The value that must not be equalled.
    * @returns {Parse.Query} Returns the query, so you can chain this call.
    */
-  notEqualTo(key: string | { [key: string]: any }, value: ?mixed): ParseQuery {
+  notEqualTo(key: string | { [key: string]: any }, value?: any): ParseQuery {
     if (key && typeof key === 'object') {
       Object.entries(key).forEach(([k, val]) => this.notEqualTo(k, val));
       return this;
     }
-    return this._addCondition(key, '$ne', value);
+    return this._addCondition(key as string, '$ne', value);
   }
 
   /**
@@ -1257,7 +1269,7 @@ class ParseQuery {
    * @param value The value that provides an upper bound.
    * @returns {Parse.Query} Returns the query, so you can chain this call.
    */
-  lessThan(key: string, value: mixed): ParseQuery {
+  lessThan(key: string, value: any): ParseQuery {
     return this._addCondition(key, '$lt', value);
   }
 
@@ -1269,7 +1281,7 @@ class ParseQuery {
    * @param value The value that provides an lower bound.
    * @returns {Parse.Query} Returns the query, so you can chain this call.
    */
-  greaterThan(key: string, value: mixed): ParseQuery {
+  greaterThan(key: string, value: any): ParseQuery {
     return this._addCondition(key, '$gt', value);
   }
 
@@ -1281,7 +1293,7 @@ class ParseQuery {
    * @param value The value that provides an upper bound.
    * @returns {Parse.Query} Returns the query, so you can chain this call.
    */
-  lessThanOrEqualTo(key: string, value: mixed): ParseQuery {
+  lessThanOrEqualTo(key: string, value: any): ParseQuery {
     return this._addCondition(key, '$lte', value);
   }
 
@@ -1293,7 +1305,7 @@ class ParseQuery {
    * @param {*} value The value that provides an lower bound.
    * @returns {Parse.Query} Returns the query, so you can chain this call.
    */
-  greaterThanOrEqualTo(key: string, value: mixed): ParseQuery {
+  greaterThanOrEqualTo(key: string, value: any): ParseQuery {
     return this._addCondition(key, '$gte', value);
   }
 
@@ -1305,7 +1317,7 @@ class ParseQuery {
    * @param {Array<*>} value The values that will match.
    * @returns {Parse.Query} Returns the query, so you can chain this call.
    */
-  containedIn(key: string, value: Array<mixed>): ParseQuery {
+  containedIn(key: string, value: Array<any>): ParseQuery {
     return this._addCondition(key, '$in', value);
   }
 
@@ -1317,7 +1329,7 @@ class ParseQuery {
    * @param {Array<*>} value The values that will not match.
    * @returns {Parse.Query} Returns the query, so you can chain this call.
    */
-  notContainedIn(key: string, value: Array<mixed>): ParseQuery {
+  notContainedIn(key: string, value: Array<any>): ParseQuery {
     return this._addCondition(key, '$nin', value);
   }
 
@@ -1329,7 +1341,7 @@ class ParseQuery {
    * @param {Array} values The values that will match.
    * @returns {Parse.Query} Returns the query, so you can chain this call.
    */
-  containedBy(key: string, values: Array<mixed>): ParseQuery {
+  containedBy(key: string, values: Array<any>): ParseQuery {
     return this._addCondition(key, '$containedBy', values);
   }
 
@@ -1341,7 +1353,7 @@ class ParseQuery {
    * @param {Array} values The values that will match.
    * @returns {Parse.Query} Returns the query, so you can chain this call.
    */
-  containsAll(key: string, values: Array<mixed>): ParseQuery {
+  containsAll(key: string, values: Array<any>): ParseQuery {
     return this._addCondition(key, '$all', values);
   }
 
@@ -1392,20 +1404,22 @@ class ParseQuery {
    * This may be slow for large datasets.
    *
    * @param {string} key The key that the string to match is stored in.
-   * @param {RegExp} regex The regular expression pattern to match.
+   * @param {RegExp | string} regex The regular expression pattern to match.
    * @param {string} modifiers The regular expression mode.
    * @returns {Parse.Query} Returns the query, so you can chain this call.
    */
-  matches(key: string, regex: RegExp, modifiers: string): ParseQuery {
+  matches(key: string, regex: RegExp | string, modifiers: string): ParseQuery {
     this._addCondition(key, '$regex', regex);
     if (!modifiers) {
       modifiers = '';
     }
-    if (regex.ignoreCase) {
-      modifiers += 'i';
-    }
-    if (regex.multiline) {
-      modifiers += 'm';
+    if (typeof regex !== 'string') {
+      if (regex.ignoreCase) {
+        modifiers += 'i';
+      }
+      if (regex.multiline) {
+        modifiers += 'm';
+      }
     }
     if (modifiers.length) {
       this._addCondition(key, '$options', modifiers);
@@ -1527,7 +1541,7 @@ class ParseQuery {
    * @param {boolean} options.diacriticSensitive A boolean flag to enable or disable diacritic sensitive search.
    * @returns {Parse.Query} Returns the query, so you can chain this call.
    */
-  fullText(key: string, value: string, options: ?Object): ParseQuery {
+  fullText(key: string, value: string, options: FullTextQueryOptions = {}): ParseQuery {
     options = options || {};
 
     if (!key) {
@@ -1540,7 +1554,7 @@ class ParseQuery {
       throw new Error('The value being searched for must be a string.');
     }
 
-    const fullOptions = {};
+    const fullOptions: { $term?: string, $language?: string, $caseSensitive?: boolean, $diacriticSensitive?: boolean } = {};
     fullOptions.$term = value;
 
     for (const option in options) {
@@ -1972,8 +1986,8 @@ class ParseQuery {
     subqueryReadPreference?: string
   ): ParseQuery {
     this._readPreference = readPreference;
-    this._includeReadPreference = includeReadPreference;
-    this._subqueryReadPreference = subqueryReadPreference;
+    this._includeReadPreference = includeReadPreference || null;
+    this._subqueryReadPreference = subqueryReadPreference || null;
     return this;
   }
 
@@ -1987,13 +2001,13 @@ class ParseQuery {
   async subscribe(sessionToken?: string): Promise<LiveQuerySubscription> {
     const currentUser = await CoreManager.getUserController().currentUserAsync();
     if (!sessionToken) {
-      sessionToken = currentUser ? currentUser.getSessionToken() : undefined;
+      sessionToken = currentUser ? currentUser.getSessionToken() || undefined : undefined;
     }
     const liveQueryClient = await CoreManager.getLiveQueryController().getDefaultLiveQueryClient();
     if (liveQueryClient.shouldOpen()) {
       liveQueryClient.open();
     }
-    const subscription = liveQueryClient.subscribe(this, sessionToken);
+    const subscription = liveQueryClient.subscribe(this, sessionToken!);
     return subscription.subscribePromise.then(() => {
       return subscription;
     });
@@ -2013,7 +2027,7 @@ class ParseQuery {
    */
   static or(...queries: Array<ParseQuery>): ParseQuery {
     const className = _getClassNameFromQueries(queries);
-    const query = new ParseQuery(className);
+    const query = new ParseQuery(className!);
     query._orQuery(queries);
     return query;
   }
@@ -2032,7 +2046,7 @@ class ParseQuery {
    */
   static and(...queries: Array<ParseQuery>): ParseQuery {
     const className = _getClassNameFromQueries(queries);
-    const query = new ParseQuery(className);
+    const query = new ParseQuery(className!);
     query._andQuery(queries);
     return query;
   }
@@ -2051,7 +2065,7 @@ class ParseQuery {
    */
   static nor(...queries: Array<ParseQuery>): ParseQuery {
     const className = _getClassNameFromQueries(queries);
-    const query = new ParseQuery(className);
+    const query = new ParseQuery(className!);
     query._norQuery(queries);
     return query;
   }
@@ -2091,7 +2105,7 @@ class ParseQuery {
    * @param {string} name The name of query source.
    * @returns {Parse.Query} Returns the query, so you can chain this call.
    */
-  fromPinWithName(name?: string): ParseQuery {
+  fromPinWithName(name?: string | null): ParseQuery {
     const localDatastore = CoreManager.getLocalDatastore();
     if (localDatastore.checkIfEnabled()) {
       this._queriesLocalDatastore = true;
@@ -2113,7 +2127,8 @@ class ParseQuery {
       this._xhrRequest.onchange = () => {};
       return this;
     }
-    return (this._xhrRequest.onchange = () => this.cancel());
+    this._xhrRequest.onchange = () => this.cancel();
+    return this;
   }
 
   _setRequestTask(options) {
@@ -2125,7 +2140,7 @@ class ParseQuery {
 
   /**
    * Sets a comment to the query so that the query
-   *can be identified when using a the profiler for MongoDB.
+   * can be identified when using a the profiler for MongoDB.
    *
    * @param {string} value a comment can make your profile data easier to interpret and trace.
    * @returns {Parse.Query} Returns the query, so you can chain this call.
@@ -2144,19 +2159,18 @@ class ParseQuery {
 }
 
 const DefaultController = {
-  find(className: string, params: QueryJSON, options: RequestOptions): Promise<Array<ParseObject>> {
+  find(className: string, params: QueryJSON, options: RequestOptions): Promise<{ results: Array<ParseObject> }> {
     const RESTController = CoreManager.getRESTController();
     return RESTController.request('GET', 'classes/' + className, params, options);
   },
 
-  aggregate(className: string, params: any, options: RequestOptions): Promise<Array<mixed>> {
+  aggregate(className: string, params: any, options: RequestOptions): Promise<{ results: Array<any> }> {
     const RESTController = CoreManager.getRESTController();
 
     return RESTController.request('GET', 'aggregate/' + className, params, options);
   },
 };
 
-CoreManager.setParseQuery(ParseQuery);
 CoreManager.setQueryController(DefaultController);
 
 export default ParseQuery;

--- a/src/ParseRole.ts
+++ b/src/ParseRole.ts
@@ -1,7 +1,3 @@
-/**
- * @flow
- */
-
 import CoreManager from './CoreManager';
 import ParseACL from './ParseACL';
 import ParseError from './ParseError';
@@ -43,7 +39,7 @@ class ParseRole extends ParseObject {
    *
    * @returns {string} the name of the role.
    */
-  getName(): ?string {
+  getName(): string | null {
     const name = this.get('name');
     if (name == null || typeof name === 'string') {
       return name;
@@ -68,7 +64,7 @@ class ParseRole extends ParseObject {
    *     callbacks.
    * @returns {(ParseObject|boolean)} true if the set succeeded.
    */
-  setName(name: string, options?: mixed): ParseObject | boolean {
+  setName(name: string, options?: any): ParseObject | boolean {
     this._validateName(name);
     return this.set('name', name, options);
   }
@@ -115,8 +111,8 @@ class ParseRole extends ParseObject {
     }
   }
 
-  validate(attrs: AttributeMap, options?: mixed): ParseError | boolean {
-    const isInvalid = super.validate(attrs, options);
+  validate(attrs: AttributeMap, options?: any): ParseError | boolean {
+    const isInvalid = (super.validate as typeof this['validate'])(attrs, options);
     if (isInvalid) {
       return isInvalid;
     }

--- a/src/ParseUser.ts
+++ b/src/ParseUser.ts
@@ -1246,7 +1246,7 @@ const DefaultController = {
 
     const RESTController = CoreManager.getRESTController();
     const result = await RESTController.request('POST', 'upgradeToRevocableSession', {}, options);
-    user._finishFetch({ sessionToken: result.sessionToken });
+    user._finishFetch({ sessionToken: result?.sessionToken || '' });
     const current = await user.isCurrentAsync();
     if (current) {
       return DefaultController.setCurrentUser(user);

--- a/src/ParseUser.ts
+++ b/src/ParseUser.ts
@@ -2,7 +2,6 @@ import CoreManager from './CoreManager';
 import isRevocableSession from './isRevocableSession';
 import ParseError from './ParseError';
 import ParseObject from './ParseObject';
-import ParseSession from './ParseSession';
 import Storage from './Storage';
 
 import type { AttributeMap } from './ObjectStateMutations';
@@ -1247,9 +1246,7 @@ const DefaultController = {
 
     const RESTController = CoreManager.getRESTController();
     const result = await RESTController.request('POST', 'upgradeToRevocableSession', {}, options);
-    const session = new ParseSession();
-    session._finishFetch(result);
-    user._finishFetch({ sessionToken: session.getSessionToken() });
+    user._finishFetch({ sessionToken: result.sessionToken });
     const current = await user.isCurrentAsync();
     if (current) {
       return DefaultController.setCurrentUser(user);

--- a/src/Push.ts
+++ b/src/Push.ts
@@ -1,10 +1,7 @@
-/**
- * @flow
- */
-
 import CoreManager from './CoreManager';
 import ParseQuery from './ParseQuery';
 
+import type ParseObject from './ParseObject';
 import type { WhereClause } from './ParseQuery';
 import type { FullOptions } from './RESTController';
 
@@ -49,9 +46,9 @@ export type PushData = {
  *     be used for this request.
  * </ul>
  * @returns {Promise} A promise that is fulfilled when the push request
- *     completes.
+ *     completes and returns `pushStatusId`.
  */
-export function send(data: PushData, options?: FullOptions = {}): Promise {
+export function send(data: PushData, options: FullOptions = {}): Promise<string> {
   if (data.where && data.where instanceof ParseQuery) {
     data.where = data.where.toJSON().where;
   }
@@ -89,7 +86,7 @@ export function send(data: PushData, options?: FullOptions = {}): Promise {
  * </ul>
  * @returns {Parse.Object} Status of Push.
  */
-export function getPushStatus(pushStatusId: string, options?: FullOptions = {}): Promise<string> {
+export function getPushStatus(pushStatusId: string, options: FullOptions = {}): Promise<ParseObject> {
   const pushOptions = { useMasterKey: true };
   if (options.hasOwnProperty('useMasterKey')) {
     pushOptions.useMasterKey = options.useMasterKey;

--- a/src/TaskQueue.ts
+++ b/src/TaskQueue.ts
@@ -1,11 +1,8 @@
-/**
- * @flow
- */
 import { resolvingPromise } from './promiseUtils';
 
 type Task = {
-  task: () => Promise,
-  _completion: Promise,
+  task: () => Promise<void>,
+  _completion: any,
 };
 
 class TaskQueue {
@@ -15,8 +12,8 @@ class TaskQueue {
     this.queue = [];
   }
 
-  enqueue(task: () => Promise): Promise {
-    const taskComplete = new resolvingPromise();
+  enqueue(task: () => Promise<void>): Promise<void> {
+    const taskComplete = resolvingPromise<void>();
     this.queue.push({
       task: task,
       _completion: taskComplete,
@@ -55,3 +52,4 @@ class TaskQueue {
 }
 
 module.exports = TaskQueue;
+export default TaskQueue;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,6 +2,7 @@
   "compilerOptions": {
     "module": "commonjs",
     "target": "es2015",
+    "lib": ["dom"],
     "declaration": true,
     "emitDeclarationOnly": true,
     "outDir": "types",

--- a/types/CoreManager.d.ts
+++ b/types/CoreManager.d.ts
@@ -60,7 +60,7 @@ type InstallationController = {
 };
 type ObjectController = {
     fetch: (object: ParseObject | Array<ParseObject>, forceFetch: boolean, options: RequestOptions) => Promise<Array<ParseObject | undefined> | ParseObject | undefined>;
-    save: (object: ParseObject | Array<ParseObject | ParseFile> | null, options: RequestOptions) => Promise<ParseObject | Array<ParseObject> | ParseFile>;
+    save: (object: ParseObject | Array<ParseObject | ParseFile> | null, options: RequestOptions) => Promise<ParseObject | Array<ParseObject> | ParseFile | undefined>;
     destroy: (object: ParseObject | Array<ParseObject>, options: RequestOptions) => Promise<ParseObject | Array<ParseObject>>;
 };
 type ObjectStateController = {

--- a/types/ObjectStateMutations.d.ts
+++ b/types/ObjectStateMutations.d.ts
@@ -1,28 +1,28 @@
-// @ts-nocheck
-export function defaultState(): State;
-export function setServerData(serverData: AttributeMap, attributes: AttributeMap): void;
-export function setPendingOp(pendingOps: Array<OpsMap>, attr: string, op: Op | null): void;
-export function pushPendingState(pendingOps: Array<OpsMap>): void;
-export function popPendingState(pendingOps: Array<OpsMap>): OpsMap;
-export function mergeFirstPendingState(pendingOps: Array<OpsMap>): void;
-export function estimateAttribute(serverData: AttributeMap, pendingOps: Array<OpsMap>, className: string, id: string | null, attr: string): mixed;
-export function estimateAttributes(serverData: AttributeMap, pendingOps: Array<OpsMap>, className: string, id: string | null): AttributeMap;
-export function commitServerChanges(serverData: AttributeMap, objectCache: ObjectCache, changes: AttributeMap): void;
-type AttributeMap = {
+import TaskQueue from './TaskQueue';
+import type { Op } from './ParseOp';
+import type ParseObject from './ParseObject';
+export type AttributeMap = {
     [attr: string]: any;
 };
-type OpsMap = {
+export type OpsMap = {
     [attr: string]: Op;
 };
-type ObjectCache = {
+export type ObjectCache = {
     [attr: string]: string;
 };
-type State = {
+export type State = {
     serverData: AttributeMap;
-    pendingOps: OpsMap[];
+    pendingOps: Array<OpsMap>;
     objectCache: ObjectCache;
     tasks: TaskQueue;
     existed: boolean;
 };
-import { Op } from './ParseOp';
-export {};
+export declare function defaultState(): State;
+export declare function setServerData(serverData: AttributeMap, attributes: AttributeMap): void;
+export declare function setPendingOp(pendingOps: Array<OpsMap>, attr: string, op?: Op): void;
+export declare function pushPendingState(pendingOps: Array<OpsMap>): void;
+export declare function popPendingState(pendingOps: Array<OpsMap>): OpsMap;
+export declare function mergeFirstPendingState(pendingOps: Array<OpsMap>): void;
+export declare function estimateAttribute(serverData: AttributeMap, pendingOps: Array<OpsMap>, object: ParseObject, attr: string): any;
+export declare function estimateAttributes(serverData: AttributeMap, pendingOps: Array<OpsMap>, object: ParseObject): AttributeMap;
+export declare function commitServerChanges(serverData: AttributeMap, objectCache: ObjectCache, changes: AttributeMap): void;

--- a/types/Parse.d.ts
+++ b/types/Parse.d.ts
@@ -32,7 +32,7 @@ import LiveQueryClient from './LiveQueryClient';
  * @global
  * @class
  * @hideconstructor
-*/
+ */
 interface ParseType {
     ACL: typeof ACL;
     Parse?: ParseType;

--- a/types/ParseFile.d.ts
+++ b/types/ParseFile.d.ts
@@ -1,18 +1,32 @@
-// @ts-nocheck
-type FileSource = {
-    format: "file";
+import type { FullOptions } from './RESTController';
+type Base64 = {
+    base64: string;
+};
+type Uri = {
+    uri: string;
+};
+type FileData = Array<number> | Base64 | Blob | Uri;
+export type FileSaveOptions = FullOptions & {
+    metadata?: {
+        [key: string]: any;
+    };
+    tags?: {
+        [key: string]: any;
+    };
+};
+export type FileSource = {
+    format: 'file';
     file: Blob;
     type: string;
 } | {
-    format: "base64";
+    format: 'base64';
     base64: string;
     type: string;
 } | {
-    format: "uri";
+    format: 'uri';
     uri: string;
     type: string;
 };
-export default ParseFile;
 /**
  * A Parse.File is a local representation of a file that is saved to the Parse
  * cloud.
@@ -20,8 +34,14 @@ export default ParseFile;
  * @alias Parse.File
  */
 declare class ParseFile {
-    static fromJSON(obj: any): ParseFile;
-    static encodeBase64(bytes: Array<number>): string;
+    _name: string;
+    _url?: string;
+    _source: FileSource;
+    _previousSave?: Promise<ParseFile>;
+    _data?: string;
+    _requestTask?: any;
+    _metadata?: Object;
+    _tags?: Object;
     /**
      * @param name {String} The file's name. This will be prefixed by a unique
      *     value once the file has finished saving. The file name must begin with
@@ -53,14 +73,6 @@ declare class ParseFile {
      * @param tags {Object} Optional key value pairs to be stored with file object
      */
     constructor(name: string, data?: FileData, type?: string, metadata?: Object, tags?: Object);
-    _name: string;
-    _url: string | null;
-    _source: FileSource;
-    _previousSave: Promise<ParseFile> | null;
-    _data: string | null;
-    _requestTask: any | null;
-    _metadata: Object | null;
-    _tags: Object | null;
     /**
      * Return the data for the file, downloading it if not already present.
      * Data is present if initialized with Byte Array, Base64 or Saved with Uri.
@@ -68,7 +80,7 @@ declare class ParseFile {
      *
      * @returns {Promise} Promise that is resolve with base64 data
      */
-    getData(): Promise<String>;
+    getData(): Promise<string>;
     /**
      * Gets the name of the file. Before save is called, this is the filename
      * given by the user. After save is called, that name gets prefixed with a
@@ -86,7 +98,7 @@ declare class ParseFile {
      */
     url(options?: {
         forceSecure?: boolean;
-    }): string | null;
+    }): string | undefined;
     /**
      * Gets the metadata of the file.
      *
@@ -122,7 +134,7 @@ declare class ParseFile {
      * </ul>
      * @returns {Promise | undefined} Promise that is resolved when the save finishes.
      */
-    save(options?: FullOptions): Promise | null;
+    save(options?: FileSaveOptions): Promise<ParseFile> | undefined;
     /**
      * Aborts the request if it has already been sent.
      */
@@ -138,12 +150,13 @@ declare class ParseFile {
      * <pre>
      * @returns {Promise} Promise that is resolved when the delete finishes.
      */
-    destroy(options?: FullOptions): Promise<any>;
+    destroy(options?: FullOptions): Promise<this>;
     toJSON(): {
-        name: string | null;
-        url: string | null;
+        __type: 'File';
+        name?: string;
+        url?: string;
     };
-    equals(other: mixed): boolean;
+    equals(other: any): boolean;
     /**
      * Sets metadata to be saved with file object. Overwrites existing metadata
      *
@@ -170,12 +183,7 @@ declare class ParseFile {
      * @param {*} value tag
      */
     addTag(key: string, value: string): void;
+    static fromJSON(obj: any): ParseFile;
+    static encodeBase64(bytes: Array<number> | Uint8Array): string;
 }
-import { FullOptions } from './RESTController';
-type FileData = number[] | Blob | Base64 | Uri;
-type Base64 = {
-    base64: string;
-};
-type Uri = {
-    uri: string;
-};
+export default ParseFile;

--- a/types/ParseGeoPoint.d.ts
+++ b/types/ParseGeoPoint.d.ts
@@ -87,9 +87,15 @@ declare class ParseGeoPoint {
      * Creates a GeoPoint with the user's current location, if available.
      *
      * @param {object} options The options.
-     * @param {boolean} [options.enableHighAccuracy=false] A boolean value that indicates the application would like to receive the best possible results. If true and if the device is able to provide a more accurate position, it will do so. Note that this can result in slower response times or increased power consumption (with a GPS chip on a mobile device for example). On the other hand, if false, the device can take the liberty to save resources by responding more quickly and/or using less power. Default: false.
-     * @param {number} [options.timeout=Infinity] A positive long value representing the maximum length of time (in milliseconds) the device is allowed to take in order to return a position. The default value is Infinity, meaning that getCurrentPosition() won't return until the position is available.
-     * @param {number} [options.maximumAge=0] A positive long value indicating the maximum age in milliseconds of a possible cached position that is acceptable to return. If set to 0, it means that the device cannot use a cached position and must attempt to retrieve the real current position. If set to Infinity the device must return a cached position regardless of its age. Default: 0.
+     * @param {boolean} [options.enableHighAccuracy=false] A boolean value that indicates the application would like to receive the best possible results.
+     *  If true and if the device is able to provide a more accurate position, it will do so.
+     *  Note that this can result in slower response times or increased power consumption (with a GPS chip on a mobile device for example).
+     *  On the other hand, if false, the device can take the liberty to save resources by responding more quickly and/or using less power. Default: false.
+     * @param {number} [options.timeout=Infinity] A positive long value representing the maximum length of time (in milliseconds) the device is allowed to take in order to return a position.
+     *  The default value is Infinity, meaning that getCurrentPosition() won't return until the position is available.
+     * @param {number} [options.maximumAge=0] A positive long value indicating the maximum age in milliseconds of a possible cached position that is acceptable to return.
+     *  If set to 0, it means that the device cannot use a cached position and must attempt to retrieve the real current position.
+     *  If set to Infinity the device must return a cached position regardless of its age. Default: 0.
      * @static
      * @returns {Promise<Parse.GeoPoint>} User's current location
      */

--- a/types/ParseHooks.d.ts
+++ b/types/ParseHooks.d.ts
@@ -1,0 +1,27 @@
+export type HookDeclaration = {
+    functionName: string;
+    url: string;
+} | {
+    className: string;
+    triggerName: string;
+    url: string;
+};
+export type HookDeleteArg = {
+    functionName: string;
+} | {
+    className: string;
+    triggerName: string;
+};
+export declare function getFunctions(): Promise<any>;
+export declare function getTriggers(): Promise<any>;
+export declare function getFunction(name: string): Promise<any>;
+export declare function getTrigger(className: string, triggerName: string): Promise<any>;
+export declare function createFunction(functionName: string, url: string): Promise<any>;
+export declare function createTrigger(className: string, triggerName: string, url: string): Promise<any>;
+export declare function create(hook: HookDeclaration): Promise<any>;
+export declare function updateFunction(functionName: string, url: string): Promise<any>;
+export declare function updateTrigger(className: string, triggerName: string, url: string): Promise<any>;
+export declare function update(hook: HookDeclaration): Promise<any>;
+export declare function removeFunction(functionName: string): Promise<any>;
+export declare function removeTrigger(className: string, triggerName: string): Promise<any>;
+export declare function remove(hook: HookDeleteArg): Promise<any>;

--- a/types/ParseObject.d.ts
+++ b/types/ParseObject.d.ts
@@ -1,5 +1,6 @@
 import ParseACL from './ParseACL';
 import ParseError from './ParseError';
+import ParseFile from './ParseFile';
 import { Op } from './ParseOp';
 import ParseRelation from './ParseRelation';
 import type { AttributeMap, OpsMap } from './ObjectStateMutations';
@@ -824,7 +825,7 @@ declare class ParseObject {
      * @static
      * @returns {Parse.Object[]}
      */
-    static saveAll(list: Array<ParseObject>, options?: SaveOptions): Promise<any>;
+    static saveAll(list: Array<ParseObject>, options?: SaveOptions): Promise<ParseFile | ParseObject | ParseObject[]>;
     /**
      * Creates a reference to a subclass of Parse.Object with the given id. This
      * does not exist on Parse.Object, only on subclasses.

--- a/types/ParseQuery.d.ts
+++ b/types/ParseQuery.d.ts
@@ -1,8 +1,33 @@
-// @ts-nocheck
-type WhereClause = {
-    [attr: string]: mixed;
+import ParseGeoPoint from './ParseGeoPoint';
+import ParseObject from './ParseObject';
+import type LiveQuerySubscription from './LiveQuerySubscription';
+import type { FullOptions } from './RESTController';
+type BatchOptions = FullOptions & {
+    batchSize?: number;
+    useMasterKey?: boolean;
+    sessionToken?: string;
+    context?: {
+        [key: string]: any;
+    };
+    json?: boolean;
 };
-type QueryJSON = {
+export type WhereClause = {
+    [attr: string]: any;
+};
+type QueryOptions = {
+    useMasterKey?: boolean;
+    sessionToken?: string;
+    context?: {
+        [key: string]: any;
+    };
+    json?: boolean;
+};
+type FullTextQueryOptions = {
+    language?: string;
+    caseSensitive?: boolean;
+    diacriticSensitive?: boolean;
+};
+export type QueryJSON = {
     where: WhereClause;
     watch?: string;
     include?: string;
@@ -13,14 +38,13 @@ type QueryJSON = {
     order?: string;
     className?: string;
     count?: number;
-    hint?: mixed;
+    hint?: any;
     explain?: boolean;
     readPreference?: string;
     includeReadPreference?: string;
     subqueryReadPreference?: string;
-    comment?: string,
+    comment?: string;
 };
-export default ParseQuery;
 /**
  * Creates a new parse Parse.Query for the given Parse.Object subclass.
  *
@@ -66,58 +90,6 @@ export default ParseQuery;
  */
 declare class ParseQuery {
     /**
-     * Static method to restore Parse.Query by json representation
-     * Internally calling Parse.Query.withJSON
-     *
-     * @param {string} className
-     * @param {QueryJSON} json from Parse.Query.toJSON() method
-     * @returns {Parse.Query} new created query
-     */
-    static fromJSON(className: string, json: QueryJSON): ParseQuery;
-    /**
-     * Constructs a Parse.Query that is the OR of the passed in queries.  For
-     * example:
-     * <pre>var compoundQuery = Parse.Query.or(query1, query2, query3);</pre>
-     *
-     * will create a compoundQuery that is an or of the query1, query2, and
-     * query3.
-     *
-     * @param {...Parse.Query} queries The list of queries to OR.
-     * @static
-     * @returns {Parse.Query} The query that is the OR of the passed in queries.
-     */
-    static or(...queries: Array<ParseQuery>): ParseQuery;
-    /**
-     * Constructs a Parse.Query that is the AND of the passed in queries.  For
-     * example:
-     * <pre>var compoundQuery = Parse.Query.and(query1, query2, query3);</pre>
-     *
-     * will create a compoundQuery that is an and of the query1, query2, and
-     * query3.
-     *
-     * @param {...Parse.Query} queries The list of queries to AND.
-     * @static
-     * @returns {Parse.Query} The query that is the AND of the passed in queries.
-     */
-    static and(...queries: Array<ParseQuery>): ParseQuery;
-    /**
-     * Constructs a Parse.Query that is the NOR of the passed in queries.  For
-     * example:
-     * <pre>const compoundQuery = Parse.Query.nor(query1, query2, query3);</pre>
-     *
-     * will create a compoundQuery that is a nor of the query1, query2, and
-     * query3.
-     *
-     * @param {...Parse.Query} queries The list of queries to NOR.
-     * @static
-     * @returns {Parse.Query} The query that is the NOR of the passed in queries.
-     */
-    static nor(...queries: Array<ParseQuery>): ParseQuery;
-    /**
-     * @param {(string | Parse.Object)} objectClass An instance of a subclass of Parse.Object, or a Parse className string.
-     */
-    constructor(objectClass: string | ParseObject);
-    /**
      * @property {string} className
      */
     className: string;
@@ -130,18 +102,22 @@ declare class ParseQuery {
     _skip: number;
     _count: boolean;
     _order: Array<string>;
-    _readPreference: string;
-    _includeReadPreference: string;
-    _subqueryReadPreference: string;
+    _readPreference: string | null;
+    _includeReadPreference: string | null;
+    _subqueryReadPreference: string | null;
     _queriesLocalDatastore: boolean;
     _localDatastorePinName: any;
     _extraOptions: {
-        [key: string]: mixed;
+        [key: string]: any;
     };
-    _hint: mixed;
+    _hint: any;
     _explain: boolean;
     _xhrRequest: any;
     _comment: string;
+    /**
+     * @param {(string | Parse.Object)} objectClass An instance of a subclass of Parse.Object, or a Parse className string.
+     */
+    constructor(objectClass: string | ParseObject);
     /**
      * Adds constraint that at least one of the passed in queries matches.
      *
@@ -171,7 +147,7 @@ declare class ParseQuery {
      * @param value
      * @returns {Parse.Query}
      */
-    _addCondition(key: string, condition: string, value: mixed): ParseQuery;
+    _addCondition(key: string, condition: string, value: any): ParseQuery;
     /**
      * Converts string for regular expression at the beginning
      *
@@ -179,7 +155,7 @@ declare class ParseQuery {
      * @returns {string}
      */
     _regexStartWith(string: string): string;
-    _handleOfflineQuery(params: any): Promise<any>;
+    _handleOfflineQuery(params: QueryJSON): Promise<any>;
     /**
      * Returns a JSON representation of this query.
      *
@@ -209,6 +185,15 @@ declare class ParseQuery {
      */
     withJSON(json: QueryJSON): ParseQuery;
     /**
+     * Static method to restore Parse.Query by json representation
+     * Internally calling Parse.Query.withJSON
+     *
+     * @param {string} className
+     * @param {QueryJSON} json from Parse.Query.toJSON() method
+     * @returns {Parse.Query} new created query
+     */
+    static fromJSON(className: string, json: QueryJSON): ParseQuery;
+    /**
      * Constructs a Parse.Object whose id is already known by fetching data from
      * the server. Unlike the <code>first</code> method, it never returns undefined.
      *
@@ -225,7 +210,7 @@ declare class ParseQuery {
      * @returns {Promise} A promise that is resolved with the result when
      * the query completes.
      */
-    get(objectId: string, options?: FullOptions): Promise<ParseObject>;
+    get(objectId: string, options?: QueryOptions): Promise<ParseObject>;
     /**
      * Retrieves a list of ParseObjects that satisfy this query.
      *
@@ -241,7 +226,7 @@ declare class ParseQuery {
      * @returns {Promise} A promise that is resolved with the results when
      * the query completes.
      */
-    find(options?: FullOptions): Promise<Array<ParseObject>>;
+    find(options?: QueryOptions): Promise<Array<ParseObject>>;
     /**
      * Retrieves a complete list of ParseObjects that satisfy this query.
      * Using `eachBatch` under the hood to fetch all the valid objects.
@@ -270,7 +255,10 @@ declare class ParseQuery {
      * @returns {Promise} A promise that is resolved with the count when
      * the query completes.
      */
-    count(options?: FullOptions): Promise<number>;
+    count(options?: {
+        useMasterKey?: boolean;
+        sessionToken?: string;
+    }): Promise<number>;
     /**
      * Executes a distinct query and returns unique values
      *
@@ -282,7 +270,9 @@ declare class ParseQuery {
      * </ul>
      * @returns {Promise} A promise that is resolved with the query completes.
      */
-    distinct(key: string, options?: FullOptions): Promise<Array<mixed>>;
+    distinct(key: string, options?: {
+        sessionToken?: string;
+    }): Promise<Array<any>>;
     /**
      * Executes an aggregate query and returns aggregate results
      *
@@ -293,7 +283,9 @@ declare class ParseQuery {
      * </ul>
      * @returns {Promise} A promise that is resolved with the query completes.
      */
-    aggregate(pipeline: mixed, options?: FullOptions): Promise<Array<mixed>>;
+    aggregate(pipeline: any, options?: {
+        sessionToken?: string;
+    }): Promise<Array<any>>;
     /**
      * Retrieves at most one Parse.Object that satisfies this query.
      *
@@ -310,7 +302,7 @@ declare class ParseQuery {
      * @returns {Promise} A promise that is resolved with the object when
      * the query completes.
      */
-    first(options?: FullOptions): Promise<ParseObject | void>;
+    first(options?: QueryOptions): Promise<ParseObject | void>;
     /**
      * Iterates over objects matching a query, calling a callback for each batch.
      * If the callback returns a promise, the iteration will not continue until
@@ -332,7 +324,7 @@ declare class ParseQuery {
      * @returns {Promise} A promise that will be fulfilled once the
      *     iteration has completed.
      */
-    eachBatch(callback: (objs: Array<ParseObject>) => Promise<any>, options?: BatchOptions): Promise<void>;
+    eachBatch(callback: (objs: Array<ParseObject>) => void, options?: BatchOptions): Promise<void>;
     /**
      * Iterates over each result of a query, calling a callback for each one. If
      * the callback returns a promise, the iteration will not continue until
@@ -360,7 +352,7 @@ declare class ParseQuery {
      * @param {(string|object)} value String or Object of index that should be used when executing query
      * @returns {Parse.Query} Returns the query, so you can chain this call.
      */
-    hint(value: mixed): ParseQuery;
+    hint(value: any): ParseQuery;
     /**
      * Investigates the query execution plan. Useful for optimizing queries. (https://docs.mongodb.com/manual/reference/operator/meta/explain/)
      *
@@ -448,7 +440,7 @@ declare class ParseQuery {
      */
     equalTo(key: string | {
         [key: string]: any;
-    }, value: mixed): ParseQuery;
+    }, value?: any): ParseQuery;
     /**
      * Adds a constraint to the query that requires a particular key's value to
      * be not equal to the provided value.
@@ -459,7 +451,7 @@ declare class ParseQuery {
      */
     notEqualTo(key: string | {
         [key: string]: any;
-    }, value: mixed): ParseQuery;
+    }, value?: any): ParseQuery;
     /**
      * Adds a constraint to the query that requires a particular key's value to
      * be less than the provided value.
@@ -468,7 +460,7 @@ declare class ParseQuery {
      * @param value The value that provides an upper bound.
      * @returns {Parse.Query} Returns the query, so you can chain this call.
      */
-    lessThan(key: string, value: mixed): ParseQuery;
+    lessThan(key: string, value: any): ParseQuery;
     /**
      * Adds a constraint to the query that requires a particular key's value to
      * be greater than the provided value.
@@ -477,7 +469,7 @@ declare class ParseQuery {
      * @param value The value that provides an lower bound.
      * @returns {Parse.Query} Returns the query, so you can chain this call.
      */
-    greaterThan(key: string, value: mixed): ParseQuery;
+    greaterThan(key: string, value: any): ParseQuery;
     /**
      * Adds a constraint to the query that requires a particular key's value to
      * be less than or equal to the provided value.
@@ -486,7 +478,7 @@ declare class ParseQuery {
      * @param value The value that provides an upper bound.
      * @returns {Parse.Query} Returns the query, so you can chain this call.
      */
-    lessThanOrEqualTo(key: string, value: mixed): ParseQuery;
+    lessThanOrEqualTo(key: string, value: any): ParseQuery;
     /**
      * Adds a constraint to the query that requires a particular key's value to
      * be greater than or equal to the provided value.
@@ -495,7 +487,7 @@ declare class ParseQuery {
      * @param {*} value The value that provides an lower bound.
      * @returns {Parse.Query} Returns the query, so you can chain this call.
      */
-    greaterThanOrEqualTo(key: string, value: mixed): ParseQuery;
+    greaterThanOrEqualTo(key: string, value: any): ParseQuery;
     /**
      * Adds a constraint to the query that requires a particular key's value to
      * be contained in the provided list of values.
@@ -504,7 +496,7 @@ declare class ParseQuery {
      * @param {Array<*>} value The values that will match.
      * @returns {Parse.Query} Returns the query, so you can chain this call.
      */
-    containedIn(key: string, value: Array<mixed>): ParseQuery;
+    containedIn(key: string, value: Array<any>): ParseQuery;
     /**
      * Adds a constraint to the query that requires a particular key's value to
      * not be contained in the provided list of values.
@@ -513,7 +505,7 @@ declare class ParseQuery {
      * @param {Array<*>} value The values that will not match.
      * @returns {Parse.Query} Returns the query, so you can chain this call.
      */
-    notContainedIn(key: string, value: Array<mixed>): ParseQuery;
+    notContainedIn(key: string, value: Array<any>): ParseQuery;
     /**
      * Adds a constraint to the query that requires a particular key's value to
      * be contained by the provided list of values. Get objects where all array elements match.
@@ -522,7 +514,7 @@ declare class ParseQuery {
      * @param {Array} values The values that will match.
      * @returns {Parse.Query} Returns the query, so you can chain this call.
      */
-    containedBy(key: string, values: Array<mixed>): ParseQuery;
+    containedBy(key: string, values: Array<any>): ParseQuery;
     /**
      * Adds a constraint to the query that requires a particular key's value to
      * contain each one of the provided list of values.
@@ -531,7 +523,7 @@ declare class ParseQuery {
      * @param {Array} values The values that will match.
      * @returns {Parse.Query} Returns the query, so you can chain this call.
      */
-    containsAll(key: string, values: Array<mixed>): ParseQuery;
+    containsAll(key: string, values: Array<any>): ParseQuery;
     /**
      * Adds a constraint to the query that requires a particular key's value to
      * contain each one of the provided list of values starting with given strings.
@@ -561,11 +553,11 @@ declare class ParseQuery {
      * This may be slow for large datasets.
      *
      * @param {string} key The key that the string to match is stored in.
-     * @param {RegExp} regex The regular expression pattern to match.
+     * @param {RegExp | string} regex The regular expression pattern to match.
      * @param {string} modifiers The regular expression mode.
      * @returns {Parse.Query} Returns the query, so you can chain this call.
      */
-    matches(key: string, regex: RegExp, modifiers: string): ParseQuery;
+    matches(key: string, regex: RegExp | string, modifiers: string): ParseQuery;
     /**
      * Adds a constraint that requires that a key's value matches a Parse.Query
      * constraint.
@@ -648,13 +640,13 @@ declare class ParseQuery {
      * @param {boolean} options.diacriticSensitive A boolean flag to enable or disable diacritic sensitive search.
      * @returns {Parse.Query} Returns the query, so you can chain this call.
      */
-    fullText(key: string, value: string, options: Object | null): ParseQuery;
+    fullText(key: string, value: string, options?: FullTextQueryOptions): ParseQuery;
     /**
      * Method to sort the full text search by text score
      *
      * @returns {Parse.Query} Returns the query, so you can chain this call.
      */
-    sortByTextScore(): Parse.Query;
+    sortByTextScore(): this;
     /**
      * Adds a constraint for finding string values that start with a provided
      * string.  This query will use the backend index, so it will be fast even
@@ -886,6 +878,45 @@ declare class ParseQuery {
      */
     subscribe(sessionToken?: string): Promise<LiveQuerySubscription>;
     /**
+     * Constructs a Parse.Query that is the OR of the passed in queries.  For
+     * example:
+     * <pre>var compoundQuery = Parse.Query.or(query1, query2, query3);</pre>
+     *
+     * will create a compoundQuery that is an or of the query1, query2, and
+     * query3.
+     *
+     * @param {...Parse.Query} queries The list of queries to OR.
+     * @static
+     * @returns {Parse.Query} The query that is the OR of the passed in queries.
+     */
+    static or(...queries: Array<ParseQuery>): ParseQuery;
+    /**
+     * Constructs a Parse.Query that is the AND of the passed in queries.  For
+     * example:
+     * <pre>var compoundQuery = Parse.Query.and(query1, query2, query3);</pre>
+     *
+     * will create a compoundQuery that is an and of the query1, query2, and
+     * query3.
+     *
+     * @param {...Parse.Query} queries The list of queries to AND.
+     * @static
+     * @returns {Parse.Query} The query that is the AND of the passed in queries.
+     */
+    static and(...queries: Array<ParseQuery>): ParseQuery;
+    /**
+     * Constructs a Parse.Query that is the NOR of the passed in queries.  For
+     * example:
+     * <pre>const compoundQuery = Parse.Query.nor(query1, query2, query3);</pre>
+     *
+     * will create a compoundQuery that is a nor of the query1, query2, and
+     * query3.
+     *
+     * @param {...Parse.Query} queries The list of queries to NOR.
+     * @static
+     * @returns {Parse.Query} The query that is the NOR of the passed in queries.
+     */
+    static nor(...queries: Array<ParseQuery>): ParseQuery;
+    /**
      * Change the source of this query to the server.
      *
      * @returns {Parse.Query} Returns the query, so you can chain this call.
@@ -909,7 +940,7 @@ declare class ParseQuery {
      * @param {string} name The name of query source.
      * @returns {Parse.Query} Returns the query, so you can chain this call.
      */
-    fromPinWithName(name?: string): ParseQuery;
+    fromPinWithName(name?: string | null): ParseQuery;
     /**
      * Cancels the current network request (if any is running).
      *
@@ -918,7 +949,7 @@ declare class ParseQuery {
     cancel(): ParseQuery;
     _setRequestTask(options: any): void;
     /**
-     * Sets a comment to the query so that the query 
+     * Sets a comment to the query so that the query
      * can be identified when using a the profiler for MongoDB.
      *
      * @param {string} value a comment can make your profile data easier to interpret and trace.
@@ -926,10 +957,4 @@ declare class ParseQuery {
      */
     comment(value: string): ParseQuery;
 }
-import { FullOptions } from './RESTController';
-import ParseObject from './ParseObject';
-type BatchOptions = FullOptions & {
-    batchSize?: number;
-};
-import ParseGeoPoint from './ParseGeoPoint';
-import LiveQuerySubscription from './LiveQuerySubscription';
+export default ParseQuery;

--- a/types/ParseRole.d.ts
+++ b/types/ParseRole.d.ts
@@ -1,5 +1,8 @@
-// @ts-nocheck
-export default ParseRole;
+import ParseACL from './ParseACL';
+import ParseError from './ParseError';
+import ParseObject from './ParseObject';
+import type { AttributeMap } from './ObjectStateMutations';
+import type ParseRelation from './ParseRelation';
 /**
  * Represents a Role on the Parse server. Roles represent groupings of
  * Users for the purposes of granting permissions (e.g. specifying an ACL
@@ -13,7 +16,7 @@ export default ParseRole;
  * @alias Parse.Role
  * @augments Parse.Object
  */
-declare class ParseRole {
+declare class ParseRole extends ParseObject {
     /**
      * @param {string} name The name of the Role to create.
      * @param {Parse.ACL} acl The ACL for this role. Roles must have an ACL.
@@ -44,7 +47,7 @@ declare class ParseRole {
      *     callbacks.
      * @returns {(ParseObject|boolean)} true if the set succeeded.
      */
-    setName(name: string, options?: mixed): ParseObject | boolean;
+    setName(name: string, options?: any): ParseObject | boolean;
     /**
      * Gets the Parse.Relation for the Parse.Users that are direct
      * children of this role. These users are granted any privileges that this
@@ -70,10 +73,6 @@ declare class ParseRole {
      */
     getRoles(): ParseRelation;
     _validateName(newName: any): void;
-    validate(attrs: AttributeMap, options?: mixed): ParseError | boolean;
+    validate(attrs: AttributeMap, options?: any): ParseError | boolean;
 }
-import ParseObject from './ParseObject';
-import ParseRelation from './ParseRelation';
-import { AttributeMap } from './ObjectStateMutations';
-import ParseError from './ParseError';
-import ParseACL from './ParseACL';
+export default ParseRole;

--- a/types/ParseSession.d.ts
+++ b/types/ParseSession.d.ts
@@ -29,7 +29,7 @@ declare class ParseSession extends ParseObject {
      * object after it has been fetched. If there is no current user, the
      * promise will be rejected.
      */
-    static current(options: FullOptions): any;
+    static current(options: FullOptions): Promise<ParseSession>;
     /**
      * Determines whether the current session token is revocable.
      * This method is useful for migrating Express.js or Node.js web apps to

--- a/types/ParseUser.d.ts
+++ b/types/ParseUser.d.ts
@@ -1,8 +1,18 @@
-// @ts-nocheck
-type AuthData = {
-    [key: string]: mixed;
+import ParseObject from './ParseObject';
+import type { AttributeMap } from './ObjectStateMutations';
+import type { RequestOptions, FullOptions } from './RESTController';
+export type AuthData = {
+    [key: string]: any;
 };
-export default ParseUser;
+export type AuthProviderType = {
+    authenticate?(options: {
+        error?: (provider: AuthProviderType, error: string | any) => void;
+        success?: (provider: AuthProviderType, result: AuthData) => void;
+    }): void;
+    restoreAuthentication(authData: any): boolean;
+    getAuthType(): string;
+    deauthenticate?(): void;
+};
 /**
  * <p>A Parse.User object is a local representation of a user persisted to the
  * Parse cloud. This class is a subclass of a Parse.Object, and retains the
@@ -13,249 +23,11 @@ export default ParseUser;
  * @alias Parse.User
  * @augments Parse.Object
  */
-declare class ParseUser {
-    static readOnlyAttributes(): string[];
-    /**
-     * Adds functionality to the existing Parse.User class.
-     *
-     * @param {object} protoProps A set of properties to add to the prototype
-     * @param {object} classProps A set of static properties to add to the class
-     * @static
-     * @returns {Parse.User} The newly extended Parse.User class
-     */
-    static extend(protoProps: {
-        [prop: string]: any;
-    }, classProps: {
-        [prop: string]: any;
-    }): Parse.User;
-    /**
-     * Retrieves the currently logged in ParseUser with a valid session,
-     * either from memory or localStorage, if necessary.
-     *
-     * @static
-     * @returns {Parse.Object} The currently logged in Parse.User.
-     */
-    static current(): ParseUser | null;
-    /**
-     * Retrieves the currently logged in ParseUser from asynchronous Storage.
-     *
-     * @static
-     * @returns {Promise} A Promise that is resolved with the currently
-     *   logged in Parse User
-     */
-    static currentAsync(): Promise<ParseUser | null>;
-    /**
-     * Signs up a new user with a username (or email) and password.
-     * This will create a new Parse.User on the server, and also persist the
-     * session in localStorage so that you can access the user using
-     * {@link #current}.
-     *
-     * @param {string} username The username (or email) to sign up with.
-     * @param {string} password The password to sign up with.
-     * @param {object} attrs Extra fields to set on the new user.
-     * @param {object} options
-     * @static
-     * @returns {Promise} A promise that is fulfilled with the user when
-     *     the signup completes.
-     */
-    static signUp(username: string, password: string, attrs: AttributeMap, options?: FullOptions): Promise<any>;
-    /**
-     * Logs in a user with a username (or email) and password. On success, this
-     * saves the session to disk, so you can retrieve the currently logged in
-     * user using <code>current</code>.
-     *
-     * @param {string} username The username (or email) to log in with.
-     * @param {string} password The password to log in with.
-     * @param {object} options
-     * @static
-     * @returns {Promise} A promise that is fulfilled with the user when
-     *     the login completes.
-     */
-    static logIn(username: string, password: string, options?: FullOptions): Promise<any>;
-    /**
-     * Logs in a user with a username (or email) and password, and authData. On success, this
-     * saves the session to disk, so you can retrieve the currently logged in
-     * user using <code>current</code>.
-     *
-     * @param {string} username The username (or email) to log in with.
-     * @param {string} password The password to log in with.
-     * @param {object} authData The authData to log in with.
-     * @param {object} options
-     * @static
-     * @returns {Promise} A promise that is fulfilled with the user when
-     *     the login completes.
-     */
-    static logInWithAdditionalAuth(username: string, password: string, authData: AuthData, options?: FullOptions): Promise<any>;
-    /**
-     * Logs in a user with an objectId. On success, this saves the session
-     * to disk, so you can retrieve the currently logged in user using
-     * <code>current</code>.
-     *
-     * @param {string} userId The objectId for the user.
-     * @static
-     * @returns {Promise} A promise that is fulfilled with the user when
-     *     the login completes.
-     */
-    static loginAs(userId: string): Promise<any>;
-    /**
-     * Logs in a user with a session token. On success, this saves the session
-     * to disk, so you can retrieve the currently logged in user using
-     * <code>current</code>.
-     *
-     * @param {string} sessionToken The sessionToken to log in with.
-     * @param {object} options
-     * @static
-     * @returns {Promise} A promise that is fulfilled with the user when
-     *     the login completes.
-     */
-    static become(sessionToken: string, options?: RequestOptions): Promise<any>;
-    /**
-     * Retrieves a user with a session token.
-     *
-     * @param {string} sessionToken The sessionToken to get user with.
-     * @param {object} options
-     * @static
-     * @returns {Promise} A promise that is fulfilled with the user is fetched.
-     */
-    static me(sessionToken: string, options?: RequestOptions): Promise<any>;
-    /**
-     * Logs in a user with a session token. On success, this saves the session
-     * to disk, so you can retrieve the currently logged in user using
-     * <code>current</code>. If there is no session token the user will not logged in.
-     *
-     * @param {object} userJSON The JSON map of the User's data
-     * @static
-     * @returns {Promise} A promise that is fulfilled with the user when
-     *     the login completes.
-     */
-    static hydrate(userJSON: AttributeMap): Promise<any>;
-    /**
-     * Static version of {@link https://parseplatform.org/Parse-SDK-JS/api/master/Parse.User.html#linkWith linkWith}
-     *
-     * @param provider
-     * @param options
-     * @param saveOpts
-     * @static
-     * @returns {Promise}
-     */
-    static logInWith(provider: any, options: {
-        authData?: AuthData;
-    }, saveOpts?: FullOptions): Promise<ParseUser>;
-    /**
-     * Logs out the currently logged in user session. This will remove the
-     * session from disk, log out of linked services, and future calls to
-     * <code>current</code> will return <code>null</code>.
-     *
-     * @param {object} options
-     * @static
-     * @returns {Promise} A promise that is resolved when the session is
-     *   destroyed on the server.
-     */
-    static logOut(options?: RequestOptions): Promise<any>;
-    /**
-     * Requests a password reset email to be sent to the specified email address
-     * associated with the user account. This email allows the user to securely
-     * reset their password on the Parse site.
-     *
-     * @param {string} email The email address associated with the user that
-     *     forgot their password.
-     * @param {object} options
-     * @static
-     * @returns {Promise}
-     */
-    static requestPasswordReset(email: string, options?: RequestOptions): Promise<any>;
-    /**
-     * Request an email verification.
-     *
-     * @param {string} email The email address associated with the user that
-     *     needs to verify their email.
-     * @param {object} options
-     * @static
-     * @returns {Promise}
-     */
-    static requestEmailVerification(email: string, options?: RequestOptions): Promise<any>;
-    /**
-     * Verify whether a given password is the password of the current user.
-     *
-     * @param {string} username  A username to be used for identificaiton
-     * @param {string} password A password to be verified
-     * @param {object} options
-     * @static
-     * @returns {Promise} A promise that is fulfilled with a user
-     *  when the password is correct.
-     */
-    static verifyPassword(username: string, password: string, options?: RequestOptions): Promise<any>;
-    /**
-     * Allow someone to define a custom User class without className
-     * being rewritten to _User. The default behavior is to rewrite
-     * User to _User for legacy reasons. This allows developers to
-     * override that behavior.
-     *
-     * @param {boolean} isAllowed Whether or not to allow custom User class
-     * @static
-     */
-    static allowCustomUserClass(isAllowed: boolean): void;
-    /**
-     * Allows a legacy application to start using revocable sessions. If the
-     * current session token is not revocable, a request will be made for a new,
-     * revocable session.
-     * It is not necessary to call this method from cloud code unless you are
-     * handling user signup or login from the server side. In a cloud code call,
-     * this function will not attempt to upgrade the current token.
-     *
-     * @param {object} options
-     * @static
-     * @returns {Promise} A promise that is resolved when the process has
-     *   completed. If a replacement session token is requested, the promise
-     *   will be resolved after a new token has been fetched.
-     */
-    static enableRevocableSession(options?: RequestOptions): Promise<any>;
-    /**
-     * Enables the use of become or the current user in a server
-     * environment. These features are disabled by default, since they depend on
-     * global objects that are not memory-safe for most servers.
-     *
-     * @static
-     */
-    static enableUnsafeCurrentUser(): void;
-    /**
-     * Disables the use of become or the current user in any environment.
-     * These features are disabled on servers by default, since they depend on
-     * global objects that are not memory-safe for most servers.
-     *
-     * @static
-     */
-    static disableUnsafeCurrentUser(): void;
-    /**
-     * When registering users with {@link https://parseplatform.org/Parse-SDK-JS/api/master/Parse.User.html#linkWith linkWith} a basic auth provider
-     * is automatically created for you.
-     *
-     * For advanced authentication, you can register an Auth provider to
-     * implement custom authentication, deauthentication.
-     *
-     * @param provider
-     * @see {@link https://parseplatform.org/Parse-SDK-JS/api/master/AuthProvider.html AuthProvider}
-     * @see {@link https://docs.parseplatform.org/js/guide/#custom-authentication-module Custom Authentication Module}
-     * @static
-     */
-    static _registerAuthenticationProvider(provider: any): void;
-    /**
-     * @param provider
-     * @param options
-     * @param saveOpts
-     * @deprecated since 2.9.0 see {@link https://parseplatform.org/Parse-SDK-JS/api/master/Parse.User.html#logInWith logInWith}
-     * @static
-     * @returns {Promise}
-     */
-    static _logInWith(provider: any, options: {
-        authData?: AuthData;
-    }, saveOpts?: FullOptions): Promise<any>;
-    static _clearCache(): void;
-    static _setCurrentUserCache(user: ParseUser): void;
+declare class ParseUser extends ParseObject {
     /**
      * @param {object} attributes The initial set of data to store in the user.
      */
-    constructor(attributes: AttributeMap | null);
+    constructor(attributes?: AttributeMap);
     /**
      * Request a revocable session token to replace the older style of token.
      *
@@ -279,7 +51,7 @@ declare class ParseUser {
      * @param {object} saveOpts useMasterKey / sessionToken
      * @returns {Promise} A promise that is fulfilled with the user is linked
      */
-    linkWith(provider: any, options: {
+    linkWith(provider: AuthProviderType, options: {
         authData?: AuthData;
     }, saveOpts?: FullOptions): Promise<ParseUser>;
     /**
@@ -298,7 +70,7 @@ declare class ParseUser {
      *
      * @param provider
      */
-    _synchronizeAuthData(provider: string): void;
+    _synchronizeAuthData(provider: string | AuthProviderType): void;
     /**
      * Synchronizes authData for all providers.
      */
@@ -353,6 +125,8 @@ declare class ParseUser {
      * @returns {Promise<boolean>} true if user is cached on disk
      */
     isCurrentAsync(): Promise<boolean>;
+    stripAnonymity(): void;
+    restoreAnonimity(anonymousData: any): void;
     /**
      * Returns get("username").
      *
@@ -383,7 +157,7 @@ declare class ParseUser {
      * @param {string} email
      * @returns {boolean}
      */
-    setEmail(email: string): boolean;
+    setEmail(email: string): boolean | ParseObject;
     /**
      * Returns the session token for this user, if the user has been logged in,
      * or if it is the result of a query with the master key. Otherwise, returns
@@ -411,7 +185,9 @@ declare class ParseUser {
      * @returns {Promise} A promise that is fulfilled when the signup
      *     finishes.
      */
-    signUp(attrs: AttributeMap, options?: FullOptions): Promise<ParseUser>;
+    signUp(attrs: AttributeMap, options?: FullOptions & {
+        context?: AttributeMap;
+    }): Promise<ParseUser>;
     /**
      * Logs in a Parse.User. On success, this saves the session to disk,
      * so you can retrieve the currently logged in user using
@@ -423,7 +199,9 @@ declare class ParseUser {
      * @returns {Promise} A promise that is fulfilled with the user when
      *     the login is complete.
      */
-    logIn(options?: FullOptions): Promise<ParseUser>;
+    logIn(options?: FullOptions & {
+        context?: AttributeMap;
+    }): Promise<ParseUser>;
     /**
      * Wrap the default save behavior with functionality to save to local
      * storage if this is current user.
@@ -431,7 +209,7 @@ declare class ParseUser {
      * @param {...any} args
      * @returns {Promise}
      */
-    save(...args: Array<any>): Promise<ParseUser>;
+    save(...args: Array<any>): Promise<this>;
     /**
      * Wrap the default destroy behavior with functionality that logs out
      * the current user when it is destroyed
@@ -439,7 +217,7 @@ declare class ParseUser {
      * @param {...any} args
      * @returns {Parse.User}
      */
-    destroy(...args: Array<any>): Promise<ParseUser>;
+    destroy(...args: Array<any>): Promise<ParseUser | void>;
     /**
      * Wrap the default fetch behavior with functionality to save to local
      * storage if this is current user.
@@ -459,13 +237,251 @@ declare class ParseUser {
     /**
      * Verify whether a given password is the password of the current user.
      *
-     * @param {string} password A password to be verified
-     * @param {object} options
-     * @returns {Promise} A promise that is fulfilled with a user
-     *  when the password is correct.
+     * @param {string} password The password to be verified.
+     * @param {object} options The options.
+     * @param {boolean} [options.ignoreEmailVerification=false] Set to `true` to bypass email verification and verify
+     * the password regardless of whether the email has been verified. This requires the master key.
+     * @returns {Promise} A promise that is fulfilled with a user when the password is correct.
      */
     verifyPassword(password: string, options?: RequestOptions): Promise<ParseUser>;
+    static readOnlyAttributes(): string[];
+    /**
+     * Adds functionality to the existing Parse.User class.
+     *
+     * @param {object} protoProps A set of properties to add to the prototype
+     * @param {object} classProps A set of static properties to add to the class
+     * @static
+     * @returns {Parse.User} The newly extended Parse.User class
+     */
+    static extend(protoProps: {
+        [prop: string]: any;
+    }, classProps: {
+        [prop: string]: any;
+    }): typeof ParseUser;
+    /**
+     * Retrieves the currently logged in ParseUser with a valid session,
+     * either from memory or localStorage, if necessary.
+     *
+     * @static
+     * @returns {Parse.Object} The currently logged in Parse.User.
+     */
+    static current(): ParseUser | null;
+    /**
+     * Retrieves the currently logged in ParseUser from asynchronous Storage.
+     *
+     * @static
+     * @returns {Promise} A Promise that is resolved with the currently
+     *   logged in Parse User
+     */
+    static currentAsync(): Promise<ParseUser | null>;
+    /**
+     * Signs up a new user with a username (or email) and password.
+     * This will create a new Parse.User on the server, and also persist the
+     * session in localStorage so that you can access the user using
+     * {@link #current}.
+     *
+     * @param {string} username The username (or email) to sign up with.
+     * @param {string} password The password to sign up with.
+     * @param {object} attrs Extra fields to set on the new user.
+     * @param {object} options
+     * @static
+     * @returns {Promise} A promise that is fulfilled with the user when
+     *     the signup completes.
+     */
+    static signUp(username: string, password: string, attrs: AttributeMap, options?: FullOptions): Promise<ParseUser>;
+    /**
+     * Logs in a user with a username (or email) and password. On success, this
+     * saves the session to disk, so you can retrieve the currently logged in
+     * user using <code>current</code>.
+     *
+     * @param {string} username The username (or email) to log in with.
+     * @param {string} password The password to log in with.
+     * @param {object} options
+     * @static
+     * @returns {Promise} A promise that is fulfilled with the user when
+     *     the login completes.
+     */
+    static logIn(username: string, password: string, options?: FullOptions): Promise<ParseUser>;
+    /**
+     * Logs in a user with a username (or email) and password, and authData. On success, this
+     * saves the session to disk, so you can retrieve the currently logged in
+     * user using <code>current</code>.
+     *
+     * @param {string} username The username (or email) to log in with.
+     * @param {string} password The password to log in with.
+     * @param {object} authData The authData to log in with.
+     * @param {object} options
+     * @static
+     * @returns {Promise} A promise that is fulfilled with the user when
+     *     the login completes.
+     */
+    static logInWithAdditionalAuth(username: string, password: string, authData: AuthData, options?: FullOptions): Promise<ParseUser>;
+    /**
+     * Logs in a user with an objectId. On success, this saves the session
+     * to disk, so you can retrieve the currently logged in user using
+     * <code>current</code>.
+     *
+     * @param {string} userId The objectId for the user.
+     * @static
+     * @returns {Promise} A promise that is fulfilled with the user when
+     *     the login completes.
+     */
+    static loginAs(userId: string): Promise<ParseUser>;
+    /**
+     * Logs in a user with a session token. On success, this saves the session
+     * to disk, so you can retrieve the currently logged in user using
+     * <code>current</code>.
+     *
+     * @param {string} sessionToken The sessionToken to log in with.
+     * @param {object} options
+     * @static
+     * @returns {Promise} A promise that is fulfilled with the user when
+     *     the login completes.
+     */
+    static become(sessionToken: string, options?: RequestOptions): Promise<ParseUser>;
+    /**
+     * Retrieves a user with a session token.
+     *
+     * @param {string} sessionToken The sessionToken to get user with.
+     * @param {object} options
+     * @static
+     * @returns {Promise} A promise that is fulfilled with the user is fetched.
+     */
+    static me(sessionToken: string, options?: RequestOptions): Promise<ParseUser>;
+    /**
+     * Logs in a user with a session token. On success, this saves the session
+     * to disk, so you can retrieve the currently logged in user using
+     * <code>current</code>. If there is no session token the user will not logged in.
+     *
+     * @param {object} userJSON The JSON map of the User's data
+     * @static
+     * @returns {Promise} A promise that is fulfilled with the user when
+     *     the login completes.
+     */
+    static hydrate(userJSON: AttributeMap): Promise<ParseUser>;
+    /**
+     * Static version of {@link https://parseplatform.org/Parse-SDK-JS/api/master/Parse.User.html#linkWith linkWith}
+     *
+     * @param provider
+     * @param options
+     * @param saveOpts
+     * @static
+     * @returns {Promise}
+     */
+    static logInWith(provider: any, options: {
+        authData?: AuthData;
+    }, saveOpts?: FullOptions): Promise<ParseUser>;
+    /**
+     * Logs out the currently logged in user session. This will remove the
+     * session from disk, log out of linked services, and future calls to
+     * <code>current</code> will return <code>null</code>.
+     *
+     * @param {object} options
+     * @static
+     * @returns {Promise} A promise that is resolved when the session is
+     *   destroyed on the server.
+     */
+    static logOut(options?: RequestOptions): Promise<void>;
+    /**
+     * Requests a password reset email to be sent to the specified email address
+     * associated with the user account. This email allows the user to securely
+     * reset their password on the Parse site.
+     *
+     * @param {string} email The email address associated with the user that
+     *     forgot their password.
+     * @param {object} options
+     * @static
+     * @returns {Promise}
+     */
+    static requestPasswordReset(email: string, options?: RequestOptions): Promise<void>;
+    /**
+     * Request an email verification.
+     *
+     * @param {string} email The email address associated with the user that
+     *     needs to verify their email.
+     * @param {object} options
+     * @static
+     * @returns {Promise}
+     */
+    static requestEmailVerification(email: string, options?: RequestOptions): Promise<void>;
+    /**
+     * Verify whether a given password is the password of the current user.
+     * @static
+     *
+     * @param {string} username  The username of the user whose password should be verified.
+     * @param {string} password The password to be verified.
+     * @param {object} options The options.
+     * @param {boolean} [options.ignoreEmailVerification=false] Set to `true` to bypass email verification and verify
+     * the password regardless of whether the email has been verified. This requires the master key.
+     * @returns {Promise} A promise that is fulfilled with a user when the password is correct.
+     */
+    static verifyPassword(username: string, password: string, options?: RequestOptions): Promise<ParseUser>;
+    /**
+     * Allow someone to define a custom User class without className
+     * being rewritten to _User. The default behavior is to rewrite
+     * User to _User for legacy reasons. This allows developers to
+     * override that behavior.
+     *
+     * @param {boolean} isAllowed Whether or not to allow custom User class
+     * @static
+     */
+    static allowCustomUserClass(isAllowed: boolean): void;
+    /**
+     * Allows a legacy application to start using revocable sessions. If the
+     * current session token is not revocable, a request will be made for a new,
+     * revocable session.
+     * It is not necessary to call this method from cloud code unless you are
+     * handling user signup or login from the server side. In a cloud code call,
+     * this function will not attempt to upgrade the current token.
+     *
+     * @param {object} options
+     * @static
+     * @returns {Promise} A promise that is resolved when the process has
+     *   completed. If a replacement session token is requested, the promise
+     *   will be resolved after a new token has been fetched.
+     */
+    static enableRevocableSession(options?: RequestOptions): Promise<void>;
+    /**
+     * Enables the use of become or the current user in a server
+     * environment. These features are disabled by default, since they depend on
+     * global objects that are not memory-safe for most servers.
+     *
+     * @static
+     */
+    static enableUnsafeCurrentUser(): void;
+    /**
+     * Disables the use of become or the current user in any environment.
+     * These features are disabled on servers by default, since they depend on
+     * global objects that are not memory-safe for most servers.
+     *
+     * @static
+     */
+    static disableUnsafeCurrentUser(): void;
+    /**
+     * When registering users with {@link https://parseplatform.org/Parse-SDK-JS/api/master/Parse.User.html#linkWith linkWith} a basic auth provider
+     * is automatically created for you.
+     *
+     * For advanced authentication, you can register an Auth provider to
+     * implement custom authentication, deauthentication.
+     *
+     * @param provider
+     * @see {@link https://parseplatform.org/Parse-SDK-JS/api/master/AuthProvider.html AuthProvider}
+     * @see {@link https://docs.parseplatform.org/js/guide/#custom-authentication-module Custom Authentication Module}
+     * @static
+     */
+    static _registerAuthenticationProvider(provider: any): void;
+    /**
+     * @param provider
+     * @param options
+     * @param saveOpts
+     * @deprecated since 2.9.0 see {@link https://parseplatform.org/Parse-SDK-JS/api/master/Parse.User.html#logInWith logInWith}
+     * @static
+     * @returns {Promise}
+     */
+    static _logInWith(provider: any, options: {
+        authData?: AuthData;
+    }, saveOpts?: FullOptions): Promise<ParseUser>;
+    static _clearCache(): void;
+    static _setCurrentUserCache(user: ParseUser): void;
 }
-import { RequestOptions } from './RESTController';
-import { FullOptions } from './RESTController';
-import { AttributeMap } from './ObjectStateMutations';
+export default ParseUser;

--- a/types/Push.d.ts
+++ b/types/Push.d.ts
@@ -1,4 +1,13 @@
-// @ts-nocheck
+import ParseQuery from './ParseQuery';
+import type ParseObject from './ParseObject';
+import type { WhereClause } from './ParseQuery';
+import type { FullOptions } from './RESTController';
+export type PushData = {
+    where?: WhereClause | ParseQuery;
+    push_time?: Date | string;
+    expiration_time?: Date | string;
+    expiration_interval?: number;
+};
 /**
  * Contains functions to deal with Push in Parse.
  *
@@ -32,9 +41,9 @@
  *     be used for this request.
  * </ul>
  * @returns {Promise} A promise that is fulfilled when the push request
- *     completes.
+ *     completes and returns `pushStatusId`.
  */
-export function send(data: PushData, options?: FullOptions): Promise<any>;
+export declare function send(data: PushData, options?: FullOptions): Promise<string>;
 /**
  * Gets push status by Id
  *
@@ -48,12 +57,4 @@ export function send(data: PushData, options?: FullOptions): Promise<any>;
  * </ul>
  * @returns {Parse.Object} Status of Push.
  */
-export function getPushStatus(pushStatusId: string, options?: FullOptions): Promise<string>;
-type PushData = {
-    where?: WhereClause | ParseQuery;
-    push_time?: string | Date;
-    expiration_time?: string | Date;
-    expiration_interval?: number;
-};
-import { FullOptions } from './RESTController';
-export {};
+export declare function getPushStatus(pushStatusId: string, options?: FullOptions): Promise<ParseObject>;

--- a/types/TaskQueue.d.ts
+++ b/types/TaskQueue.d.ts
@@ -1,1 +1,11 @@
-export {};
+type Task = {
+    task: () => Promise<void>;
+    _completion: any;
+};
+declare class TaskQueue {
+    queue: Array<Task>;
+    constructor();
+    enqueue(task: () => Promise<void>): Promise<void>;
+    _dequeue(): void;
+}
+export default TaskQueue;

--- a/types/tsconfig.json
+++ b/types/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
       "module": "commonjs",
-      "lib": ["es6"],
+      "lib": ["es6", "dom"],
       "noImplicitAny": true,
       "noImplicitThis": true,
       "strictFunctionTypes": true,

--- a/types/tslint.json
+++ b/types/tslint.json
@@ -5,6 +5,10 @@
     "ban-types": false,
     "no-unnecessary-generics": false,
     "no-redundant-jsdoc": false,
-    "strict-export-declare-modifiers": false
+    "strict-export-declare-modifiers": false,
+    "interface-over-type-literal": false,
+    "no-duplicate-imports": false,
+    "array-type": false,
+    "void-return": false
   }
 }


### PR DESCRIPTION
## Pull Request

- Report security issues [confidentially](https://github.com/parse-community/Parse-SDK-JS/security/policy).
- Any contribution is under this [license](https://github.com/parse-community/Parse-SDK-JS/blob/alpha/LICENSE).
- Link this pull request to an [issue](https://github.com/parse-community/Parse-SDK-JS/issues?q=is%3Aissue).

## Issue
<!-- Add the link to the issue that this PR closes. -->
`npm run test:types`
```
Error: /home/runner/work/Parse-SDK-JS/Parse-SDK-JS/types/CoreManager.d.ts:1:15
ERROR: 1:15    expect  TypeScript@5.2 compile error: 
Module '"./ObjectStateMutations"' declares 'AttributeMap' locally, but it is not exported.
ERROR: 1:29    expect  TypeScript@5.2 compile error: 
Module '"./ObjectStateMutations"' declares 'ObjectCache' locally, but it is not exported.
ERROR: 1:42    expect  TypeScript@5.2 compile error: 
Module '"./ObjectStateMutations"' declares 'OpsMap' locally, but it is not exported.
ERROR: 1:50    expect  TypeScript@5.2 compile error: 
Module '"./ObjectStateMutations"' declares 'State' locally, but it is not exported.
ERROR: 3:15    expect  TypeScript@5.2 compile error: 
Module '"./ParseFile"' has no exported member 'FileSaveOptions'. Did you mean to use 'import FileSaveOptions from "./ParseFile"' instead?
ERROR: 3:32    expect  TypeScript@5.2 compile error: 
Module '"./ParseFile"' has no exported member 'FileSource'. Did you mean to use 'import FileSource from "./ParseFile"' instead?
ERROR: 7:15    expect  TypeScript@5.2 compile error: 
Module '"./ParseQuery"' has no exported member 'QueryJSON'. Did you mean to use 'import QueryJSON from "./ParseQuery"' instead?
ERROR: 9:15    expect  TypeScript@5.2 compile error: 
Module '"./ParseUser"' has no exported member 'AuthData'. Did you mean to use 'import AuthData from "./ParseUser"' instead?
ERROR: 10:15   expect  TypeScript@5.2 compile error: 
Module '"./Push"' declares 'PushData' locally, but it is not exported.
ERROR: 13:53   expect  TypeScript@5.2 compile error: 
Cannot find module './ParseHooks' or its corresponding type declarations.
ERROR: 279:[59](https://github.com/parse-community/Parse-SDK-JS/actions/runs/9116080664/job/25063872022#step:5:60)  expect  TypeScript@5.2 compile error: 
Cannot find name 'URL'.
ERROR: 280:50  expect  TypeScript@5.2 compile error: 
Cannot find name 'URL'.

/home/runner/work/Parse-SDK-JS/Parse-SDK-JS/types/ParseInstallation.d.ts:2:15
ERROR: 2:15    expect  TypeScript@5.2 compile error: 
Module '"./ObjectStateMutations"' declares 'AttributeMap' locally, but it is not exported.

/home/runner/work/Parse-SDK-JS/Parse-SDK-JS/types/ParseObject.d.ts:5:15
ERROR: 5:15    expect  TypeScript@5.2 compile error: 
Module '"./ObjectStateMutations"' declares 'AttributeMap' locally, but it is not exported.
ERROR: 5:29    expect  TypeScript@5.2 compile error: 
Module '"./ObjectStateMutations"' declares 'OpsMap' locally, but it is not exported.
```

## Approach
<!-- Describe the changes in this PR. -->
Convert the following to TypeScript
```
ObjectStateMutation
ParseFile
ParseHooks
ParseQuery
ParseRole
ParseUser
Push.js
TaskQueue
```

Added `dom` to `libs` in tsconfig for `Cannot find name 'URL'.` error
Fixed linting issues, for some reason the declaration files d.ts have parsing issues

## Tasks
<!-- Delete tasks that don't apply. -->

- [x] Add tests
- [x] Add changes to documentation (guides, repository pages, code comments)
