### PR TITLE
style: Fix pre-commit hook and enable Prettier for TypeScript

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,0 +1,2 @@
+npm run prettier
+git add .

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,2 +1,1 @@
 npm run prettier
-git add

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,1 +1,1 @@
-npm run prettier
+npm run pre-commit

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,2 +1,2 @@
 npm run prettier
-git add .
+git add

--- a/.prettierrc
+++ b/.prettierrc
@@ -3,3 +3,4 @@ trailingComma: "es5"
 singleQuote: true
 arrowParens: "avoid"
 printWidth: 100
+parser: "typescript"

--- a/integration/test/ParseDistTest.js
+++ b/integration/test/ParseDistTest.js
@@ -52,18 +52,21 @@ for (const fileName of ['parse.js', 'parse.min.js']) {
         request.continue();
       });
       page.on('requestfailed', request => {
-        if (request.failure().errorText  === 'net::ERR_ABORTED' && !request.url().includes('favicon.ico')) {
+        if (
+          request.failure().errorText === 'net::ERR_ABORTED' &&
+          !request.url().includes('favicon.ico')
+        ) {
           abortedCount += 1;
           promise.resolve();
         }
       });
       await page.evaluate(async () => {
         const parseLogo =
-        'https://raw.githubusercontent.com/parse-community/parse-server/master/.github/parse-server-logo.png';
+          'https://raw.githubusercontent.com/parse-community/parse-server/master/.github/parse-server-logo.png';
         const file = new Parse.File('parse-server-logo', { uri: parseLogo });
         file.save().then(() => {});
 
-        return new Promise((resolve) => {
+        return new Promise(resolve => {
           const intervalId = setInterval(() => {
             if (file._requestTask && typeof file._requestTask.abort === 'function') {
               file.cancel();

--- a/integration/test/ParseEventuallyQueueTest.js
+++ b/integration/test/ParseEventuallyQueueTest.js
@@ -193,7 +193,7 @@ describe('Parse EventuallyQueue', () => {
   it('can saveEventually', async () => {
     const parseServer = await reconfigureServer();
     const object = new TestObject({ hash: 'saveSecret' });
-    await new Promise((resolve) => parseServer.server.close(resolve));
+    await new Promise(resolve => parseServer.server.close(resolve));
     await object.saveEventually();
 
     const length = await Parse.EventuallyQueue.length();
@@ -225,7 +225,7 @@ describe('Parse EventuallyQueue', () => {
     const object = new TestObject({ hash: 'saveSecret' });
     object.setACL(acl);
 
-    await new Promise((resolve) => parseServer.server.close(resolve));
+    await new Promise(resolve => parseServer.server.close(resolve));
     await object.saveEventually();
 
     const length = await Parse.EventuallyQueue.length();
@@ -250,7 +250,7 @@ describe('Parse EventuallyQueue', () => {
     const parseServer = await reconfigureServer();
     const object = new TestObject({ hash: 'deleteSecret' });
     await object.save();
-    await new Promise((resolve) => parseServer.server.close(resolve));
+    await new Promise(resolve => parseServer.server.close(resolve));
     await object.destroyEventually();
     const length = await Parse.EventuallyQueue.length();
 

--- a/integration/test/ParseLiveQueryTest.js
+++ b/integration/test/ParseLiveQueryTest.js
@@ -20,7 +20,8 @@ describe('Parse LiveQuery', () => {
   it('can subscribe to query', async () => {
     const object = new TestObject();
     await object.save();
-    const installationId = await Parse.CoreManager.getInstallationController().currentInstallationId();
+    const installationId =
+      await Parse.CoreManager.getInstallationController().currentInstallationId();
 
     const query = new Parse.Query(TestObject);
     query.equalTo('objectId', object.id);
@@ -39,7 +40,8 @@ describe('Parse LiveQuery', () => {
   it('can subscribe to query with client', async () => {
     const object = new TestObject();
     await object.save();
-    const installationId = await Parse.CoreManager.getInstallationController().currentInstallationId();
+    const installationId =
+      await Parse.CoreManager.getInstallationController().currentInstallationId();
 
     const query = new Parse.Query(TestObject);
     query.equalTo('objectId', object.id);
@@ -389,7 +391,8 @@ describe('Parse LiveQuery', () => {
     Parse.CoreManager.setEventEmitter(CustomEmitter);
     const object = new TestObject();
     await object.save();
-    const installationId = await Parse.CoreManager.getInstallationController().currentInstallationId();
+    const installationId =
+      await Parse.CoreManager.getInstallationController().currentInstallationId();
 
     const query = new Parse.Query(TestObject);
     query.equalTo('objectId', object.id);

--- a/integration/test/ParseQueryTest.js
+++ b/integration/test/ParseQueryTest.js
@@ -2415,5 +2415,4 @@ describe('Parse Query', () => {
     const explain = await query.find();
     assert.equal(explain.command.comment, comment);
   });
-
 });

--- a/integration/test/ParseReactNativeTest.js
+++ b/integration/test/ParseReactNativeTest.js
@@ -32,7 +32,7 @@ describe('Parse React Native', () => {
 
   it('can log in a user', async () => {
     // Handle Storage Controller
-    await Parse.User.signUp('asdf', 'zxcv')
+    await Parse.User.signUp('asdf', 'zxcv');
     const user = await Parse.User.logIn('asdf', 'zxcv');
     expect(user.get('username')).toBe('asdf');
     expect(user.existed()).toBe(true);
@@ -86,7 +86,8 @@ describe('Parse React Native', () => {
     // Handle WebSocket Controller
     const object = new Parse.Object('TestObject');
     await object.save();
-    const installationId = await Parse.CoreManager.getInstallationController().currentInstallationId();
+    const installationId =
+      await Parse.CoreManager.getInstallationController().currentInstallationId();
 
     const query = new Parse.Query('TestObject');
     query.equalTo('objectId', object.id);

--- a/integration/test/ParseServerTest.js
+++ b/integration/test/ParseServerTest.js
@@ -6,7 +6,7 @@ describe('ParseServer', () => {
   it('can reconfigure server', async () => {
     const parseServer = await reconfigureServer({ serverURL: 'www.google.com' });
     assert.strictEqual(parseServer.config.serverURL, 'www.google.com');
-    await new Promise((resolve) => parseServer.server.close(resolve));
+    await new Promise(resolve => parseServer.server.close(resolve));
     await reconfigureServer();
   });
 
@@ -14,8 +14,10 @@ describe('ParseServer', () => {
     const parseServer = await reconfigureServer();
     const object = new TestObject({ foo: 'bar' });
     await parseServer.handleShutdown();
-    await new Promise((resolve) => parseServer.server.close(resolve));
-    await expectAsync(object.save()).toBeRejectedWithError('XMLHttpRequest failed: "Unable to connect to the Parse API"');
+    await new Promise(resolve => parseServer.server.close(resolve));
+    await expectAsync(object.save()).toBeRejectedWithError(
+      'XMLHttpRequest failed: "Unable to connect to the Parse API"'
+    );
     await reconfigureServer({});
     await object.save();
     assert(object.id);

--- a/integration/test/ParseUserTest.js
+++ b/integration/test/ParseUserTest.js
@@ -113,7 +113,8 @@ describe('Parse User', () => {
 
   it('can login users with installationId', async () => {
     Parse.User.enableUnsafeCurrentUser();
-    const currentInstallationId = await Parse.CoreManager.getInstallationController().currentInstallationId();
+    const currentInstallationId =
+      await Parse.CoreManager.getInstallationController().currentInstallationId();
     const installationId = '12345678';
     const user = new Parse.User();
     user.set('username', 'parse');
@@ -149,7 +150,8 @@ describe('Parse User', () => {
   });
 
   it('can get current installation', async () => {
-    const currentInstallationId = await Parse.CoreManager.getInstallationController().currentInstallationId();
+    const currentInstallationId =
+      await Parse.CoreManager.getInstallationController().currentInstallationId();
     const installation = await Parse.Installation.currentInstallation();
     expect(installation.installationId).toBe(currentInstallationId);
     expect(installation.deviceType).toBe(Parse.Installation.DEVICE_TYPES.WEB);
@@ -180,7 +182,8 @@ describe('Parse User', () => {
   });
 
   it('can save new installation when deleted', async () => {
-    const currentInstallationId = await Parse.CoreManager.getInstallationController().currentInstallationId();
+    const currentInstallationId =
+      await Parse.CoreManager.getInstallationController().currentInstallationId();
     const installation = await Parse.Installation.currentInstallation();
     expect(installation.installationId).toBe(currentInstallationId);
     expect(installation.deviceType).toBe(Parse.Installation.DEVICE_TYPES.WEB);
@@ -196,7 +199,8 @@ describe('Parse User', () => {
   });
 
   it('can fetch installation when deleted', async () => {
-    const currentInstallationId = await Parse.CoreManager.getInstallationController().currentInstallationId();
+    const currentInstallationId =
+      await Parse.CoreManager.getInstallationController().currentInstallationId();
     const installation = await Parse.Installation.currentInstallation();
     expect(installation.installationId).toBe(currentInstallationId);
     expect(installation.deviceType).toBe(Parse.Installation.DEVICE_TYPES.WEB);
@@ -227,9 +231,7 @@ describe('Parse User', () => {
 
     await Parse.User.logOut();
     assert(!Parse.User.current());
-    await expectAsync(Parse.User.loginAs('garbage')).toBeRejectedWithError(
-      'user not found'
-    );
+    await expectAsync(Parse.User.loginAs('garbage')).toBeRejectedWithError('user not found');
   });
 
   it('can become a user', done => {
@@ -1128,7 +1130,10 @@ describe('Parse User', () => {
       preventLoginWithUnverifiedEmail: true,
     });
     await Parse.User.signUp('asd123', 'xyz123');
-    const res = await Parse.User.verifyPassword('asd123', 'xyz123', { useMasterKey: true, ignoreEmailVerification: true });
+    const res = await Parse.User.verifyPassword('asd123', 'xyz123', {
+      useMasterKey: true,
+      ignoreEmailVerification: true,
+    });
     expect(typeof res).toBe('object');
     expect(res.username).toBe('asd123');
   });

--- a/package-lock.json
+++ b/package-lock.json
@@ -61,6 +61,7 @@
         "jest-environment-jsdom": "29.5.0",
         "jsdoc": "4.0.2",
         "jsdoc-babel": "0.5.0",
+        "lint-staged": "15.2.2",
         "madge": "7.0.0",
         "metro-react-native-babel-preset": "0.76.4",
         "mongodb-runner": "5.4.3",
@@ -8728,6 +8729,72 @@
         "@colors/colors": "1.5.0"
       }
     },
+    "node_modules/cli-truncate": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/cli-truncate/-/cli-truncate-4.0.0.tgz",
+      "integrity": "sha512-nPdaFdQ0h/GEigbPClz11D0v/ZJEwxmeVZGeMo3Z5StPtUTkA9o1lD6QwoirYiSDzbcwn2XcjwmCp68W1IS4TA==",
+      "dev": true,
+      "dependencies": {
+        "slice-ansi": "^5.0.0",
+        "string-width": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/cli-truncate/node_modules/ansi-regex": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.0.1.tgz",
+      "integrity": "sha512-n5M855fKb2SsfMIiFFoVrABHJC8QtHwVx+mHWP3QcEqBHYienj5dHSgjbxtC0WEZXYt4wcD6zrQElDPhFuZgfA==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/cli-truncate/node_modules/emoji-regex": {
+      "version": "10.3.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.3.0.tgz",
+      "integrity": "sha512-QpLs9D9v9kArv4lfDEgg1X/gN5XLnf/A6l9cs8SPZLRZR3ZkY9+kwIQTxm+fsSej5UMYGE8fdoaZVIBlqG0XTw==",
+      "dev": true
+    },
+    "node_modules/cli-truncate/node_modules/string-width": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-7.1.0.tgz",
+      "integrity": "sha512-SEIJCWiX7Kg4c129n48aDRwLbFb2LJmXXFrWBG4NGaRtMQ3myKPKbwrD1BKqQn74oCoNMBVrfDEr5M9YxCsrkw==",
+      "dev": true,
+      "dependencies": {
+        "emoji-regex": "^10.3.0",
+        "get-east-asian-width": "^1.0.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/cli-truncate/node_modules/strip-ansi": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.0.tgz",
+      "integrity": "sha512-iq6eVVI64nQQTRYq2KtEg2d2uU7LElhTJwsH4YzIHZshxlgZms/wIc4VoDQTlG/IvVIrBKG06CrZnp0qv7hkcQ==",
+      "dev": true,
+      "dependencies": {
+        "ansi-regex": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
     "node_modules/cliui": {
       "version": "7.0.4",
       "resolved": "https://registry.npmjs.org/cliui/-/cliui-7.0.4.tgz",
@@ -8935,6 +9002,12 @@
       "bin": {
         "color-support": "bin.js"
       }
+    },
+    "node_modules/colorette": {
+      "version": "2.0.20",
+      "resolved": "https://registry.npmjs.org/colorette/-/colorette-2.0.20.tgz",
+      "integrity": "sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w==",
+      "dev": true
     },
     "node_modules/colors": {
       "version": "1.4.0",
@@ -13315,6 +13388,18 @@
       "dev": true,
       "engines": {
         "node": "6.* || 8.* || >= 10.*"
+      }
+    },
+    "node_modules/get-east-asian-width": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/get-east-asian-width/-/get-east-asian-width-1.2.0.tgz",
+      "integrity": "sha512-2nk+7SIVb14QrgXFHcm84tD4bKQz0RxPuMT8Ag5KPOq7J5fEmAg0UbXdTOSHqNuHSU28k55qnceesxXRZGzKWA==",
+      "dev": true,
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/get-intrinsic": {
@@ -18604,6 +18689,15 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/lilconfig": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/lilconfig/-/lilconfig-3.0.0.tgz",
+      "integrity": "sha512-K2U4W2Ff5ibV7j7ydLr+zLAkIg5JJ4lPn1Ltsdt+Tz/IjQ8buJ55pZAxoP34lqIiwtF9iAvtLv3JGv7CAyAg+g==",
+      "dev": true,
+      "engines": {
+        "node": ">=14"
+      }
+    },
     "node_modules/limiter": {
       "version": "1.1.5",
       "resolved": "https://registry.npmjs.org/limiter/-/limiter-1.1.5.tgz",
@@ -18623,6 +18717,299 @@
       "dev": true,
       "dependencies": {
         "uc.micro": "^1.0.1"
+      }
+    },
+    "node_modules/lint-staged": {
+      "version": "15.2.2",
+      "resolved": "https://registry.npmjs.org/lint-staged/-/lint-staged-15.2.2.tgz",
+      "integrity": "sha512-TiTt93OPh1OZOsb5B7k96A/ATl2AjIZo+vnzFZ6oHK5FuTk63ByDtxGQpHm+kFETjEWqgkF95M8FRXKR/LEBcw==",
+      "dev": true,
+      "dependencies": {
+        "chalk": "5.3.0",
+        "commander": "11.1.0",
+        "debug": "4.3.4",
+        "execa": "8.0.1",
+        "lilconfig": "3.0.0",
+        "listr2": "8.0.1",
+        "micromatch": "4.0.5",
+        "pidtree": "0.6.0",
+        "string-argv": "0.3.2",
+        "yaml": "2.3.4"
+      },
+      "bin": {
+        "lint-staged": "bin/lint-staged.js"
+      },
+      "engines": {
+        "node": ">=18.12.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/lint-staged"
+      }
+    },
+    "node_modules/lint-staged/node_modules/chalk": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.3.0.tgz",
+      "integrity": "sha512-dLitG79d+GV1Nb/VYcCDFivJeK1hiukt9QjRNVOsUtTy1rR1YJsmpGGTZ3qJos+uw7WmWF4wUwBd9jxjocFC2w==",
+      "dev": true,
+      "engines": {
+        "node": "^12.17.0 || ^14.13 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/lint-staged/node_modules/commander": {
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-11.1.0.tgz",
+      "integrity": "sha512-yPVavfyCcRhmorC7rWlkHn15b4wDVgVmBA7kV4QVBsF7kv/9TKJAbAXVTxvTnwP8HHKjRCJDClKbciiYS7p0DQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/lint-staged/node_modules/execa": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/execa/-/execa-8.0.1.tgz",
+      "integrity": "sha512-VyhnebXciFV2DESc+p6B+y0LjSm0krU4OgJN44qFAhBY0TJ+1V61tYD2+wHusZ6F9n5K+vl8k0sTy7PEfV4qpg==",
+      "dev": true,
+      "dependencies": {
+        "cross-spawn": "^7.0.3",
+        "get-stream": "^8.0.1",
+        "human-signals": "^5.0.0",
+        "is-stream": "^3.0.0",
+        "merge-stream": "^2.0.0",
+        "npm-run-path": "^5.1.0",
+        "onetime": "^6.0.0",
+        "signal-exit": "^4.1.0",
+        "strip-final-newline": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=16.17"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/execa?sponsor=1"
+      }
+    },
+    "node_modules/lint-staged/node_modules/get-stream": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-8.0.1.tgz",
+      "integrity": "sha512-VaUJspBffn/LMCJVoMvSAdmscJyS1auj5Zulnn5UoYcY531UWmdwhRWkcGKnGU93m5HSXP9LP2usOryrBtQowA==",
+      "dev": true,
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/lint-staged/node_modules/human-signals": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-5.0.0.tgz",
+      "integrity": "sha512-AXcZb6vzzrFAUE61HnN4mpLqd/cSIwNQjtNWR0euPm6y0iqx3G4gOXaIDdtdDwZmhwe82LA6+zinmW4UBWVePQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=16.17.0"
+      }
+    },
+    "node_modules/lint-staged/node_modules/is-stream": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-3.0.0.tgz",
+      "integrity": "sha512-LnQR4bZ9IADDRSkvpqMGvt/tEJWclzklNgSw48V5EAaAeDd6qGvN8ei6k5p0tvxSR171VmGyHuTiAOfxAbr8kA==",
+      "dev": true,
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/lint-staged/node_modules/mimic-fn": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-4.0.0.tgz",
+      "integrity": "sha512-vqiC06CuhBTUdZH+RYl8sFrL096vA45Ok5ISO6sE/Mr1jRbGH4Csnhi8f3wKVl7x8mO4Au7Ir9D3Oyv1VYMFJw==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/lint-staged/node_modules/npm-run-path": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-5.3.0.tgz",
+      "integrity": "sha512-ppwTtiJZq0O/ai0z7yfudtBpWIoxM8yE6nHi1X47eFR2EWORqfbu6CnPlNsjeN683eT0qG6H/Pyf9fCcvjnnnQ==",
+      "dev": true,
+      "dependencies": {
+        "path-key": "^4.0.0"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/lint-staged/node_modules/onetime": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/onetime/-/onetime-6.0.0.tgz",
+      "integrity": "sha512-1FlR+gjXK7X+AsAHso35MnyN5KqGwJRi/31ft6x0M194ht7S+rWAvd7PHss9xSKMzE0asv1pyIHaJYq+BbacAQ==",
+      "dev": true,
+      "dependencies": {
+        "mimic-fn": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/lint-staged/node_modules/path-key": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-4.0.0.tgz",
+      "integrity": "sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/lint-staged/node_modules/signal-exit": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+      "dev": true,
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/lint-staged/node_modules/strip-final-newline": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-3.0.0.tgz",
+      "integrity": "sha512-dOESqjYr96iWYylGObzd39EuNTa5VJxyvVAEm5Jnh7KGo75V43Hk1odPQkNDyXNmUR6k+gEiDVXnjB8HJ3crXw==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/lint-staged/node_modules/yaml": {
+      "version": "2.3.4",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.3.4.tgz",
+      "integrity": "sha512-8aAvwVUSHpfEqTQ4w/KMlf3HcRdt50E5ODIQJBw1fQ5RL34xabzxtUlzTXVqc4rkZsPbvrXKWnABCD7kWSmocA==",
+      "dev": true,
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/listr2": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/listr2/-/listr2-8.0.1.tgz",
+      "integrity": "sha512-ovJXBXkKGfq+CwmKTjluEqFi3p4h8xvkxGQQAQan22YCgef4KZ1mKGjzfGh6PL6AW5Csw0QiQPNuQyH+6Xk3hA==",
+      "dev": true,
+      "dependencies": {
+        "cli-truncate": "^4.0.0",
+        "colorette": "^2.0.20",
+        "eventemitter3": "^5.0.1",
+        "log-update": "^6.0.0",
+        "rfdc": "^1.3.0",
+        "wrap-ansi": "^9.0.0"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/listr2/node_modules/ansi-regex": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.0.1.tgz",
+      "integrity": "sha512-n5M855fKb2SsfMIiFFoVrABHJC8QtHwVx+mHWP3QcEqBHYienj5dHSgjbxtC0WEZXYt4wcD6zrQElDPhFuZgfA==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/listr2/node_modules/ansi-styles": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.1.tgz",
+      "integrity": "sha512-bN798gFfQX+viw3R7yrGWRqnrN2oRkEkUjjl4JNn4E8GxxbjtG3FbrEIIY3l8/hrwUwIeCZvi4QuOTP4MErVug==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/listr2/node_modules/emoji-regex": {
+      "version": "10.3.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.3.0.tgz",
+      "integrity": "sha512-QpLs9D9v9kArv4lfDEgg1X/gN5XLnf/A6l9cs8SPZLRZR3ZkY9+kwIQTxm+fsSej5UMYGE8fdoaZVIBlqG0XTw==",
+      "dev": true
+    },
+    "node_modules/listr2/node_modules/eventemitter3": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.1.tgz",
+      "integrity": "sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA==",
+      "dev": true
+    },
+    "node_modules/listr2/node_modules/string-width": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-7.1.0.tgz",
+      "integrity": "sha512-SEIJCWiX7Kg4c129n48aDRwLbFb2LJmXXFrWBG4NGaRtMQ3myKPKbwrD1BKqQn74oCoNMBVrfDEr5M9YxCsrkw==",
+      "dev": true,
+      "dependencies": {
+        "emoji-regex": "^10.3.0",
+        "get-east-asian-width": "^1.0.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/listr2/node_modules/strip-ansi": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.0.tgz",
+      "integrity": "sha512-iq6eVVI64nQQTRYq2KtEg2d2uU7LElhTJwsH4YzIHZshxlgZms/wIc4VoDQTlG/IvVIrBKG06CrZnp0qv7hkcQ==",
+      "dev": true,
+      "dependencies": {
+        "ansi-regex": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
+    "node_modules/listr2/node_modules/wrap-ansi": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-9.0.0.tgz",
+      "integrity": "sha512-G8ura3S+3Z2G+mkgNRq8dqaFZAuxfsxpBB8OCTGRTCtp+l/v9nbFNmCUP1BZMts3G1142MsZfn6eeUKrr4PD1Q==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^6.2.1",
+        "string-width": "^7.0.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
       }
     },
     "node_modules/load-json-file": {
@@ -18828,6 +19215,178 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/log-update": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/log-update/-/log-update-6.0.0.tgz",
+      "integrity": "sha512-niTvB4gqvtof056rRIrTZvjNYE4rCUzO6X/X+kYjd7WFxXeJ0NwEFnRxX6ehkvv3jTwrXnNdtAak5XYZuIyPFw==",
+      "dev": true,
+      "dependencies": {
+        "ansi-escapes": "^6.2.0",
+        "cli-cursor": "^4.0.0",
+        "slice-ansi": "^7.0.0",
+        "strip-ansi": "^7.1.0",
+        "wrap-ansi": "^9.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/log-update/node_modules/ansi-escapes": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-6.2.1.tgz",
+      "integrity": "sha512-4nJ3yixlEthEJ9Rk4vPcdBRkZvQZlYyu8j4/Mqz5sgIkddmEnH2Yj2ZrnP9S3tQOvSNRUIgVNF/1yPpRAGNRig==",
+      "dev": true,
+      "engines": {
+        "node": ">=14.16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/log-update/node_modules/ansi-regex": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.0.1.tgz",
+      "integrity": "sha512-n5M855fKb2SsfMIiFFoVrABHJC8QtHwVx+mHWP3QcEqBHYienj5dHSgjbxtC0WEZXYt4wcD6zrQElDPhFuZgfA==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/log-update/node_modules/ansi-styles": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.1.tgz",
+      "integrity": "sha512-bN798gFfQX+viw3R7yrGWRqnrN2oRkEkUjjl4JNn4E8GxxbjtG3FbrEIIY3l8/hrwUwIeCZvi4QuOTP4MErVug==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/log-update/node_modules/cli-cursor": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-4.0.0.tgz",
+      "integrity": "sha512-VGtlMu3x/4DOtIUwEkRezxUZ2lBacNJCHash0N0WeZDBS+7Ux1dm3XWAgWYxLJFMMdOeXMHXorshEFhbMSGelg==",
+      "dev": true,
+      "dependencies": {
+        "restore-cursor": "^4.0.0"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/log-update/node_modules/emoji-regex": {
+      "version": "10.3.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.3.0.tgz",
+      "integrity": "sha512-QpLs9D9v9kArv4lfDEgg1X/gN5XLnf/A6l9cs8SPZLRZR3ZkY9+kwIQTxm+fsSej5UMYGE8fdoaZVIBlqG0XTw==",
+      "dev": true
+    },
+    "node_modules/log-update/node_modules/is-fullwidth-code-point": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-5.0.0.tgz",
+      "integrity": "sha512-OVa3u9kkBbw7b8Xw5F9P+D/T9X+Z4+JruYVNapTjPYZYUznQ5YfWeFkOj606XYYW8yugTfC8Pj0hYqvi4ryAhA==",
+      "dev": true,
+      "dependencies": {
+        "get-east-asian-width": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/log-update/node_modules/restore-cursor": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-4.0.0.tgz",
+      "integrity": "sha512-I9fPXU9geO9bHOt9pHHOhOkYerIMsmVaWB0rA2AI9ERh/+x/i7MV5HKBNrg+ljO5eoPVgCcnFuRjJ9uH6I/3eg==",
+      "dev": true,
+      "dependencies": {
+        "onetime": "^5.1.0",
+        "signal-exit": "^3.0.2"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/log-update/node_modules/slice-ansi": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-7.1.0.tgz",
+      "integrity": "sha512-bSiSngZ/jWeX93BqeIAbImyTbEihizcwNjFoRUIY/T1wWQsfsm2Vw1agPKylXvQTU7iASGdHhyqRlqQzfz+Htg==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^6.2.1",
+        "is-fullwidth-code-point": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/slice-ansi?sponsor=1"
+      }
+    },
+    "node_modules/log-update/node_modules/string-width": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-7.1.0.tgz",
+      "integrity": "sha512-SEIJCWiX7Kg4c129n48aDRwLbFb2LJmXXFrWBG4NGaRtMQ3myKPKbwrD1BKqQn74oCoNMBVrfDEr5M9YxCsrkw==",
+      "dev": true,
+      "dependencies": {
+        "emoji-regex": "^10.3.0",
+        "get-east-asian-width": "^1.0.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/log-update/node_modules/strip-ansi": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.0.tgz",
+      "integrity": "sha512-iq6eVVI64nQQTRYq2KtEg2d2uU7LElhTJwsH4YzIHZshxlgZms/wIc4VoDQTlG/IvVIrBKG06CrZnp0qv7hkcQ==",
+      "dev": true,
+      "dependencies": {
+        "ansi-regex": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
+    "node_modules/log-update/node_modules/wrap-ansi": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-9.0.0.tgz",
+      "integrity": "sha512-G8ura3S+3Z2G+mkgNRq8dqaFZAuxfsxpBB8OCTGRTCtp+l/v9nbFNmCUP1BZMts3G1142MsZfn6eeUKrr4PD1Q==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^6.2.1",
+        "string-width": "^7.0.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
       }
     },
     "node_modules/logform": {
@@ -24222,6 +24781,18 @@
         "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
+    "node_modules/pidtree": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/pidtree/-/pidtree-0.6.0.tgz",
+      "integrity": "sha512-eG2dWTVw5bzqGRztnHExczNxt5VGsE6OwTeCG3fdUf9KBsZzO3R5OIIIzWR+iZA0NtZ+RDVdaoE2dK1cn6jH4g==",
+      "dev": true,
+      "bin": {
+        "pidtree": "bin/pidtree.js"
+      },
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
     "node_modules/pify": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
@@ -25894,6 +26465,12 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/rfdc": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/rfdc/-/rfdc-1.3.1.tgz",
+      "integrity": "sha512-r5a3l5HzYlIC68TpmYKlxWjmOP6wiPJ1vWv2HeLhNsRZMrCkxeqxiHlQ21oXmQ4F3SiryXBHhAD7JZqvOJjFmg==",
+      "dev": true
+    },
     "node_modules/rimraf": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
@@ -26401,6 +26978,46 @@
       "dev": true,
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/slice-ansi": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-5.0.0.tgz",
+      "integrity": "sha512-FC+lgizVPfie0kkhqUScwRu1O/lF6NOgJmlCgK+/LYxDCTk8sGelYaHDhFcDN+Sn3Cv+3VSa4Byeo+IMCzpMgQ==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^6.0.0",
+        "is-fullwidth-code-point": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/slice-ansi?sponsor=1"
+      }
+    },
+    "node_modules/slice-ansi/node_modules/ansi-styles": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.1.tgz",
+      "integrity": "sha512-bN798gFfQX+viw3R7yrGWRqnrN2oRkEkUjjl4JNn4E8GxxbjtG3FbrEIIY3l8/hrwUwIeCZvi4QuOTP4MErVug==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/slice-ansi/node_modules/is-fullwidth-code-point": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-4.0.0.tgz",
+      "integrity": "sha512-O4L094N2/dZ7xqVdrXhh9r1KODPJpFms8B5sGdJLPy664AgvXsreZUyCQQNItZRDlYug4xStLjNp/sz3HvBowQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/slide": {
@@ -27077,6 +27694,15 @@
           "url": "https://feross.org/support"
         }
       ]
+    },
+    "node_modules/string-argv": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/string-argv/-/string-argv-0.3.2.tgz",
+      "integrity": "sha512-aqD2Q0144Z+/RqG52NeHEkZauTAUWJO8c6yTftGJKO3Tja5tUgIfmIl6kExvhtxSDP7fXB6DvzkfMpCd/F3G+Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.6.19"
+      }
     },
     "node_modules/string-length": {
       "version": "4.0.2",
@@ -36068,6 +36694,50 @@
         "string-width": "^4.2.0"
       }
     },
+    "cli-truncate": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/cli-truncate/-/cli-truncate-4.0.0.tgz",
+      "integrity": "sha512-nPdaFdQ0h/GEigbPClz11D0v/ZJEwxmeVZGeMo3Z5StPtUTkA9o1lD6QwoirYiSDzbcwn2XcjwmCp68W1IS4TA==",
+      "dev": true,
+      "requires": {
+        "slice-ansi": "^5.0.0",
+        "string-width": "^7.0.0"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "6.0.1",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.0.1.tgz",
+          "integrity": "sha512-n5M855fKb2SsfMIiFFoVrABHJC8QtHwVx+mHWP3QcEqBHYienj5dHSgjbxtC0WEZXYt4wcD6zrQElDPhFuZgfA==",
+          "dev": true
+        },
+        "emoji-regex": {
+          "version": "10.3.0",
+          "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.3.0.tgz",
+          "integrity": "sha512-QpLs9D9v9kArv4lfDEgg1X/gN5XLnf/A6l9cs8SPZLRZR3ZkY9+kwIQTxm+fsSej5UMYGE8fdoaZVIBlqG0XTw==",
+          "dev": true
+        },
+        "string-width": {
+          "version": "7.1.0",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-7.1.0.tgz",
+          "integrity": "sha512-SEIJCWiX7Kg4c129n48aDRwLbFb2LJmXXFrWBG4NGaRtMQ3myKPKbwrD1BKqQn74oCoNMBVrfDEr5M9YxCsrkw==",
+          "dev": true,
+          "requires": {
+            "emoji-regex": "^10.3.0",
+            "get-east-asian-width": "^1.0.0",
+            "strip-ansi": "^7.1.0"
+          }
+        },
+        "strip-ansi": {
+          "version": "7.1.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.0.tgz",
+          "integrity": "sha512-iq6eVVI64nQQTRYq2KtEg2d2uU7LElhTJwsH4YzIHZshxlgZms/wIc4VoDQTlG/IvVIrBKG06CrZnp0qv7hkcQ==",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^6.0.1"
+          }
+        }
+      }
+    },
     "cliui": {
       "version": "7.0.4",
       "resolved": "https://registry.npmjs.org/cliui/-/cliui-7.0.4.tgz",
@@ -36243,6 +36913,12 @@
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/color-support/-/color-support-1.1.3.tgz",
       "integrity": "sha512-qiBjkpbMLO/HL68y+lh4q0/O1MZFj2RX6X/KmMa3+gJD3z+WwI1ZzDHysvqHGS3mP6mznPckpXmw1nI9cJjyRg==",
+      "dev": true
+    },
+    "colorette": {
+      "version": "2.0.20",
+      "resolved": "https://registry.npmjs.org/colorette/-/colorette-2.0.20.tgz",
+      "integrity": "sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w==",
       "dev": true
     },
     "colors": {
@@ -39751,6 +40427,12 @@
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
       "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+      "dev": true
+    },
+    "get-east-asian-width": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/get-east-asian-width/-/get-east-asian-width-1.2.0.tgz",
+      "integrity": "sha512-2nk+7SIVb14QrgXFHcm84tD4bKQz0RxPuMT8Ag5KPOq7J5fEmAg0UbXdTOSHqNuHSU28k55qnceesxXRZGzKWA==",
       "dev": true
     },
     "get-intrinsic": {
@@ -43847,6 +44529,12 @@
         }
       }
     },
+    "lilconfig": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/lilconfig/-/lilconfig-3.0.0.tgz",
+      "integrity": "sha512-K2U4W2Ff5ibV7j7ydLr+zLAkIg5JJ4lPn1Ltsdt+Tz/IjQ8buJ55pZAxoP34lqIiwtF9iAvtLv3JGv7CAyAg+g==",
+      "dev": true
+    },
     "limiter": {
       "version": "1.1.5",
       "resolved": "https://registry.npmjs.org/limiter/-/limiter-1.1.5.tgz",
@@ -43866,6 +44554,192 @@
       "dev": true,
       "requires": {
         "uc.micro": "^1.0.1"
+      }
+    },
+    "lint-staged": {
+      "version": "15.2.2",
+      "resolved": "https://registry.npmjs.org/lint-staged/-/lint-staged-15.2.2.tgz",
+      "integrity": "sha512-TiTt93OPh1OZOsb5B7k96A/ATl2AjIZo+vnzFZ6oHK5FuTk63ByDtxGQpHm+kFETjEWqgkF95M8FRXKR/LEBcw==",
+      "dev": true,
+      "requires": {
+        "chalk": "5.3.0",
+        "commander": "11.1.0",
+        "debug": "4.3.4",
+        "execa": "8.0.1",
+        "lilconfig": "3.0.0",
+        "listr2": "8.0.1",
+        "micromatch": "4.0.5",
+        "pidtree": "0.6.0",
+        "string-argv": "0.3.2",
+        "yaml": "2.3.4"
+      },
+      "dependencies": {
+        "chalk": {
+          "version": "5.3.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.3.0.tgz",
+          "integrity": "sha512-dLitG79d+GV1Nb/VYcCDFivJeK1hiukt9QjRNVOsUtTy1rR1YJsmpGGTZ3qJos+uw7WmWF4wUwBd9jxjocFC2w==",
+          "dev": true
+        },
+        "commander": {
+          "version": "11.1.0",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-11.1.0.tgz",
+          "integrity": "sha512-yPVavfyCcRhmorC7rWlkHn15b4wDVgVmBA7kV4QVBsF7kv/9TKJAbAXVTxvTnwP8HHKjRCJDClKbciiYS7p0DQ==",
+          "dev": true
+        },
+        "execa": {
+          "version": "8.0.1",
+          "resolved": "https://registry.npmjs.org/execa/-/execa-8.0.1.tgz",
+          "integrity": "sha512-VyhnebXciFV2DESc+p6B+y0LjSm0krU4OgJN44qFAhBY0TJ+1V61tYD2+wHusZ6F9n5K+vl8k0sTy7PEfV4qpg==",
+          "dev": true,
+          "requires": {
+            "cross-spawn": "^7.0.3",
+            "get-stream": "^8.0.1",
+            "human-signals": "^5.0.0",
+            "is-stream": "^3.0.0",
+            "merge-stream": "^2.0.0",
+            "npm-run-path": "^5.1.0",
+            "onetime": "^6.0.0",
+            "signal-exit": "^4.1.0",
+            "strip-final-newline": "^3.0.0"
+          }
+        },
+        "get-stream": {
+          "version": "8.0.1",
+          "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-8.0.1.tgz",
+          "integrity": "sha512-VaUJspBffn/LMCJVoMvSAdmscJyS1auj5Zulnn5UoYcY531UWmdwhRWkcGKnGU93m5HSXP9LP2usOryrBtQowA==",
+          "dev": true
+        },
+        "human-signals": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-5.0.0.tgz",
+          "integrity": "sha512-AXcZb6vzzrFAUE61HnN4mpLqd/cSIwNQjtNWR0euPm6y0iqx3G4gOXaIDdtdDwZmhwe82LA6+zinmW4UBWVePQ==",
+          "dev": true
+        },
+        "is-stream": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-3.0.0.tgz",
+          "integrity": "sha512-LnQR4bZ9IADDRSkvpqMGvt/tEJWclzklNgSw48V5EAaAeDd6qGvN8ei6k5p0tvxSR171VmGyHuTiAOfxAbr8kA==",
+          "dev": true
+        },
+        "mimic-fn": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-4.0.0.tgz",
+          "integrity": "sha512-vqiC06CuhBTUdZH+RYl8sFrL096vA45Ok5ISO6sE/Mr1jRbGH4Csnhi8f3wKVl7x8mO4Au7Ir9D3Oyv1VYMFJw==",
+          "dev": true
+        },
+        "npm-run-path": {
+          "version": "5.3.0",
+          "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-5.3.0.tgz",
+          "integrity": "sha512-ppwTtiJZq0O/ai0z7yfudtBpWIoxM8yE6nHi1X47eFR2EWORqfbu6CnPlNsjeN683eT0qG6H/Pyf9fCcvjnnnQ==",
+          "dev": true,
+          "requires": {
+            "path-key": "^4.0.0"
+          }
+        },
+        "onetime": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/onetime/-/onetime-6.0.0.tgz",
+          "integrity": "sha512-1FlR+gjXK7X+AsAHso35MnyN5KqGwJRi/31ft6x0M194ht7S+rWAvd7PHss9xSKMzE0asv1pyIHaJYq+BbacAQ==",
+          "dev": true,
+          "requires": {
+            "mimic-fn": "^4.0.0"
+          }
+        },
+        "path-key": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/path-key/-/path-key-4.0.0.tgz",
+          "integrity": "sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ==",
+          "dev": true
+        },
+        "signal-exit": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+          "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+          "dev": true
+        },
+        "strip-final-newline": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-3.0.0.tgz",
+          "integrity": "sha512-dOESqjYr96iWYylGObzd39EuNTa5VJxyvVAEm5Jnh7KGo75V43Hk1odPQkNDyXNmUR6k+gEiDVXnjB8HJ3crXw==",
+          "dev": true
+        },
+        "yaml": {
+          "version": "2.3.4",
+          "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.3.4.tgz",
+          "integrity": "sha512-8aAvwVUSHpfEqTQ4w/KMlf3HcRdt50E5ODIQJBw1fQ5RL34xabzxtUlzTXVqc4rkZsPbvrXKWnABCD7kWSmocA==",
+          "dev": true
+        }
+      }
+    },
+    "listr2": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/listr2/-/listr2-8.0.1.tgz",
+      "integrity": "sha512-ovJXBXkKGfq+CwmKTjluEqFi3p4h8xvkxGQQAQan22YCgef4KZ1mKGjzfGh6PL6AW5Csw0QiQPNuQyH+6Xk3hA==",
+      "dev": true,
+      "requires": {
+        "cli-truncate": "^4.0.0",
+        "colorette": "^2.0.20",
+        "eventemitter3": "^5.0.1",
+        "log-update": "^6.0.0",
+        "rfdc": "^1.3.0",
+        "wrap-ansi": "^9.0.0"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "6.0.1",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.0.1.tgz",
+          "integrity": "sha512-n5M855fKb2SsfMIiFFoVrABHJC8QtHwVx+mHWP3QcEqBHYienj5dHSgjbxtC0WEZXYt4wcD6zrQElDPhFuZgfA==",
+          "dev": true
+        },
+        "ansi-styles": {
+          "version": "6.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.1.tgz",
+          "integrity": "sha512-bN798gFfQX+viw3R7yrGWRqnrN2oRkEkUjjl4JNn4E8GxxbjtG3FbrEIIY3l8/hrwUwIeCZvi4QuOTP4MErVug==",
+          "dev": true
+        },
+        "emoji-regex": {
+          "version": "10.3.0",
+          "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.3.0.tgz",
+          "integrity": "sha512-QpLs9D9v9kArv4lfDEgg1X/gN5XLnf/A6l9cs8SPZLRZR3ZkY9+kwIQTxm+fsSej5UMYGE8fdoaZVIBlqG0XTw==",
+          "dev": true
+        },
+        "eventemitter3": {
+          "version": "5.0.1",
+          "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.1.tgz",
+          "integrity": "sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA==",
+          "dev": true
+        },
+        "string-width": {
+          "version": "7.1.0",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-7.1.0.tgz",
+          "integrity": "sha512-SEIJCWiX7Kg4c129n48aDRwLbFb2LJmXXFrWBG4NGaRtMQ3myKPKbwrD1BKqQn74oCoNMBVrfDEr5M9YxCsrkw==",
+          "dev": true,
+          "requires": {
+            "emoji-regex": "^10.3.0",
+            "get-east-asian-width": "^1.0.0",
+            "strip-ansi": "^7.1.0"
+          }
+        },
+        "strip-ansi": {
+          "version": "7.1.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.0.tgz",
+          "integrity": "sha512-iq6eVVI64nQQTRYq2KtEg2d2uU7LElhTJwsH4YzIHZshxlgZms/wIc4VoDQTlG/IvVIrBKG06CrZnp0qv7hkcQ==",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^6.0.1"
+          }
+        },
+        "wrap-ansi": {
+          "version": "9.0.0",
+          "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-9.0.0.tgz",
+          "integrity": "sha512-G8ura3S+3Z2G+mkgNRq8dqaFZAuxfsxpBB8OCTGRTCtp+l/v9nbFNmCUP1BZMts3G1142MsZfn6eeUKrr4PD1Q==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^6.2.1",
+            "string-width": "^7.0.0",
+            "strip-ansi": "^7.1.0"
+          }
+        }
       }
     },
     "load-json-file": {
@@ -44037,6 +44911,114 @@
           "dev": true,
           "requires": {
             "has-flag": "^4.0.0"
+          }
+        }
+      }
+    },
+    "log-update": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/log-update/-/log-update-6.0.0.tgz",
+      "integrity": "sha512-niTvB4gqvtof056rRIrTZvjNYE4rCUzO6X/X+kYjd7WFxXeJ0NwEFnRxX6ehkvv3jTwrXnNdtAak5XYZuIyPFw==",
+      "dev": true,
+      "requires": {
+        "ansi-escapes": "^6.2.0",
+        "cli-cursor": "^4.0.0",
+        "slice-ansi": "^7.0.0",
+        "strip-ansi": "^7.1.0",
+        "wrap-ansi": "^9.0.0"
+      },
+      "dependencies": {
+        "ansi-escapes": {
+          "version": "6.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-6.2.1.tgz",
+          "integrity": "sha512-4nJ3yixlEthEJ9Rk4vPcdBRkZvQZlYyu8j4/Mqz5sgIkddmEnH2Yj2ZrnP9S3tQOvSNRUIgVNF/1yPpRAGNRig==",
+          "dev": true
+        },
+        "ansi-regex": {
+          "version": "6.0.1",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.0.1.tgz",
+          "integrity": "sha512-n5M855fKb2SsfMIiFFoVrABHJC8QtHwVx+mHWP3QcEqBHYienj5dHSgjbxtC0WEZXYt4wcD6zrQElDPhFuZgfA==",
+          "dev": true
+        },
+        "ansi-styles": {
+          "version": "6.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.1.tgz",
+          "integrity": "sha512-bN798gFfQX+viw3R7yrGWRqnrN2oRkEkUjjl4JNn4E8GxxbjtG3FbrEIIY3l8/hrwUwIeCZvi4QuOTP4MErVug==",
+          "dev": true
+        },
+        "cli-cursor": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-4.0.0.tgz",
+          "integrity": "sha512-VGtlMu3x/4DOtIUwEkRezxUZ2lBacNJCHash0N0WeZDBS+7Ux1dm3XWAgWYxLJFMMdOeXMHXorshEFhbMSGelg==",
+          "dev": true,
+          "requires": {
+            "restore-cursor": "^4.0.0"
+          }
+        },
+        "emoji-regex": {
+          "version": "10.3.0",
+          "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.3.0.tgz",
+          "integrity": "sha512-QpLs9D9v9kArv4lfDEgg1X/gN5XLnf/A6l9cs8SPZLRZR3ZkY9+kwIQTxm+fsSej5UMYGE8fdoaZVIBlqG0XTw==",
+          "dev": true
+        },
+        "is-fullwidth-code-point": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-5.0.0.tgz",
+          "integrity": "sha512-OVa3u9kkBbw7b8Xw5F9P+D/T9X+Z4+JruYVNapTjPYZYUznQ5YfWeFkOj606XYYW8yugTfC8Pj0hYqvi4ryAhA==",
+          "dev": true,
+          "requires": {
+            "get-east-asian-width": "^1.0.0"
+          }
+        },
+        "restore-cursor": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-4.0.0.tgz",
+          "integrity": "sha512-I9fPXU9geO9bHOt9pHHOhOkYerIMsmVaWB0rA2AI9ERh/+x/i7MV5HKBNrg+ljO5eoPVgCcnFuRjJ9uH6I/3eg==",
+          "dev": true,
+          "requires": {
+            "onetime": "^5.1.0",
+            "signal-exit": "^3.0.2"
+          }
+        },
+        "slice-ansi": {
+          "version": "7.1.0",
+          "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-7.1.0.tgz",
+          "integrity": "sha512-bSiSngZ/jWeX93BqeIAbImyTbEihizcwNjFoRUIY/T1wWQsfsm2Vw1agPKylXvQTU7iASGdHhyqRlqQzfz+Htg==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^6.2.1",
+            "is-fullwidth-code-point": "^5.0.0"
+          }
+        },
+        "string-width": {
+          "version": "7.1.0",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-7.1.0.tgz",
+          "integrity": "sha512-SEIJCWiX7Kg4c129n48aDRwLbFb2LJmXXFrWBG4NGaRtMQ3myKPKbwrD1BKqQn74oCoNMBVrfDEr5M9YxCsrkw==",
+          "dev": true,
+          "requires": {
+            "emoji-regex": "^10.3.0",
+            "get-east-asian-width": "^1.0.0",
+            "strip-ansi": "^7.1.0"
+          }
+        },
+        "strip-ansi": {
+          "version": "7.1.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.0.tgz",
+          "integrity": "sha512-iq6eVVI64nQQTRYq2KtEg2d2uU7LElhTJwsH4YzIHZshxlgZms/wIc4VoDQTlG/IvVIrBKG06CrZnp0qv7hkcQ==",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^6.0.1"
+          }
+        },
+        "wrap-ansi": {
+          "version": "9.0.0",
+          "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-9.0.0.tgz",
+          "integrity": "sha512-G8ura3S+3Z2G+mkgNRq8dqaFZAuxfsxpBB8OCTGRTCtp+l/v9nbFNmCUP1BZMts3G1142MsZfn6eeUKrr4PD1Q==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^6.2.1",
+            "string-width": "^7.0.0",
+            "strip-ansi": "^7.1.0"
           }
         }
       }
@@ -48030,6 +49012,12 @@
       "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
       "dev": true
     },
+    "pidtree": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/pidtree/-/pidtree-0.6.0.tgz",
+      "integrity": "sha512-eG2dWTVw5bzqGRztnHExczNxt5VGsE6OwTeCG3fdUf9KBsZzO3R5OIIIzWR+iZA0NtZ+RDVdaoE2dK1cn6jH4g==",
+      "dev": true
+    },
     "pify": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
@@ -49341,6 +50329,12 @@
       "integrity": "sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw==",
       "dev": true
     },
+    "rfdc": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/rfdc/-/rfdc-1.3.1.tgz",
+      "integrity": "sha512-r5a3l5HzYlIC68TpmYKlxWjmOP6wiPJ1vWv2HeLhNsRZMrCkxeqxiHlQ21oXmQ4F3SiryXBHhAD7JZqvOJjFmg==",
+      "dev": true
+    },
     "rimraf": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
@@ -49743,6 +50737,30 @@
       "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
       "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
       "dev": true
+    },
+    "slice-ansi": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-5.0.0.tgz",
+      "integrity": "sha512-FC+lgizVPfie0kkhqUScwRu1O/lF6NOgJmlCgK+/LYxDCTk8sGelYaHDhFcDN+Sn3Cv+3VSa4Byeo+IMCzpMgQ==",
+      "dev": true,
+      "requires": {
+        "ansi-styles": "^6.0.0",
+        "is-fullwidth-code-point": "^4.0.0"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "6.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.1.tgz",
+          "integrity": "sha512-bN798gFfQX+viw3R7yrGWRqnrN2oRkEkUjjl4JNn4E8GxxbjtG3FbrEIIY3l8/hrwUwIeCZvi4QuOTP4MErVug==",
+          "dev": true
+        },
+        "is-fullwidth-code-point": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-4.0.0.tgz",
+          "integrity": "sha512-O4L094N2/dZ7xqVdrXhh9r1KODPJpFms8B5sGdJLPy664AgvXsreZUyCQQNItZRDlYug4xStLjNp/sz3HvBowQ==",
+          "dev": true
+        }
+      }
     },
     "slide": {
       "version": "1.1.6",
@@ -50320,6 +51338,12 @@
           "dev": true
         }
       }
+    },
+    "string-argv": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/string-argv/-/string-argv-0.3.2.tgz",
+      "integrity": "sha512-aqD2Q0144Z+/RqG52NeHEkZauTAUWJO8c6yTftGJKO3Tja5tUgIfmIl6kExvhtxSDP7fXB6DvzkfMpCd/F3G+Q==",
+      "dev": true
     },
     "string-length": {
       "version": "4.0.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -53,7 +53,7 @@
         "gulp-rename": "2.0.0",
         "gulp-uglify": "3.0.2",
         "gulp-watch": "5.0.1",
-        "husky": "8.0.3",
+        "husky": "9.0.11",
         "jasmine": "5.1.0",
         "jasmine-reporters": "2.5.2",
         "jasmine-spec-reporter": "7.0.0",
@@ -61,12 +61,11 @@
         "jest-environment-jsdom": "29.5.0",
         "jsdoc": "4.0.2",
         "jsdoc-babel": "0.5.0",
-        "lint-staged": "13.2.2",
         "madge": "7.0.0",
         "metro-react-native-babel-preset": "0.76.4",
         "mongodb-runner": "5.4.3",
         "parse-server": "7.1.0-alpha.1",
-        "prettier": "3.0.2",
+        "prettier": "3.2.5",
         "puppeteer": "20.4.0",
         "regenerator-runtime": "0.13.11",
         "semantic-release": "19.0.5",
@@ -7132,15 +7131,6 @@
         "node": ">=4"
       }
     },
-    "node_modules/astral-regex": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-2.0.0.tgz",
-      "integrity": "sha512-Z7tMw1ytTXt5jqMcOP+OQteU1VuNK9Y02uuJtKQ1Sv69jXQKKg5cibLwGJow8yzZP+eAc18EmLGPal0bp36rvQ==",
-      "dev": true,
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/async": {
       "version": "3.2.5",
       "resolved": "https://registry.npmjs.org/async/-/async-3.2.5.tgz",
@@ -8738,112 +8728,6 @@
         "@colors/colors": "1.5.0"
       }
     },
-    "node_modules/cli-truncate": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/cli-truncate/-/cli-truncate-3.1.0.tgz",
-      "integrity": "sha512-wfOBkjXteqSnI59oPcJkcPl/ZmwvMMOj340qUIY1SKZCv0B9Cf4D4fAucRkIKQmsIuYK3x1rrgU7MeGRruiuiA==",
-      "dev": true,
-      "dependencies": {
-        "slice-ansi": "^5.0.0",
-        "string-width": "^5.0.0"
-      },
-      "engines": {
-        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/cli-truncate/node_modules/ansi-regex": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.0.1.tgz",
-      "integrity": "sha512-n5M855fKb2SsfMIiFFoVrABHJC8QtHwVx+mHWP3QcEqBHYienj5dHSgjbxtC0WEZXYt4wcD6zrQElDPhFuZgfA==",
-      "dev": true,
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
-      }
-    },
-    "node_modules/cli-truncate/node_modules/ansi-styles": {
-      "version": "6.2.1",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.1.tgz",
-      "integrity": "sha512-bN798gFfQX+viw3R7yrGWRqnrN2oRkEkUjjl4JNn4E8GxxbjtG3FbrEIIY3l8/hrwUwIeCZvi4QuOTP4MErVug==",
-      "dev": true,
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
-    "node_modules/cli-truncate/node_modules/emoji-regex": {
-      "version": "9.2.2",
-      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
-      "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
-      "dev": true
-    },
-    "node_modules/cli-truncate/node_modules/is-fullwidth-code-point": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-4.0.0.tgz",
-      "integrity": "sha512-O4L094N2/dZ7xqVdrXhh9r1KODPJpFms8B5sGdJLPy664AgvXsreZUyCQQNItZRDlYug4xStLjNp/sz3HvBowQ==",
-      "dev": true,
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/cli-truncate/node_modules/slice-ansi": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-5.0.0.tgz",
-      "integrity": "sha512-FC+lgizVPfie0kkhqUScwRu1O/lF6NOgJmlCgK+/LYxDCTk8sGelYaHDhFcDN+Sn3Cv+3VSa4Byeo+IMCzpMgQ==",
-      "dev": true,
-      "dependencies": {
-        "ansi-styles": "^6.0.0",
-        "is-fullwidth-code-point": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/slice-ansi?sponsor=1"
-      }
-    },
-    "node_modules/cli-truncate/node_modules/string-width": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
-      "integrity": "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==",
-      "dev": true,
-      "dependencies": {
-        "eastasianwidth": "^0.2.0",
-        "emoji-regex": "^9.2.2",
-        "strip-ansi": "^7.0.1"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/cli-truncate/node_modules/strip-ansi": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.0.1.tgz",
-      "integrity": "sha512-cXNxvT8dFNRVfhVME3JAe98mkXDYN2O1l7jmcwMnOslDeESg1rF/OZMtK0nRAhiari1unG5cD4jG3rapUAkLbw==",
-      "dev": true,
-      "dependencies": {
-        "ansi-regex": "^6.0.1"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
-      }
-    },
     "node_modules/cliui": {
       "version": "7.0.4",
       "resolved": "https://registry.npmjs.org/cliui/-/cliui-7.0.4.tgz",
@@ -9051,12 +8935,6 @@
       "bin": {
         "color-support": "bin.js"
       }
-    },
-    "node_modules/colorette": {
-      "version": "2.0.19",
-      "resolved": "https://registry.npmjs.org/colorette/-/colorette-2.0.19.tgz",
-      "integrity": "sha512-3tlv/dIP7FWvj3BsbHrGLJ6l/oKh1O3TcgBqMn+yyCagOxc23fyzDS6HypQbgxWbkpDnf52p1LuR4eWDQ/K9WQ==",
-      "dev": true
     },
     "node_modules/colors": {
       "version": "1.4.0",
@@ -11083,31 +10961,6 @@
       },
       "engines": {
         "node": ">=10.13.0"
-      }
-    },
-    "node_modules/enquirer": {
-      "version": "2.3.6",
-      "resolved": "https://registry.npmjs.org/enquirer/-/enquirer-2.3.6.tgz",
-      "integrity": "sha512-yjNnPr315/FjS4zIsUxYguYUPP2e1NK4d7E7ZOLiyYCcbFBiTMyID+2wvm2w6+pZ/odMA7cRkjhsPbltwBOrLg==",
-      "dev": true,
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "ansi-colors": "^4.1.1"
-      },
-      "engines": {
-        "node": ">=8.6"
-      }
-    },
-    "node_modules/enquirer/node_modules/ansi-colors": {
-      "version": "4.1.3",
-      "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-4.1.3.tgz",
-      "integrity": "sha512-/6w/C21Pm1A7aZitlI5Ni/2J6FFQN8i1Cvz3kHABAAbw93v/NlvKdVOqz7CCWz/3iv/JplRSEEZ83XION15ovw==",
-      "dev": true,
-      "optional": true,
-      "peer": true,
-      "engines": {
-        "node": ">=6"
       }
     },
     "node_modules/ent": {
@@ -15211,15 +15064,15 @@
       }
     },
     "node_modules/husky": {
-      "version": "8.0.3",
-      "resolved": "https://registry.npmjs.org/husky/-/husky-8.0.3.tgz",
-      "integrity": "sha512-+dQSyqPh4x1hlO1swXBiNb2HzTDN1I2IGLQx1GrBuiqFJfoMrnZWwVmatvSiO+Iz8fBUnf+lekwNo4c2LlXItg==",
+      "version": "9.0.11",
+      "resolved": "https://registry.npmjs.org/husky/-/husky-9.0.11.tgz",
+      "integrity": "sha512-AB6lFlbwwyIqMdHYhwPe+kjOC3Oc5P3nThEoW/AaO2BX3vJDjWPFxYLxokUZOo6RNX20He3AaT8sESs9NJcmEw==",
       "dev": true,
       "bin": {
-        "husky": "lib/bin.js"
+        "husky": "bin.mjs"
       },
       "engines": {
-        "node": ">=14"
+        "node": ">=18"
       },
       "funding": {
         "url": "https://github.com/sponsors/typicode"
@@ -18751,15 +18604,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/lilconfig": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/lilconfig/-/lilconfig-2.1.0.tgz",
-      "integrity": "sha512-utWOt/GHzuUxnLKxB6dk81RoOeoNeHgbrXiuGk4yyF5qlRz+iIVWu56E2fqGHFrXz0QNUhLB/8nKqvRH66JKGQ==",
-      "dev": true,
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/limiter": {
       "version": "1.1.5",
       "resolved": "https://registry.npmjs.org/limiter/-/limiter-1.1.5.tgz",
@@ -18779,281 +18623,6 @@
       "dev": true,
       "dependencies": {
         "uc.micro": "^1.0.1"
-      }
-    },
-    "node_modules/lint-staged": {
-      "version": "13.2.2",
-      "resolved": "https://registry.npmjs.org/lint-staged/-/lint-staged-13.2.2.tgz",
-      "integrity": "sha512-71gSwXKy649VrSU09s10uAT0rWCcY3aewhMaHyl2N84oBk4Xs9HgxvUp3AYu+bNsK4NrOYYxvSgg7FyGJ+jGcA==",
-      "dev": true,
-      "dependencies": {
-        "chalk": "5.2.0",
-        "cli-truncate": "^3.1.0",
-        "commander": "^10.0.0",
-        "debug": "^4.3.4",
-        "execa": "^7.0.0",
-        "lilconfig": "2.1.0",
-        "listr2": "^5.0.7",
-        "micromatch": "^4.0.5",
-        "normalize-path": "^3.0.0",
-        "object-inspect": "^1.12.3",
-        "pidtree": "^0.6.0",
-        "string-argv": "^0.3.1",
-        "yaml": "^2.2.2"
-      },
-      "bin": {
-        "lint-staged": "bin/lint-staged.js"
-      },
-      "engines": {
-        "node": "^14.13.1 || >=16.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/lint-staged"
-      }
-    },
-    "node_modules/lint-staged/node_modules/chalk": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.2.0.tgz",
-      "integrity": "sha512-ree3Gqw/nazQAPuJJEy+avdl7QfZMcUvmHIKgEZkGL+xOBzRvup5Hxo6LHuMceSxOabuJLJm5Yp/92R9eMmMvA==",
-      "dev": true,
-      "engines": {
-        "node": "^12.17.0 || ^14.13 || >=16.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/chalk?sponsor=1"
-      }
-    },
-    "node_modules/lint-staged/node_modules/execa": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/execa/-/execa-7.0.0.tgz",
-      "integrity": "sha512-tQbH0pH/8LHTnwTrsKWideqi6rFB/QNUawEwrn+WHyz7PX1Tuz2u7wfTvbaNBdP5JD5LVWxNo8/A8CHNZ3bV6g==",
-      "dev": true,
-      "dependencies": {
-        "cross-spawn": "^7.0.3",
-        "get-stream": "^6.0.1",
-        "human-signals": "^4.3.0",
-        "is-stream": "^3.0.0",
-        "merge-stream": "^2.0.0",
-        "npm-run-path": "^5.1.0",
-        "onetime": "^6.0.0",
-        "signal-exit": "^3.0.7",
-        "strip-final-newline": "^3.0.0"
-      },
-      "engines": {
-        "node": "^14.18.0 || ^16.14.0 || >=18.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/sindresorhus/execa?sponsor=1"
-      }
-    },
-    "node_modules/lint-staged/node_modules/human-signals": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-4.3.0.tgz",
-      "integrity": "sha512-zyzVyMjpGBX2+6cDVZeFPCdtOtdsxOeseRhB9tkQ6xXmGUNrcnBzdEKPy3VPNYz+4gy1oukVOXcrJCunSyc6QQ==",
-      "dev": true,
-      "engines": {
-        "node": ">=14.18.0"
-      }
-    },
-    "node_modules/lint-staged/node_modules/is-stream": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-3.0.0.tgz",
-      "integrity": "sha512-LnQR4bZ9IADDRSkvpqMGvt/tEJWclzklNgSw48V5EAaAeDd6qGvN8ei6k5p0tvxSR171VmGyHuTiAOfxAbr8kA==",
-      "dev": true,
-      "engines": {
-        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/lint-staged/node_modules/mimic-fn": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-4.0.0.tgz",
-      "integrity": "sha512-vqiC06CuhBTUdZH+RYl8sFrL096vA45Ok5ISO6sE/Mr1jRbGH4Csnhi8f3wKVl7x8mO4Au7Ir9D3Oyv1VYMFJw==",
-      "dev": true,
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/lint-staged/node_modules/normalize-path": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
-      "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
-      "dev": true,
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/lint-staged/node_modules/npm-run-path": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-5.1.0.tgz",
-      "integrity": "sha512-sJOdmRGrY2sjNTRMbSvluQqg+8X7ZK61yvzBEIDhz4f8z1TZFYABsqjjCBd/0PUNE9M6QDgHJXQkGUEm7Q+l9Q==",
-      "dev": true,
-      "dependencies": {
-        "path-key": "^4.0.0"
-      },
-      "engines": {
-        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/lint-staged/node_modules/onetime": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/onetime/-/onetime-6.0.0.tgz",
-      "integrity": "sha512-1FlR+gjXK7X+AsAHso35MnyN5KqGwJRi/31ft6x0M194ht7S+rWAvd7PHss9xSKMzE0asv1pyIHaJYq+BbacAQ==",
-      "dev": true,
-      "dependencies": {
-        "mimic-fn": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/lint-staged/node_modules/path-key": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/path-key/-/path-key-4.0.0.tgz",
-      "integrity": "sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ==",
-      "dev": true,
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/lint-staged/node_modules/strip-final-newline": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-3.0.0.tgz",
-      "integrity": "sha512-dOESqjYr96iWYylGObzd39EuNTa5VJxyvVAEm5Jnh7KGo75V43Hk1odPQkNDyXNmUR6k+gEiDVXnjB8HJ3crXw==",
-      "dev": true,
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/lint-staged/node_modules/yaml": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.2.2.tgz",
-      "integrity": "sha512-CBKFWExMn46Foo4cldiChEzn7S7SRV+wqiluAb6xmueD/fGyRHIhX8m14vVGgeFWjN540nKCNVj6P21eQjgTuA==",
-      "dev": true,
-      "engines": {
-        "node": ">= 14"
-      }
-    },
-    "node_modules/listr2": {
-      "version": "5.0.7",
-      "resolved": "https://registry.npmjs.org/listr2/-/listr2-5.0.7.tgz",
-      "integrity": "sha512-MD+qXHPmtivrHIDRwPYdfNkrzqDiuaKU/rfBcec3WMyMF3xylQj3jMq344OtvQxz7zaCFViRAeqlr2AFhPvXHw==",
-      "dev": true,
-      "dependencies": {
-        "cli-truncate": "^2.1.0",
-        "colorette": "^2.0.19",
-        "log-update": "^4.0.0",
-        "p-map": "^4.0.0",
-        "rfdc": "^1.3.0",
-        "rxjs": "^7.8.0",
-        "through": "^2.3.8",
-        "wrap-ansi": "^7.0.0"
-      },
-      "engines": {
-        "node": "^14.13.1 || >=16.0.0"
-      },
-      "peerDependencies": {
-        "enquirer": ">= 2.3.0 < 3"
-      },
-      "peerDependenciesMeta": {
-        "enquirer": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/listr2/node_modules/ansi-styles": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-      "dev": true,
-      "dependencies": {
-        "color-convert": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
-    "node_modules/listr2/node_modules/cli-truncate": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/cli-truncate/-/cli-truncate-2.1.0.tgz",
-      "integrity": "sha512-n8fOixwDD6b/ObinzTrp1ZKFzbgvKZvuz/TvejnLn1aQfC6r52XEx85FmuC+3HI+JM7coBRXUvNqEU2PHVrHpg==",
-      "dev": true,
-      "dependencies": {
-        "slice-ansi": "^3.0.0",
-        "string-width": "^4.2.0"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/listr2/node_modules/color-convert": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-      "dev": true,
-      "dependencies": {
-        "color-name": "~1.1.4"
-      },
-      "engines": {
-        "node": ">=7.0.0"
-      }
-    },
-    "node_modules/listr2/node_modules/color-name": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-      "dev": true
-    },
-    "node_modules/listr2/node_modules/p-map": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/p-map/-/p-map-4.0.0.tgz",
-      "integrity": "sha512-/bjOqmgETBYB5BoEeGVea8dmvHb2m9GLy1E9W43yeyfP6QQCZGFNa+XRceJEuDB6zqr+gKpIAmlLebMpykw/MQ==",
-      "dev": true,
-      "dependencies": {
-        "aggregate-error": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/listr2/node_modules/slice-ansi": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-3.0.0.tgz",
-      "integrity": "sha512-pSyv7bSTC7ig9Dcgbw9AuRNUb5k5V6oDudjZoMBSr13qpLBG7tB+zgCkARjq7xIUgdz5P1Qe8u+rSGdouOOIyQ==",
-      "dev": true,
-      "dependencies": {
-        "ansi-styles": "^4.0.0",
-        "astral-regex": "^2.0.0",
-        "is-fullwidth-code-point": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/load-json-file": {
@@ -19256,98 +18825,6 @@
       "dev": true,
       "dependencies": {
         "has-flag": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/log-update": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/log-update/-/log-update-4.0.0.tgz",
-      "integrity": "sha512-9fkkDevMefjg0mmzWFBW8YkFP91OrizzkW3diF7CpG+S2EYdy4+TVfGwz1zeF8x7hCx1ovSPTOE9Ngib74qqUg==",
-      "dev": true,
-      "dependencies": {
-        "ansi-escapes": "^4.3.0",
-        "cli-cursor": "^3.1.0",
-        "slice-ansi": "^4.0.0",
-        "wrap-ansi": "^6.2.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/log-update/node_modules/ansi-escapes": {
-      "version": "4.3.2",
-      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.3.2.tgz",
-      "integrity": "sha512-gKXj5ALrKWQLsYG9jlTRmR/xKluxHV+Z9QEwNIgCfM1/uwPMCuzVVnh5mwTd+OuBZcwSIMbqssNWRm1lE51QaQ==",
-      "dev": true,
-      "dependencies": {
-        "type-fest": "^0.21.3"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/log-update/node_modules/ansi-styles": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-      "dev": true,
-      "dependencies": {
-        "color-convert": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
-    "node_modules/log-update/node_modules/color-convert": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-      "dev": true,
-      "dependencies": {
-        "color-name": "~1.1.4"
-      },
-      "engines": {
-        "node": ">=7.0.0"
-      }
-    },
-    "node_modules/log-update/node_modules/color-name": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-      "dev": true
-    },
-    "node_modules/log-update/node_modules/type-fest": {
-      "version": "0.21.3",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.21.3.tgz",
-      "integrity": "sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==",
-      "dev": true,
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/log-update/node_modules/wrap-ansi": {
-      "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
-      "integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
-      "dev": true,
-      "dependencies": {
-        "ansi-styles": "^4.0.0",
-        "string-width": "^4.1.0",
-        "strip-ansi": "^6.0.0"
       },
       "engines": {
         "node": ">=8"
@@ -24745,18 +24222,6 @@
         "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
-    "node_modules/pidtree": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/pidtree/-/pidtree-0.6.0.tgz",
-      "integrity": "sha512-eG2dWTVw5bzqGRztnHExczNxt5VGsE6OwTeCG3fdUf9KBsZzO3R5OIIIzWR+iZA0NtZ+RDVdaoE2dK1cn6jH4g==",
-      "dev": true,
-      "bin": {
-        "pidtree": "bin/pidtree.js"
-      },
-      "engines": {
-        "node": ">=0.10"
-      }
-    },
     "node_modules/pify": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
@@ -25065,9 +24530,9 @@
       }
     },
     "node_modules/prettier": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.0.2.tgz",
-      "integrity": "sha512-o2YR9qtniXvwEZlOKbveKfDQVyqxbEIWn48Z8m3ZJjBjcCmUy3xZGIv+7AkaeuaTr6yPXJjwv07ZWlsWbEy1rQ==",
+      "version": "3.2.5",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.2.5.tgz",
+      "integrity": "sha512-3/GWa9aOC0YeD7LUfvOG2NiDyhOWRvt1k+rcKhOuYnMY24iiCphgneUfJDyFXd6rZCAnuLBv6UeAULtrhT/F4A==",
       "dev": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
@@ -26429,12 +25894,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/rfdc": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/rfdc/-/rfdc-1.3.0.tgz",
-      "integrity": "sha512-V2hovdzFbOi77/WajaSMXk2OLm+xNIeQdMMuB7icj7bk6zi2F8GGAxigcnDFpJHbNyNcgyJDiP+8nOrY5cZGrA==",
-      "dev": true
-    },
     "node_modules/rimraf": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
@@ -26481,15 +25940,6 @@
       ],
       "dependencies": {
         "queue-microtask": "^1.2.2"
-      }
-    },
-    "node_modules/rxjs": {
-      "version": "7.8.0",
-      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.0.tgz",
-      "integrity": "sha512-F2+gxDshqmIub1KdvZkaEfGDwLNpPvk9Fs6LD/MyQxNgMds/WH9OdDDXOmxUZpME+iSK3rQCctkL0DYyytUqMg==",
-      "dev": true,
-      "dependencies": {
-        "tslib": "^2.1.0"
       }
     },
     "node_modules/safari-14-idb-fix": {
@@ -26952,56 +26402,6 @@
       "engines": {
         "node": ">=8"
       }
-    },
-    "node_modules/slice-ansi": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-4.0.0.tgz",
-      "integrity": "sha512-qMCMfhY040cVHT43K9BFygqYbUPFZKHOg7K73mtTWJRb8pyP3fzf4Ixd5SzdEJQ6MRUg/WBnOLxghZtKKurENQ==",
-      "dev": true,
-      "dependencies": {
-        "ansi-styles": "^4.0.0",
-        "astral-regex": "^2.0.0",
-        "is-fullwidth-code-point": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/slice-ansi?sponsor=1"
-      }
-    },
-    "node_modules/slice-ansi/node_modules/ansi-styles": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-      "dev": true,
-      "dependencies": {
-        "color-convert": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
-    "node_modules/slice-ansi/node_modules/color-convert": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-      "dev": true,
-      "dependencies": {
-        "color-name": "~1.1.4"
-      },
-      "engines": {
-        "node": ">=7.0.0"
-      }
-    },
-    "node_modules/slice-ansi/node_modules/color-name": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-      "dev": true
     },
     "node_modules/slide": {
       "version": "1.1.6",
@@ -27677,15 +27077,6 @@
           "url": "https://feross.org/support"
         }
       ]
-    },
-    "node_modules/string-argv": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/string-argv/-/string-argv-0.3.1.tgz",
-      "integrity": "sha512-a1uQGz7IyVy9YwhqjZIZu1c8JO8dNIe20xBmSS6qu9kv++k3JGzCVmprbNN5Kn+BgzD5E7YYwg1CcjuJMRNsvg==",
-      "dev": true,
-      "engines": {
-        "node": ">=0.6.19"
-      }
     },
     "node_modules/string-length": {
       "version": "4.0.2",
@@ -35380,12 +34771,6 @@
         "tslib": "^2.0.1"
       }
     },
-    "astral-regex": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-2.0.0.tgz",
-      "integrity": "sha512-Z7tMw1ytTXt5jqMcOP+OQteU1VuNK9Y02uuJtKQ1Sv69jXQKKg5cibLwGJow8yzZP+eAc18EmLGPal0bp36rvQ==",
-      "dev": true
-    },
     "async": {
       "version": "3.2.5",
       "resolved": "https://registry.npmjs.org/async/-/async-3.2.5.tgz",
@@ -36683,72 +36068,6 @@
         "string-width": "^4.2.0"
       }
     },
-    "cli-truncate": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/cli-truncate/-/cli-truncate-3.1.0.tgz",
-      "integrity": "sha512-wfOBkjXteqSnI59oPcJkcPl/ZmwvMMOj340qUIY1SKZCv0B9Cf4D4fAucRkIKQmsIuYK3x1rrgU7MeGRruiuiA==",
-      "dev": true,
-      "requires": {
-        "slice-ansi": "^5.0.0",
-        "string-width": "^5.0.0"
-      },
-      "dependencies": {
-        "ansi-regex": {
-          "version": "6.0.1",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.0.1.tgz",
-          "integrity": "sha512-n5M855fKb2SsfMIiFFoVrABHJC8QtHwVx+mHWP3QcEqBHYienj5dHSgjbxtC0WEZXYt4wcD6zrQElDPhFuZgfA==",
-          "dev": true
-        },
-        "ansi-styles": {
-          "version": "6.2.1",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.1.tgz",
-          "integrity": "sha512-bN798gFfQX+viw3R7yrGWRqnrN2oRkEkUjjl4JNn4E8GxxbjtG3FbrEIIY3l8/hrwUwIeCZvi4QuOTP4MErVug==",
-          "dev": true
-        },
-        "emoji-regex": {
-          "version": "9.2.2",
-          "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
-          "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
-          "dev": true
-        },
-        "is-fullwidth-code-point": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-4.0.0.tgz",
-          "integrity": "sha512-O4L094N2/dZ7xqVdrXhh9r1KODPJpFms8B5sGdJLPy664AgvXsreZUyCQQNItZRDlYug4xStLjNp/sz3HvBowQ==",
-          "dev": true
-        },
-        "slice-ansi": {
-          "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-5.0.0.tgz",
-          "integrity": "sha512-FC+lgizVPfie0kkhqUScwRu1O/lF6NOgJmlCgK+/LYxDCTk8sGelYaHDhFcDN+Sn3Cv+3VSa4Byeo+IMCzpMgQ==",
-          "dev": true,
-          "requires": {
-            "ansi-styles": "^6.0.0",
-            "is-fullwidth-code-point": "^4.0.0"
-          }
-        },
-        "string-width": {
-          "version": "5.1.2",
-          "resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
-          "integrity": "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==",
-          "dev": true,
-          "requires": {
-            "eastasianwidth": "^0.2.0",
-            "emoji-regex": "^9.2.2",
-            "strip-ansi": "^7.0.1"
-          }
-        },
-        "strip-ansi": {
-          "version": "7.0.1",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.0.1.tgz",
-          "integrity": "sha512-cXNxvT8dFNRVfhVME3JAe98mkXDYN2O1l7jmcwMnOslDeESg1rF/OZMtK0nRAhiari1unG5cD4jG3rapUAkLbw==",
-          "dev": true,
-          "requires": {
-            "ansi-regex": "^6.0.1"
-          }
-        }
-      }
-    },
     "cliui": {
       "version": "7.0.4",
       "resolved": "https://registry.npmjs.org/cliui/-/cliui-7.0.4.tgz",
@@ -36924,12 +36243,6 @@
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/color-support/-/color-support-1.1.3.tgz",
       "integrity": "sha512-qiBjkpbMLO/HL68y+lh4q0/O1MZFj2RX6X/KmMa3+gJD3z+WwI1ZzDHysvqHGS3mP6mznPckpXmw1nI9cJjyRg==",
-      "dev": true
-    },
-    "colorette": {
-      "version": "2.0.19",
-      "resolved": "https://registry.npmjs.org/colorette/-/colorette-2.0.19.tgz",
-      "integrity": "sha512-3tlv/dIP7FWvj3BsbHrGLJ6l/oKh1O3TcgBqMn+yyCagOxc23fyzDS6HypQbgxWbkpDnf52p1LuR4eWDQ/K9WQ==",
       "dev": true
     },
     "colors": {
@@ -38582,27 +37895,6 @@
       "requires": {
         "graceful-fs": "^4.2.4",
         "tapable": "^2.2.0"
-      }
-    },
-    "enquirer": {
-      "version": "2.3.6",
-      "resolved": "https://registry.npmjs.org/enquirer/-/enquirer-2.3.6.tgz",
-      "integrity": "sha512-yjNnPr315/FjS4zIsUxYguYUPP2e1NK4d7E7ZOLiyYCcbFBiTMyID+2wvm2w6+pZ/odMA7cRkjhsPbltwBOrLg==",
-      "dev": true,
-      "optional": true,
-      "peer": true,
-      "requires": {
-        "ansi-colors": "^4.1.1"
-      },
-      "dependencies": {
-        "ansi-colors": {
-          "version": "4.1.3",
-          "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-4.1.3.tgz",
-          "integrity": "sha512-/6w/C21Pm1A7aZitlI5Ni/2J6FFQN8i1Cvz3kHABAAbw93v/NlvKdVOqz7CCWz/3iv/JplRSEEZ83XION15ovw==",
-          "dev": true,
-          "optional": true,
-          "peer": true
-        }
       }
     },
     "ent": {
@@ -41895,9 +41187,9 @@
       "dev": true
     },
     "husky": {
-      "version": "8.0.3",
-      "resolved": "https://registry.npmjs.org/husky/-/husky-8.0.3.tgz",
-      "integrity": "sha512-+dQSyqPh4x1hlO1swXBiNb2HzTDN1I2IGLQx1GrBuiqFJfoMrnZWwVmatvSiO+Iz8fBUnf+lekwNo4c2LlXItg==",
+      "version": "9.0.11",
+      "resolved": "https://registry.npmjs.org/husky/-/husky-9.0.11.tgz",
+      "integrity": "sha512-AB6lFlbwwyIqMdHYhwPe+kjOC3Oc5P3nThEoW/AaO2BX3vJDjWPFxYLxokUZOo6RNX20He3AaT8sESs9NJcmEw==",
       "dev": true
     },
     "iconv-lite": {
@@ -44555,12 +43847,6 @@
         }
       }
     },
-    "lilconfig": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/lilconfig/-/lilconfig-2.1.0.tgz",
-      "integrity": "sha512-utWOt/GHzuUxnLKxB6dk81RoOeoNeHgbrXiuGk4yyF5qlRz+iIVWu56E2fqGHFrXz0QNUhLB/8nKqvRH66JKGQ==",
-      "dev": true
-    },
     "limiter": {
       "version": "1.1.5",
       "resolved": "https://registry.npmjs.org/limiter/-/limiter-1.1.5.tgz",
@@ -44580,184 +43866,6 @@
       "dev": true,
       "requires": {
         "uc.micro": "^1.0.1"
-      }
-    },
-    "lint-staged": {
-      "version": "13.2.2",
-      "resolved": "https://registry.npmjs.org/lint-staged/-/lint-staged-13.2.2.tgz",
-      "integrity": "sha512-71gSwXKy649VrSU09s10uAT0rWCcY3aewhMaHyl2N84oBk4Xs9HgxvUp3AYu+bNsK4NrOYYxvSgg7FyGJ+jGcA==",
-      "dev": true,
-      "requires": {
-        "chalk": "5.2.0",
-        "cli-truncate": "^3.1.0",
-        "commander": "^10.0.0",
-        "debug": "^4.3.4",
-        "execa": "^7.0.0",
-        "lilconfig": "2.1.0",
-        "listr2": "^5.0.7",
-        "micromatch": "^4.0.5",
-        "normalize-path": "^3.0.0",
-        "object-inspect": "^1.12.3",
-        "pidtree": "^0.6.0",
-        "string-argv": "^0.3.1",
-        "yaml": "^2.2.2"
-      },
-      "dependencies": {
-        "chalk": {
-          "version": "5.2.0",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.2.0.tgz",
-          "integrity": "sha512-ree3Gqw/nazQAPuJJEy+avdl7QfZMcUvmHIKgEZkGL+xOBzRvup5Hxo6LHuMceSxOabuJLJm5Yp/92R9eMmMvA==",
-          "dev": true
-        },
-        "execa": {
-          "version": "7.0.0",
-          "resolved": "https://registry.npmjs.org/execa/-/execa-7.0.0.tgz",
-          "integrity": "sha512-tQbH0pH/8LHTnwTrsKWideqi6rFB/QNUawEwrn+WHyz7PX1Tuz2u7wfTvbaNBdP5JD5LVWxNo8/A8CHNZ3bV6g==",
-          "dev": true,
-          "requires": {
-            "cross-spawn": "^7.0.3",
-            "get-stream": "^6.0.1",
-            "human-signals": "^4.3.0",
-            "is-stream": "^3.0.0",
-            "merge-stream": "^2.0.0",
-            "npm-run-path": "^5.1.0",
-            "onetime": "^6.0.0",
-            "signal-exit": "^3.0.7",
-            "strip-final-newline": "^3.0.0"
-          }
-        },
-        "human-signals": {
-          "version": "4.3.0",
-          "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-4.3.0.tgz",
-          "integrity": "sha512-zyzVyMjpGBX2+6cDVZeFPCdtOtdsxOeseRhB9tkQ6xXmGUNrcnBzdEKPy3VPNYz+4gy1oukVOXcrJCunSyc6QQ==",
-          "dev": true
-        },
-        "is-stream": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-3.0.0.tgz",
-          "integrity": "sha512-LnQR4bZ9IADDRSkvpqMGvt/tEJWclzklNgSw48V5EAaAeDd6qGvN8ei6k5p0tvxSR171VmGyHuTiAOfxAbr8kA==",
-          "dev": true
-        },
-        "mimic-fn": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-4.0.0.tgz",
-          "integrity": "sha512-vqiC06CuhBTUdZH+RYl8sFrL096vA45Ok5ISO6sE/Mr1jRbGH4Csnhi8f3wKVl7x8mO4Au7Ir9D3Oyv1VYMFJw==",
-          "dev": true
-        },
-        "normalize-path": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
-          "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
-          "dev": true
-        },
-        "npm-run-path": {
-          "version": "5.1.0",
-          "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-5.1.0.tgz",
-          "integrity": "sha512-sJOdmRGrY2sjNTRMbSvluQqg+8X7ZK61yvzBEIDhz4f8z1TZFYABsqjjCBd/0PUNE9M6QDgHJXQkGUEm7Q+l9Q==",
-          "dev": true,
-          "requires": {
-            "path-key": "^4.0.0"
-          }
-        },
-        "onetime": {
-          "version": "6.0.0",
-          "resolved": "https://registry.npmjs.org/onetime/-/onetime-6.0.0.tgz",
-          "integrity": "sha512-1FlR+gjXK7X+AsAHso35MnyN5KqGwJRi/31ft6x0M194ht7S+rWAvd7PHss9xSKMzE0asv1pyIHaJYq+BbacAQ==",
-          "dev": true,
-          "requires": {
-            "mimic-fn": "^4.0.0"
-          }
-        },
-        "path-key": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/path-key/-/path-key-4.0.0.tgz",
-          "integrity": "sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ==",
-          "dev": true
-        },
-        "strip-final-newline": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-3.0.0.tgz",
-          "integrity": "sha512-dOESqjYr96iWYylGObzd39EuNTa5VJxyvVAEm5Jnh7KGo75V43Hk1odPQkNDyXNmUR6k+gEiDVXnjB8HJ3crXw==",
-          "dev": true
-        },
-        "yaml": {
-          "version": "2.2.2",
-          "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.2.2.tgz",
-          "integrity": "sha512-CBKFWExMn46Foo4cldiChEzn7S7SRV+wqiluAb6xmueD/fGyRHIhX8m14vVGgeFWjN540nKCNVj6P21eQjgTuA==",
-          "dev": true
-        }
-      }
-    },
-    "listr2": {
-      "version": "5.0.7",
-      "resolved": "https://registry.npmjs.org/listr2/-/listr2-5.0.7.tgz",
-      "integrity": "sha512-MD+qXHPmtivrHIDRwPYdfNkrzqDiuaKU/rfBcec3WMyMF3xylQj3jMq344OtvQxz7zaCFViRAeqlr2AFhPvXHw==",
-      "dev": true,
-      "requires": {
-        "cli-truncate": "^2.1.0",
-        "colorette": "^2.0.19",
-        "log-update": "^4.0.0",
-        "p-map": "^4.0.0",
-        "rfdc": "^1.3.0",
-        "rxjs": "^7.8.0",
-        "through": "^2.3.8",
-        "wrap-ansi": "^7.0.0"
-      },
-      "dependencies": {
-        "ansi-styles": {
-          "version": "4.3.0",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-          "dev": true,
-          "requires": {
-            "color-convert": "^2.0.1"
-          }
-        },
-        "cli-truncate": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/cli-truncate/-/cli-truncate-2.1.0.tgz",
-          "integrity": "sha512-n8fOixwDD6b/ObinzTrp1ZKFzbgvKZvuz/TvejnLn1aQfC6r52XEx85FmuC+3HI+JM7coBRXUvNqEU2PHVrHpg==",
-          "dev": true,
-          "requires": {
-            "slice-ansi": "^3.0.0",
-            "string-width": "^4.2.0"
-          }
-        },
-        "color-convert": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-          "dev": true,
-          "requires": {
-            "color-name": "~1.1.4"
-          }
-        },
-        "color-name": {
-          "version": "1.1.4",
-          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-          "dev": true
-        },
-        "p-map": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/p-map/-/p-map-4.0.0.tgz",
-          "integrity": "sha512-/bjOqmgETBYB5BoEeGVea8dmvHb2m9GLy1E9W43yeyfP6QQCZGFNa+XRceJEuDB6zqr+gKpIAmlLebMpykw/MQ==",
-          "dev": true,
-          "requires": {
-            "aggregate-error": "^3.0.0"
-          }
-        },
-        "slice-ansi": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-3.0.0.tgz",
-          "integrity": "sha512-pSyv7bSTC7ig9Dcgbw9AuRNUb5k5V6oDudjZoMBSr13qpLBG7tB+zgCkARjq7xIUgdz5P1Qe8u+rSGdouOOIyQ==",
-          "dev": true,
-          "requires": {
-            "ansi-styles": "^4.0.0",
-            "astral-regex": "^2.0.0",
-            "is-fullwidth-code-point": "^3.0.0"
-          }
-        }
       }
     },
     "load-json-file": {
@@ -44929,70 +44037,6 @@
           "dev": true,
           "requires": {
             "has-flag": "^4.0.0"
-          }
-        }
-      }
-    },
-    "log-update": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/log-update/-/log-update-4.0.0.tgz",
-      "integrity": "sha512-9fkkDevMefjg0mmzWFBW8YkFP91OrizzkW3diF7CpG+S2EYdy4+TVfGwz1zeF8x7hCx1ovSPTOE9Ngib74qqUg==",
-      "dev": true,
-      "requires": {
-        "ansi-escapes": "^4.3.0",
-        "cli-cursor": "^3.1.0",
-        "slice-ansi": "^4.0.0",
-        "wrap-ansi": "^6.2.0"
-      },
-      "dependencies": {
-        "ansi-escapes": {
-          "version": "4.3.2",
-          "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.3.2.tgz",
-          "integrity": "sha512-gKXj5ALrKWQLsYG9jlTRmR/xKluxHV+Z9QEwNIgCfM1/uwPMCuzVVnh5mwTd+OuBZcwSIMbqssNWRm1lE51QaQ==",
-          "dev": true,
-          "requires": {
-            "type-fest": "^0.21.3"
-          }
-        },
-        "ansi-styles": {
-          "version": "4.3.0",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-          "dev": true,
-          "requires": {
-            "color-convert": "^2.0.1"
-          }
-        },
-        "color-convert": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-          "dev": true,
-          "requires": {
-            "color-name": "~1.1.4"
-          }
-        },
-        "color-name": {
-          "version": "1.1.4",
-          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-          "dev": true
-        },
-        "type-fest": {
-          "version": "0.21.3",
-          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.21.3.tgz",
-          "integrity": "sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==",
-          "dev": true
-        },
-        "wrap-ansi": {
-          "version": "6.2.0",
-          "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
-          "integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
-          "dev": true,
-          "requires": {
-            "ansi-styles": "^4.0.0",
-            "string-width": "^4.1.0",
-            "strip-ansi": "^6.0.0"
           }
         }
       }
@@ -48986,12 +48030,6 @@
       "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
       "dev": true
     },
-    "pidtree": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/pidtree/-/pidtree-0.6.0.tgz",
-      "integrity": "sha512-eG2dWTVw5bzqGRztnHExczNxt5VGsE6OwTeCG3fdUf9KBsZzO3R5OIIIzWR+iZA0NtZ+RDVdaoE2dK1cn6jH4g==",
-      "dev": true
-    },
     "pify": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
@@ -49209,9 +48247,9 @@
       "dev": true
     },
     "prettier": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.0.2.tgz",
-      "integrity": "sha512-o2YR9qtniXvwEZlOKbveKfDQVyqxbEIWn48Z8m3ZJjBjcCmUy3xZGIv+7AkaeuaTr6yPXJjwv07ZWlsWbEy1rQ==",
+      "version": "3.2.5",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.2.5.tgz",
+      "integrity": "sha512-3/GWa9aOC0YeD7LUfvOG2NiDyhOWRvt1k+rcKhOuYnMY24iiCphgneUfJDyFXd6rZCAnuLBv6UeAULtrhT/F4A==",
       "dev": true
     },
     "pretty-format": {
@@ -50303,12 +49341,6 @@
       "integrity": "sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw==",
       "dev": true
     },
-    "rfdc": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/rfdc/-/rfdc-1.3.0.tgz",
-      "integrity": "sha512-V2hovdzFbOi77/WajaSMXk2OLm+xNIeQdMMuB7icj7bk6zi2F8GGAxigcnDFpJHbNyNcgyJDiP+8nOrY5cZGrA==",
-      "dev": true
-    },
     "rimraf": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
@@ -50335,15 +49367,6 @@
       "dev": true,
       "requires": {
         "queue-microtask": "^1.2.2"
-      }
-    },
-    "rxjs": {
-      "version": "7.8.0",
-      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.0.tgz",
-      "integrity": "sha512-F2+gxDshqmIub1KdvZkaEfGDwLNpPvk9Fs6LD/MyQxNgMds/WH9OdDDXOmxUZpME+iSK3rQCctkL0DYyytUqMg==",
-      "dev": true,
-      "requires": {
-        "tslib": "^2.1.0"
       }
     },
     "safari-14-idb-fix": {
@@ -50720,43 +49743,6 @@
       "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
       "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
       "dev": true
-    },
-    "slice-ansi": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-4.0.0.tgz",
-      "integrity": "sha512-qMCMfhY040cVHT43K9BFygqYbUPFZKHOg7K73mtTWJRb8pyP3fzf4Ixd5SzdEJQ6MRUg/WBnOLxghZtKKurENQ==",
-      "dev": true,
-      "requires": {
-        "ansi-styles": "^4.0.0",
-        "astral-regex": "^2.0.0",
-        "is-fullwidth-code-point": "^3.0.0"
-      },
-      "dependencies": {
-        "ansi-styles": {
-          "version": "4.3.0",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-          "dev": true,
-          "requires": {
-            "color-convert": "^2.0.1"
-          }
-        },
-        "color-convert": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-          "dev": true,
-          "requires": {
-            "color-name": "~1.1.4"
-          }
-        },
-        "color-name": {
-          "version": "1.1.4",
-          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-          "dev": true
-        }
-      }
     },
     "slide": {
       "version": "1.1.6",
@@ -51334,12 +50320,6 @@
           "dev": true
         }
       }
-    },
-    "string-argv": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/string-argv/-/string-argv-0.3.1.tgz",
-      "integrity": "sha512-a1uQGz7IyVy9YwhqjZIZu1c8JO8dNIe20xBmSS6qu9kv++k3JGzCVmprbNN5Kn+BgzD5E7YYwg1CcjuJMRNsvg==",
-      "dev": true
     },
     "string-length": {
       "version": "4.0.2",

--- a/package.json
+++ b/package.json
@@ -113,7 +113,7 @@
     "integration": "cross-env TESTING=1 jasmine --config=jasmine.json",
     "docs": "jsdoc -c ./jsdoc-conf.json ./src",
     "madge:circular": "madge ./src --extensions js,ts --circular",
-    "prepare": "npm run build",
+    "prepare": "husky && npm run build",
     "release_docs": "./release_docs.sh",
     "gulp": "gulp",
     "prettier": "prettier --write '{src,integration}/{**/*,*}.{js,ts}' && npm run lint:fix",

--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
     "gulp-rename": "2.0.0",
     "gulp-uglify": "3.0.2",
     "gulp-watch": "5.0.1",
-    "husky": "8.0.3",
+    "husky": "9.0.11",
     "jasmine": "5.1.0",
     "jasmine-reporters": "2.5.2",
     "jasmine-spec-reporter": "7.0.0",
@@ -81,12 +81,11 @@
     "jest-environment-jsdom": "29.5.0",
     "jsdoc": "4.0.2",
     "jsdoc-babel": "0.5.0",
-    "lint-staged": "13.2.2",
     "madge": "7.0.0",
     "metro-react-native-babel-preset": "0.76.4",
     "mongodb-runner": "5.4.3",
     "parse-server": "7.1.0-alpha.1",
-    "prettier": "3.0.2",
+    "prettier": "3.2.5",
     "puppeteer": "20.4.0",
     "regenerator-runtime": "0.13.11",
     "semantic-release": "19.0.5",
@@ -117,20 +116,8 @@
     "prepare": "npm run build",
     "release_docs": "./release_docs.sh",
     "gulp": "gulp",
-    "prettier": "prettier --write '{src,integration}/{**/*,*}.js' && npm run lint:fix",
+    "prettier": "prettier --write '{src,integration}/{**/*,*}.{js,ts}' && npm run lint:fix",
     "cross-env": "cross-env"
-  },
-  "husky": {
-    "hooks": {
-      "pre-commit": "lint-staged"
-    }
-  },
-  "lint-staged": {
-    "{src,integration}/{**/*,*}.js": [
-      "prettier --write",
-      "eslint --fix --cache",
-      "git add"
-    ]
   },
   "engines": {
     "node": ">=18 <21"

--- a/package.json
+++ b/package.json
@@ -81,6 +81,7 @@
     "jest-environment-jsdom": "29.5.0",
     "jsdoc": "4.0.2",
     "jsdoc-babel": "0.5.0",
+    "lint-staged": "15.2.2",
     "madge": "7.0.0",
     "metro-react-native-babel-preset": "0.76.4",
     "mongodb-runner": "5.4.3",
@@ -114,10 +115,18 @@
     "docs": "jsdoc -c ./jsdoc-conf.json ./src",
     "madge:circular": "madge ./src --extensions js,ts --circular",
     "prepare": "husky && npm run build",
+    "pre-commit": "lint-staged",
     "release_docs": "./release_docs.sh",
     "gulp": "gulp",
     "prettier": "prettier --write '{src,integration}/{**/*,*}.{js,ts}' && npm run lint:fix",
     "cross-env": "cross-env"
+  },
+  "lint-staged": {
+    "{src,integration}/{**/*,*}.{js,ts}": [
+      "prettier --write",
+      "eslint --fix --cache",
+      "git add"
+    ]
   },
   "engines": {
     "node": ">=18 <21"

--- a/src/CoreManager.ts
+++ b/src/CoreManager.ts
@@ -17,154 +17,187 @@ import type ParseSchema from './ParseSchema';
 import type ParseInstallation from './ParseInstallation';
 
 type AnalyticsController = {
-  track: (name: string, dimensions: { [key: string]: string }) => Promise<any>,
+  track: (name: string, dimensions: { [key: string]: string }) => Promise<any>;
 };
 type CloudController = {
-  run: (name: string, data: any, options: RequestOptions) => Promise<any>,
-  getJobsData: (options: RequestOptions) => Promise<any>,
+  run: (name: string, data: any, options: RequestOptions) => Promise<any>;
+  getJobsData: (options: RequestOptions) => Promise<any>;
   /** Returns promise which resolves with JobStatusId of the job */
-  startJob: (name: string, data: any, options: RequestOptions) => Promise<string>,
+  startJob: (name: string, data: any, options: RequestOptions) => Promise<string>;
 };
 type ConfigController = {
-  current: () => Promise<ParseConfig> | ParseConfig,
-  get: (opts?: RequestOptions) => Promise<ParseConfig>,
-  save: (attrs: { [key: string]: any }, masterKeyOnlyFlags?: { [key: string]: any }) => Promise<void>,
+  current: () => Promise<ParseConfig> | ParseConfig;
+  get: (opts?: RequestOptions) => Promise<ParseConfig>;
+  save: (
+    attrs: { [key: string]: any },
+    masterKeyOnlyFlags?: { [key: string]: any }
+  ) => Promise<void>;
 };
 type CryptoController = {
-  encrypt: (obj: any, secretKey: string) => string,
-  decrypt: (encryptedText: string, secretKey: any) => string,
+  encrypt: (obj: any, secretKey: string) => string;
+  decrypt: (encryptedText: string, secretKey: any) => string;
 };
 type FileController = {
-  saveFile: (name: string, source: FileSource, options?: FullOptions) => Promise<any>,
-  saveBase64: (name: string, source: FileSource, options?: FileSaveOptions) => Promise<{ name: string, url: string }>,
-  download: (uri: string, options?: any) => Promise<{ base64?: string, contentType?: string }>,
-  deleteFile: (name: string, options?: { useMasterKey?: boolean }) => Promise<void>,
+  saveFile: (name: string, source: FileSource, options?: FullOptions) => Promise<any>;
+  saveBase64: (
+    name: string,
+    source: FileSource,
+    options?: FileSaveOptions
+  ) => Promise<{ name: string; url: string }>;
+  download: (uri: string, options?: any) => Promise<{ base64?: string; contentType?: string }>;
+  deleteFile: (name: string, options?: { useMasterKey?: boolean }) => Promise<void>;
 };
 type InstallationController = {
-  currentInstallationId: () => Promise<string>,
-  currentInstallation: () => Promise<ParseInstallation | null>,
-  updateInstallationOnDisk: (installation: ParseInstallation) => Promise<void>,
+  currentInstallationId: () => Promise<string>;
+  currentInstallation: () => Promise<ParseInstallation | null>;
+  updateInstallationOnDisk: (installation: ParseInstallation) => Promise<void>;
 };
 type ObjectController = {
   fetch: (
     object: ParseObject | Array<ParseObject>,
     forceFetch: boolean,
     options: RequestOptions
-  ) => Promise<Array<ParseObject | undefined> | ParseObject | undefined>,
-  save: (object: ParseObject | Array<ParseObject | ParseFile> | null, options: RequestOptions) => Promise<ParseObject | Array<ParseObject> | ParseFile | undefined>,
-  destroy: (object: ParseObject | Array<ParseObject>, options: RequestOptions) => Promise<ParseObject | Array<ParseObject>>,
+  ) => Promise<Array<ParseObject | undefined> | ParseObject | undefined>;
+  save: (
+    object: ParseObject | Array<ParseObject | ParseFile> | null,
+    options: RequestOptions
+  ) => Promise<ParseObject | Array<ParseObject> | ParseFile | undefined>;
+  destroy: (
+    object: ParseObject | Array<ParseObject>,
+    options: RequestOptions
+  ) => Promise<ParseObject | Array<ParseObject>>;
 };
 type ObjectStateController = {
-  getState: (obj: any) => State | null,
-  initializeState: (obj: any, initial?: State) => State,
-  removeState: (obj: any) => State | null,
-  getServerData: (obj: any) => AttributeMap,
-  setServerData: (obj: any, attributes: AttributeMap) => void,
-  getPendingOps: (obj: any) => Array<OpsMap>,
-  setPendingOp: (obj: any, attr: string, op?: Op) => void,
-  pushPendingState: (obj: any) => void,
-  popPendingState: (obj: any) => OpsMap | undefined,
-  mergeFirstPendingState: (obj: any) => void,
-  getObjectCache: (obj: any) => ObjectCache,
-  estimateAttribute: (obj: any, attr: string) => any,
-  estimateAttributes: (obj: any) => AttributeMap,
-  commitServerChanges: (obj: any, changes: AttributeMap) => void,
-  enqueueTask: (obj: any, task: () => Promise<void>) => Promise<void>,
-  clearAllState: () => void,
-  duplicateState: (source: any, dest: any) => void,
+  getState: (obj: any) => State | null;
+  initializeState: (obj: any, initial?: State) => State;
+  removeState: (obj: any) => State | null;
+  getServerData: (obj: any) => AttributeMap;
+  setServerData: (obj: any, attributes: AttributeMap) => void;
+  getPendingOps: (obj: any) => Array<OpsMap>;
+  setPendingOp: (obj: any, attr: string, op?: Op) => void;
+  pushPendingState: (obj: any) => void;
+  popPendingState: (obj: any) => OpsMap | undefined;
+  mergeFirstPendingState: (obj: any) => void;
+  getObjectCache: (obj: any) => ObjectCache;
+  estimateAttribute: (obj: any, attr: string) => any;
+  estimateAttributes: (obj: any) => AttributeMap;
+  commitServerChanges: (obj: any, changes: AttributeMap) => void;
+  enqueueTask: (obj: any, task: () => Promise<void>) => Promise<void>;
+  clearAllState: () => void;
+  duplicateState: (source: any, dest: any) => void;
 };
 type PushController = {
-  send: (data: PushData, options?: FullOptions) => Promise<any>,
+  send: (data: PushData, options?: FullOptions) => Promise<any>;
 };
 type QueryController = {
-  find(className: string, params: QueryJSON, options: RequestOptions): Promise<{ results?: Array<ParseObject>, className?: string, count?: number }>;
-  aggregate(className: string, params: any, options: RequestOptions): Promise<{ results?: Array<any> }>;
+  find(
+    className: string,
+    params: QueryJSON,
+    options: RequestOptions
+  ): Promise<{ results?: Array<ParseObject>; className?: string; count?: number }>;
+  aggregate(
+    className: string,
+    params: any,
+    options: RequestOptions
+  ): Promise<{ results?: Array<any> }>;
 };
 type EventuallyQueue = {
-  save: (object: ParseObject, serverOptions: SaveOptions) => Promise<any>,
-  destroy: (object: ParseObject, serverOptions: RequestOptions) => Promise<any>,
-  poll: (ms?: number) => void
+  save: (object: ParseObject, serverOptions: SaveOptions) => Promise<any>;
+  destroy: (object: ParseObject, serverOptions: RequestOptions) => Promise<any>;
+  poll: (ms?: number) => void;
 };
 type RESTController = {
-  request: (method: string, path: string, data?: any, options?: RequestOptions) => Promise<any>,
-  ajax: (method: string, url: string, data: any, headers?: any, options?: FullOptions) => Promise<any>,
-  handleError: (err?: any) => void,
+  request: (method: string, path: string, data?: any, options?: RequestOptions) => Promise<any>;
+  ajax: (
+    method: string,
+    url: string,
+    data: any,
+    headers?: any,
+    options?: FullOptions
+  ) => Promise<any>;
+  handleError: (err?: any) => void;
 };
 type SchemaController = {
-  purge: (className: string) => Promise<any>,
-  get: (className: string, options?: RequestOptions) => Promise<{ results: ParseSchema[] }>,
-  delete: (className: string, options?: RequestOptions) => Promise<void>,
-  create: (className: string, params: any, options?: RequestOptions) => Promise<any>,
-  update: (className: string, params: any, options?: RequestOptions) => Promise<any>,
-  send(className: string, method: string, params: any, options: RequestOptions): Promise<any>,
+  purge: (className: string) => Promise<any>;
+  get: (className: string, options?: RequestOptions) => Promise<{ results: ParseSchema[] }>;
+  delete: (className: string, options?: RequestOptions) => Promise<void>;
+  create: (className: string, params: any, options?: RequestOptions) => Promise<any>;
+  update: (className: string, params: any, options?: RequestOptions) => Promise<any>;
+  send(className: string, method: string, params: any, options: RequestOptions): Promise<any>;
 };
 type SessionController = {
-  getSession: (token: RequestOptions) => Promise<ParseSession>,
+  getSession: (token: RequestOptions) => Promise<ParseSession>;
 };
-type StorageController = {
-  async: 0,
-  getItem: (path: string) => string | null,
-  setItem: (path: string, value: string) => void,
-  removeItem: (path: string) => void,
-  getItemAsync?: (path: string) => Promise<string | null>,
-  setItemAsync?: (path: string, value: string) => Promise<void>,
-  removeItemAsync?: (path: string) => Promise<void>,
-  clear: () => void,
-  getAllKeys?: () => Array<string>
-  getAllKeysAsync?: () => Promise<Array<string>>
-} | {
-  async: 1,
-  getItem?: (path: string) => string | null,
-  setItem?: (path: string, value: string) => void,
-  removeItem?: (path: string) => void,
-  getItemAsync: (path: string) => Promise<string | null>,
-  setItemAsync: (path: string, value: string) => Promise<void>,
-  removeItemAsync: (path: string) => Promise<void>,
-  clear: () => void,
-  getAllKeys?: () => Array<string>
-  getAllKeysAsync?: () => Promise<Array<string>>
-};
+type StorageController =
+  | {
+      async: 0;
+      getItem: (path: string) => string | null;
+      setItem: (path: string, value: string) => void;
+      removeItem: (path: string) => void;
+      getItemAsync?: (path: string) => Promise<string | null>;
+      setItemAsync?: (path: string, value: string) => Promise<void>;
+      removeItemAsync?: (path: string) => Promise<void>;
+      clear: () => void;
+      getAllKeys?: () => Array<string>;
+      getAllKeysAsync?: () => Promise<Array<string>>;
+    }
+  | {
+      async: 1;
+      getItem?: (path: string) => string | null;
+      setItem?: (path: string, value: string) => void;
+      removeItem?: (path: string) => void;
+      getItemAsync: (path: string) => Promise<string | null>;
+      setItemAsync: (path: string, value: string) => Promise<void>;
+      removeItemAsync: (path: string) => Promise<void>;
+      clear: () => void;
+      getAllKeys?: () => Array<string>;
+      getAllKeysAsync?: () => Promise<Array<string>>;
+    };
 type LocalDatastoreController = {
-  fromPinWithName: (name: string) => any | undefined,
-  pinWithName: (name: string, objects: any) => void,
-  unPinWithName: (name: string) => void,
-  getAllContents: () => any | undefined,
-  clear: () => void,
+  fromPinWithName: (name: string) => any | undefined;
+  pinWithName: (name: string, objects: any) => void;
+  unPinWithName: (name: string) => void;
+  getAllContents: () => any | undefined;
+  clear: () => void;
   // Use for testing
   // getRawStorage(): Promise<Object>,
 };
 type UserController = {
-  setCurrentUser: (user: ParseUser) => Promise<void>,
-  currentUser: () => ParseUser | null,
-  currentUserAsync: () => Promise<ParseUser | null>,
-  signUp: (user: ParseUser, attrs: AttributeMap, options: RequestOptions) => Promise<ParseUser>,
-  logIn: (user: ParseUser, options: RequestOptions) => Promise<ParseUser>,
-  loginAs: (user: ParseUser, userId: string) => Promise<ParseUser>,
-  become: (user: ParseUser, options: RequestOptions) => Promise<ParseUser>,
-  hydrate: (user: ParseUser, userJSON: AttributeMap) => Promise<ParseUser>,
-  logOut: (options: RequestOptions) => Promise<void>,
-  me: (user: ParseUser, options: RequestOptions) => Promise<ParseUser>,
-  requestPasswordReset: (email: string, options: RequestOptions) => Promise<void>,
-  updateUserOnDisk: (user: ParseUser) => Promise<ParseUser>,
-  upgradeToRevocableSession: (user: ParseUser, options: RequestOptions) => Promise<void>,
-  linkWith: (user: ParseUser, authData: AuthData, options?: FullOptions) => Promise<ParseUser>,
-  removeUserFromDisk: () => Promise<ParseUser | void>,
-  verifyPassword: (username: string, password: string, options: RequestOptions) => Promise<ParseUser>,
-  requestEmailVerification: (email: string, options: RequestOptions) => Promise<void>,
+  setCurrentUser: (user: ParseUser) => Promise<void>;
+  currentUser: () => ParseUser | null;
+  currentUserAsync: () => Promise<ParseUser | null>;
+  signUp: (user: ParseUser, attrs: AttributeMap, options: RequestOptions) => Promise<ParseUser>;
+  logIn: (user: ParseUser, options: RequestOptions) => Promise<ParseUser>;
+  loginAs: (user: ParseUser, userId: string) => Promise<ParseUser>;
+  become: (user: ParseUser, options: RequestOptions) => Promise<ParseUser>;
+  hydrate: (user: ParseUser, userJSON: AttributeMap) => Promise<ParseUser>;
+  logOut: (options: RequestOptions) => Promise<void>;
+  me: (user: ParseUser, options: RequestOptions) => Promise<ParseUser>;
+  requestPasswordReset: (email: string, options: RequestOptions) => Promise<void>;
+  updateUserOnDisk: (user: ParseUser) => Promise<ParseUser>;
+  upgradeToRevocableSession: (user: ParseUser, options: RequestOptions) => Promise<void>;
+  linkWith: (user: ParseUser, authData: AuthData, options?: FullOptions) => Promise<ParseUser>;
+  removeUserFromDisk: () => Promise<ParseUser | void>;
+  verifyPassword: (
+    username: string,
+    password: string,
+    options: RequestOptions
+  ) => Promise<ParseUser>;
+  requestEmailVerification: (email: string, options: RequestOptions) => Promise<void>;
 };
 type HooksController = {
-  get: (type: string, functionName?: string, triggerName?: string) => Promise<any>,
-  create: (hook: HookDeclaration) => Promise<any>,
-  remove: (hook: HookDeleteArg) => Promise<any>,
-  update: (hook: HookDeclaration) => Promise<any>,
+  get: (type: string, functionName?: string, triggerName?: string) => Promise<any>;
+  create: (hook: HookDeclaration) => Promise<any>;
+  remove: (hook: HookDeleteArg) => Promise<any>;
+  update: (hook: HookDeclaration) => Promise<any>;
   // Renamed to sendRequest since ParseHooks file & tests file uses this. (originally declared as just "send")
-  sendRequest?: (method: string, path: string, body?: any) => Promise<any>,
+  sendRequest?: (method: string, path: string, body?: any) => Promise<any>;
 };
 type LiveQueryControllerType = {
   setDefaultLiveQueryClient(liveQueryClient: LiveQueryClient): void;
   getDefaultLiveQueryClient(): Promise<LiveQueryClient>;
   _clearCachedDefaultClient(): void;
-}
+};
 /** Based on https://github.com/react-native-async-storage/async-storage/blob/main/packages/default-storage-backend/src/types.ts */
 type AsyncStorageType = {
   /** Fetches an item for a `key` and invokes a callback upon completion. */
@@ -177,7 +210,11 @@ type AsyncStorageType = {
   /** Removes an item for a `key` and invokes a callback upon completion. */
   removeItem: (key: string, callback?: (error?: Error | null) => void) => Promise<void>;
   /** Merges an existing `key` value with an input value, assuming both values are stringified JSON. */
-  mergeItem: (key: string, value: string, callback?: (error?: Error | null) => void) => Promise<void>;
+  mergeItem: (
+    key: string,
+    value: string,
+    callback?: (error?: Error | null) => void
+  ) => Promise<void>;
   /**
    * Erases *all* `AsyncStorage` for all clients, libraries, etc. You probably
    * don't want to call this; use `removeItem` or `multiRemove` to clear only
@@ -195,7 +232,10 @@ type AsyncStorageType = {
    */
   multiGet: (
     keys: readonly string[],
-    callback?: (errors?: readonly (Error | null)[] | null, result?: readonly [string, string][]) => void
+    callback?: (
+      errors?: readonly (Error | null)[] | null,
+      result?: readonly [string, string][]
+    ) => void
   ) => Promise<readonly [string, string | null][]>;
 
   /**
@@ -231,33 +271,36 @@ type AsyncStorageType = {
   ) => Promise<void>;
 };
 export type WebSocketController = {
-  onopen: () => void,
-  onmessage: (message: any) => void,
-  onclose: (arg?: any) => void,
-  onerror: (error: any) => void,
-  send: (data: any) => void,
-  close: () => void,
+  onopen: () => void;
+  onmessage: (message: any) => void;
+  onclose: (arg?: any) => void;
+  onerror: (error: any) => void;
+  send: (data: any) => void;
+  close: () => void;
 };
 type Config = {
-  AnalyticsController?: AnalyticsController,
-  CloudController?: CloudController,
-  ConfigController?: ConfigController,
-  FileController?: FileController,
-  InstallationController?: InstallationController,
-  ObjectController?: ObjectController,
-  ObjectStateController?: ObjectStateController,
-  PushController?: PushController,
-  QueryController?: QueryController,
-  RESTController?: RESTController,
-  SchemaController?: SchemaController,
-  SessionController?: SessionController,
-  StorageController?: StorageController,
-  LocalDatastoreController?: LocalDatastoreController,
-  UserController?: UserController,
-  HooksController?: HooksController,
-  WebSocketController?: new (url: string | URL, protocols?: string | string[] | undefined) => WebSocketController,
-  LiveQueryController?: LiveQueryControllerType,
-  AsyncStorage?: AsyncStorageType
+  AnalyticsController?: AnalyticsController;
+  CloudController?: CloudController;
+  ConfigController?: ConfigController;
+  FileController?: FileController;
+  InstallationController?: InstallationController;
+  ObjectController?: ObjectController;
+  ObjectStateController?: ObjectStateController;
+  PushController?: PushController;
+  QueryController?: QueryController;
+  RESTController?: RESTController;
+  SchemaController?: SchemaController;
+  SessionController?: SessionController;
+  StorageController?: StorageController;
+  LocalDatastoreController?: LocalDatastoreController;
+  UserController?: UserController;
+  HooksController?: HooksController;
+  WebSocketController?: new (
+    url: string | URL,
+    protocols?: string | string[] | undefined
+  ) => WebSocketController;
+  LiveQueryController?: LiveQueryControllerType;
+  AsyncStorage?: AsyncStorageType;
 };
 
 const config: Config & { [key: string]: any } = {
@@ -538,11 +581,19 @@ const CoreManager = {
     return config['AsyncStorage'];
   },
 
-  setWebSocketController(controller: new (url: string | URL, protocols?: string | string[] | undefined) => WebSocketController) {
+  setWebSocketController(
+    controller: new (
+      url: string | URL,
+      protocols?: string | string[] | undefined
+    ) => WebSocketController
+  ) {
     config['WebSocketController'] = controller;
   },
 
-  getWebSocketController(): new (url: string | URL, protocols?: string | string[] | undefined) => WebSocketController {
+  getWebSocketController(): new (
+    url: string | URL,
+    protocols?: string | string[] | undefined
+  ) => WebSocketController {
     return config['WebSocketController']!;
   },
 

--- a/src/EventuallyQueue.js
+++ b/src/EventuallyQueue.js
@@ -14,14 +14,14 @@ import type { SaveOptions } from './ParseObject';
 import type { RequestOptions } from './RESTController';
 
 type QueueObject = {
-  queueId: string,
-  action: string,
-  object: ParseObject,
-  serverOptions: SaveOptions | RequestOptions,
-  id: string,
-  className: string,
-  hash: string,
-  createdAt: Date,
+  queueId: string;
+  action: string;
+  object: ParseObject;
+  serverOptions: SaveOptions | RequestOptions;
+  id: string;
+  className: string;
+  hash: string;
+  createdAt: Date;
 };
 
 type Queue = Array<QueueObject>;

--- a/src/InstallationController.ts
+++ b/src/InstallationController.ts
@@ -57,7 +57,7 @@ const InstallationController = {
     installation.set('installationId', installationId);
     installation.set('parseVersion', CoreManager.get('VERSION'));
     currentInstallationCache = installation;
-    await Storage.setItemAsync(path, JSON.stringify(installation.toJSON()))
+    await Storage.setItemAsync(path, JSON.stringify(installation.toJSON()));
     return installation;
   },
 

--- a/src/LiveQueryClient.ts
+++ b/src/LiveQueryClient.ts
@@ -240,11 +240,13 @@ class LiveQueryClient {
       op: OP_TYPES.UNSUBSCRIBE,
       requestId: subscription.id,
     };
-    return this.connectPromise.then(() => {
-      return this.socket.send(JSON.stringify(unsubscribeRequest));
-    }).then(() => {
-      return subscription.unsubscribePromise;
-    });
+    return this.connectPromise
+      .then(() => {
+        return this.socket.send(JSON.stringify(unsubscribeRequest));
+      })
+      .then(() => {
+        return subscription.unsubscribePromise;
+      });
   }
 
   /**
@@ -275,7 +277,7 @@ class LiveQueryClient {
       this._handleWebSocketMessage(event);
     };
 
-    this.socket.onclose = (event) => {
+    this.socket.onclose = event => {
       this.socket.closingPromise?.resolve(event);
       this._handleWebSocketClose();
     };
@@ -353,7 +355,7 @@ class LiveQueryClient {
       javascriptKey: this.javascriptKey,
       masterKey: this.masterKey,
       sessionToken: this.sessionToken,
-      installationId: undefined as string | undefined
+      installationId: undefined as string | undefined,
     };
     if (this.additionalProperties) {
       connectRequest.installationId = this.installationId;

--- a/src/ObjectStateMutations.ts
+++ b/src/ObjectStateMutations.ts
@@ -12,11 +12,11 @@ export type OpsMap = { [attr: string]: Op };
 export type ObjectCache = { [attr: string]: string };
 
 export type State = {
-  serverData: AttributeMap,
-  pendingOps: Array<OpsMap>,
-  objectCache: ObjectCache,
-  tasks: TaskQueue,
-  existed: boolean,
+  serverData: AttributeMap;
+  pendingOps: Array<OpsMap>;
+  objectCache: ObjectCache;
+  tasks: TaskQueue;
+  existed: boolean;
 };
 
 export function defaultState(): State {

--- a/src/OfflineQuery.js
+++ b/src/OfflineQuery.js
@@ -101,7 +101,7 @@ function equalObjectsGeneric(obj, compareTo, eqlFn) {
  * relative to now.
  *
  * @param {string} text The text to convert.
- * @param {Date} [now=new Date()] The date from which add or subtract. Default is now.
+ * @param {Date} [now] The date from which add or subtract. Default is now.
  * @returns {RelativeTimeToDateResult}
  */
 function relativeTimeToDate(text, now = new Date()) {

--- a/src/Parse.ts
+++ b/src/Parse.ts
@@ -7,31 +7,31 @@ import InstallationController from './InstallationController';
 import * as ParseOp from './ParseOp';
 import RESTController from './RESTController';
 import ACL from './ParseACL';
-import * as Analytics from './Analytics'
-import AnonymousUtils from './AnonymousUtils'
+import * as Analytics from './Analytics';
+import AnonymousUtils from './AnonymousUtils';
 import * as Cloud from './Cloud';
 import CLP from './ParseCLP';
 import CoreManager from './CoreManager';
 import EventEmitter from './EventEmitter';
-import Config from './ParseConfig'
-import ParseError from './ParseError'
-import FacebookUtils from './FacebookUtils'
-import File from './ParseFile'
-import GeoPoint from './ParseGeoPoint'
-import Polygon from './ParsePolygon'
-import Installation from './ParseInstallation'
-import LocalDatastore from './LocalDatastore'
+import Config from './ParseConfig';
+import ParseError from './ParseError';
+import FacebookUtils from './FacebookUtils';
+import File from './ParseFile';
+import GeoPoint from './ParseGeoPoint';
+import Polygon from './ParsePolygon';
+import Installation from './ParseInstallation';
+import LocalDatastore from './LocalDatastore';
 import ParseObject from './ParseObject';
-import * as Push from './Push'
-import Query from './ParseQuery'
-import Relation from './ParseRelation'
-import Role from './ParseRole'
-import Schema from './ParseSchema'
-import Session from './ParseSession'
-import Storage from './Storage'
-import User from './ParseUser'
-import ParseLiveQuery from './ParseLiveQuery'
-import LiveQueryClient from './LiveQueryClient'
+import * as Push from './Push';
+import Query from './ParseQuery';
+import Relation from './ParseRelation';
+import Role from './ParseRole';
+import Schema from './ParseSchema';
+import Session from './ParseSession';
+import Storage from './Storage';
+import User from './ParseUser';
+import ParseLiveQuery from './ParseLiveQuery';
+import LiveQueryClient from './LiveQueryClient';
 import LocalDatastoreController from './LocalDatastoreController';
 import StorageController from './StorageController';
 import WebSocketController from './WebSocketController';
@@ -45,75 +45,75 @@ import WebSocketController from './WebSocketController';
  * @hideconstructor
  */
 interface ParseType {
-  ACL: typeof ACL,
-  Parse?: ParseType,
-  Analytics: typeof Analytics,
-  AnonymousUtils: typeof AnonymousUtils,
+  ACL: typeof ACL;
+  Parse?: ParseType;
+  Analytics: typeof Analytics;
+  AnonymousUtils: typeof AnonymousUtils;
   Cloud: typeof Cloud & {
     /** only available in server environments */
-    useMasterKey?: () => void
-  },
-  CLP: typeof CLP,
-  CoreManager: typeof CoreManager,
-  Config: typeof Config,
-  Error: typeof ParseError,
-  EventuallyQueue: typeof EventuallyQueue,
-  FacebookUtils: typeof FacebookUtils,
-  File: typeof File,
-  GeoPoint: typeof GeoPoint,
-  Hooks?: any,
-  Polygon: typeof Polygon,
-  Installation: typeof Installation,
-  LocalDatastore: typeof LocalDatastore,
-  Object: typeof ParseObject,
-  Op: {
-    Set: typeof ParseOp.SetOp,
-    Unset: typeof ParseOp.UnsetOp,
-    Increment: typeof ParseOp.IncrementOp,
-    Add: typeof ParseOp.AddOp,
-    Remove: typeof ParseOp.RemoveOp,
-    AddUnique: typeof ParseOp.AddUniqueOp,
-    Relation: typeof ParseOp.RelationOp,
+    useMasterKey?: () => void;
   };
-  Push: typeof Push,
-  Query: typeof Query,
-  Relation: typeof Relation,
-  Role: typeof Role,
-  Schema: typeof Schema,
-  Session: typeof Session,
-  Storage: typeof Storage,
-  User: typeof User,
-  LiveQuery: typeof ParseLiveQuery,
-  LiveQueryClient: typeof LiveQueryClient,
+  CLP: typeof CLP;
+  CoreManager: typeof CoreManager;
+  Config: typeof Config;
+  Error: typeof ParseError;
+  EventuallyQueue: typeof EventuallyQueue;
+  FacebookUtils: typeof FacebookUtils;
+  File: typeof File;
+  GeoPoint: typeof GeoPoint;
+  Hooks?: any;
+  Polygon: typeof Polygon;
+  Installation: typeof Installation;
+  LocalDatastore: typeof LocalDatastore;
+  Object: typeof ParseObject;
+  Op: {
+    Set: typeof ParseOp.SetOp;
+    Unset: typeof ParseOp.UnsetOp;
+    Increment: typeof ParseOp.IncrementOp;
+    Add: typeof ParseOp.AddOp;
+    Remove: typeof ParseOp.RemoveOp;
+    AddUnique: typeof ParseOp.AddUniqueOp;
+    Relation: typeof ParseOp.RelationOp;
+  };
+  Push: typeof Push;
+  Query: typeof Query;
+  Relation: typeof Relation;
+  Role: typeof Role;
+  Schema: typeof Schema;
+  Session: typeof Session;
+  Storage: typeof Storage;
+  User: typeof User;
+  LiveQuery: typeof ParseLiveQuery;
+  LiveQueryClient: typeof LiveQueryClient;
 
-  initialize(applicationId: string, javaScriptKey: string): void,
-  _initialize(applicationId: string, javaScriptKey: string, masterKey?: string): void,
-  setAsyncStorage(storage: any): void,
-  setLocalDatastoreController(controller: any): void,
-  getServerHealth(): Promise<any>,
+  initialize(applicationId: string, javaScriptKey: string): void;
+  _initialize(applicationId: string, javaScriptKey: string, masterKey?: string): void;
+  setAsyncStorage(storage: any): void;
+  setLocalDatastoreController(controller: any): void;
+  getServerHealth(): Promise<any>;
 
-  applicationId: string,
-  javaScriptKey: string,
-  masterKey: string,
-  serverURL: string,
-  serverAuthToken: string,
-  serverAuthType: string,
-  liveQueryServerURL: string,
-  encryptedUser: boolean,
-  secret: string,
-  idempotency: boolean,
-  allowCustomObjectId: boolean,
-  IndexedDB?: any,
-  _request(...args: any[]): void,
-  _ajax(...args: any[]): void,
-  _decode(...args: any[]): void,
-  _encode(...args: any[]): void,
-  _getInstallationId?(): Promise<string>,
-  enableLocalDatastore(polling: boolean, ms: number): void,
-  isLocalDatastoreEnabled(): boolean,
-  dumpLocalDatastore(): void,
-  enableEncryptedUser(): void,
-  isEncryptedUserEnabled(): void,
+  applicationId: string;
+  javaScriptKey: string;
+  masterKey: string;
+  serverURL: string;
+  serverAuthToken: string;
+  serverAuthType: string;
+  liveQueryServerURL: string;
+  encryptedUser: boolean;
+  secret: string;
+  idempotency: boolean;
+  allowCustomObjectId: boolean;
+  IndexedDB?: any;
+  _request(...args: any[]): void;
+  _ajax(...args: any[]): void;
+  _decode(...args: any[]): void;
+  _encode(...args: any[]): void;
+  _getInstallationId?(): Promise<string>;
+  enableLocalDatastore(polling: boolean, ms: number): void;
+  isLocalDatastoreEnabled(): boolean;
+  dumpLocalDatastore(): void;
+  enableEncryptedUser(): void;
+  isEncryptedUserEnabled(): void;
 }
 
 const Parse: ParseType = {
@@ -183,7 +183,7 @@ const Parse: ParseType = {
       /* eslint-disable no-console */
       console.log(
         "It looks like you're using the browser version of the SDK in a " +
-        "node.js environment. You should require('parse/node') instead."
+          "node.js environment. You should require('parse/node') instead."
       );
       /* eslint-enable no-console */
     }
@@ -205,7 +205,10 @@ const Parse: ParseType = {
     CoreManager.setIfNeeded('WebSocketController', WebSocketController);
 
     if (process.env.PARSE_BUILD === 'browser') {
-      Parse.IndexedDB = CoreManager.setIfNeeded('IndexedDBStorageController', IndexedDBStorageController);
+      Parse.IndexedDB = CoreManager.setIfNeeded(
+        'IndexedDBStorageController',
+        IndexedDBStorageController
+      );
     }
   },
 
@@ -467,7 +470,7 @@ CoreManager.setRESTController(RESTController);
 
 if (process.env.PARSE_BUILD === 'node') {
   Parse.initialize = Parse._initialize;
-  Parse.Cloud = Parse.Cloud || {} as any;
+  Parse.Cloud = Parse.Cloud || ({} as any);
   Parse.Cloud.useMasterKey = function () {
     CoreManager.set('USE_MASTER_KEY', true);
   };

--- a/src/ParseCLP.ts
+++ b/src/ParseCLP.ts
@@ -3,7 +3,9 @@ import ParseUser from './ParseUser';
 
 type Entity = ParseUser | ParseRole | string;
 type UsersMap = { [userId: string]: boolean | any };
-export type PermissionsMap = { writeUserFields?: string[], readUserFields?: string[] } & { [permission: string]: UsersMap };
+export type PermissionsMap = { writeUserFields?: string[]; readUserFields?: string[] } & {
+  [permission: string]: UsersMap;
+};
 
 const PUBLIC_KEY = '*';
 
@@ -431,9 +433,9 @@ class ParseCLP {
    */
   getReadAccess(userId: Entity): boolean {
     return (
-      this._getAccess('find', userId) as boolean &&
-      this._getAccess('get', userId) as boolean &&
-      this._getAccess('count', userId) as boolean
+      (this._getAccess('find', userId) as boolean) &&
+      (this._getAccess('get', userId) as boolean) &&
+      (this._getAccess('count', userId) as boolean)
     );
   }
 
@@ -461,10 +463,10 @@ class ParseCLP {
    */
   getWriteAccess(userId: Entity): boolean {
     return (
-      this._getAccess('create', userId) as boolean &&
-      this._getAccess('update', userId) as boolean &&
-      this._getAccess('delete', userId) as boolean &&
-      this._getAccess('addField', userId) as boolean
+      (this._getAccess('create', userId) as boolean) &&
+      (this._getAccess('update', userId) as boolean) &&
+      (this._getAccess('delete', userId) as boolean) &&
+      (this._getAccess('addField', userId) as boolean)
     );
   }
 

--- a/src/ParseError.js
+++ b/src/ParseError.js
@@ -16,7 +16,7 @@ class ParseError extends Error {
     super(message);
     this.code = code;
     let customMessage = message;
-    CoreManager.get('PARSE_ERRORS').forEach((error) => {
+    CoreManager.get('PARSE_ERRORS').forEach(error => {
       if (error.code === code && error.code) {
         customMessage = error.message;
       }

--- a/src/ParseFile.ts
+++ b/src/ParseFile.ts
@@ -15,24 +15,24 @@ type Base64 = { base64: string };
 type Uri = { uri: string };
 type FileData = Array<number> | Base64 | Blob | Uri;
 export type FileSaveOptions = FullOptions & {
-  metadata?: { [key: string]: any },
-  tags?: { [key: string]: any },
+  metadata?: { [key: string]: any };
+  tags?: { [key: string]: any };
 };
 export type FileSource =
   | {
-      format: 'file',
-      file: Blob,
-      type: string | undefined,
+      format: 'file';
+      file: Blob;
+      type: string | undefined;
     }
   | {
-      format: 'base64',
-      base64: string,
-      type: string | undefined,
+      format: 'base64';
+      base64: string;
+      type: string | undefined;
     }
   | {
-      format: 'uri',
-      uri: string,
-      type: string | undefined,
+      format: 'uri';
+      uri: string;
+      type: string | undefined;
     };
 
 function b64Digit(number: number): string {
@@ -272,7 +272,7 @@ class ParseFile {
             this._requestTask = null;
             return controller.saveBase64(this._name, newSource, options);
           })
-          .then((res: { name?: string, url?: string }) => {
+          .then((res: { name?: string; url?: string }) => {
             this._name = res.name;
             this._url = res.url;
             this._requestTask = null;
@@ -330,7 +330,7 @@ class ParseFile {
     });
   }
 
-  toJSON(): { __type: 'File', name?: string, url?: string } {
+  toJSON(): { __type: 'File'; name?: string; url?: string } {
     return {
       __type: 'File',
       name: this._name,
@@ -463,7 +463,7 @@ const DefaultController = {
     if (source.format !== 'base64') {
       throw new Error('saveBase64 can only be used with Base64-type sources.');
     }
-    const data: { base64: any, _ContentType?: any, fileData: any } = {
+    const data: { base64: any; _ContentType?: any; fileData: any } = {
       base64: source.base64,
       fileData: {
         metadata: { ...options.metadata },

--- a/src/ParseGeoPoint.ts
+++ b/src/ParseGeoPoint.ts
@@ -31,7 +31,7 @@ class ParseGeoPoint {
    * @param {number} arg2 The longitude of the GeoPoint
    */
   constructor(
-    arg1: Array<number> | { latitude: number, longitude: number } | number,
+    arg1: Array<number> | { latitude: number; longitude: number } | number,
     arg2?: number
   ) {
     if (Array.isArray(arg1)) {
@@ -89,7 +89,7 @@ class ParseGeoPoint {
    *
    * @returns {object}
    */
-  toJSON(): { __type: string, latitude: number, longitude: number } {
+  toJSON(): { __type: string; latitude: number; longitude: number } {
     ParseGeoPoint._validate(this._latitude, this._longitude);
     return {
       __type: 'GeoPoint',
@@ -180,13 +180,13 @@ class ParseGeoPoint {
    * Creates a GeoPoint with the user's current location, if available.
    *
    * @param {object} options The options.
-   * @param {boolean} [options.enableHighAccuracy=false] A boolean value that indicates the application would like to receive the best possible results.
+   * @param {boolean} [options.enableHighAccuracy] A boolean value that indicates the application would like to receive the best possible results.
    *  If true and if the device is able to provide a more accurate position, it will do so.
    *  Note that this can result in slower response times or increased power consumption (with a GPS chip on a mobile device for example).
    *  On the other hand, if false, the device can take the liberty to save resources by responding more quickly and/or using less power. Default: false.
-   * @param {number} [options.timeout=Infinity] A positive long value representing the maximum length of time (in milliseconds) the device is allowed to take in order to return a position.
+   * @param {number} [options.timeout] A positive long value representing the maximum length of time (in milliseconds) the device is allowed to take in order to return a position.
    *  The default value is Infinity, meaning that getCurrentPosition() won't return until the position is available.
-   * @param {number} [options.maximumAge=0] A positive long value indicating the maximum age in milliseconds of a possible cached position that is acceptable to return.
+   * @param {number} [options.maximumAge] A positive long value indicating the maximum age in milliseconds of a possible cached position that is acceptable to return.
    *  If set to 0, it means that the device cannot use a cached position and must attempt to retrieve the real current position.
    *  If set to Infinity the device must return a cached position regardless of its age. Default: 0.
    * @static
@@ -194,9 +194,13 @@ class ParseGeoPoint {
    */
   static current(options): Promise<ParseGeoPoint> {
     return new Promise((resolve, reject) => {
-      navigator.geolocation.getCurrentPosition(location => {
-        resolve(new ParseGeoPoint(location.coords.latitude, location.coords.longitude));
-      }, reject, options);
+      navigator.geolocation.getCurrentPosition(
+        location => {
+          resolve(new ParseGeoPoint(location.coords.latitude, location.coords.longitude));
+        },
+        reject,
+        options
+      );
     });
   }
 }

--- a/src/ParseHooks.ts
+++ b/src/ParseHooks.ts
@@ -2,8 +2,10 @@ import CoreManager from './CoreManager';
 import decode from './decode';
 import ParseError from './ParseError';
 
-export type HookDeclaration = { functionName: string, url: string } | { className: string, triggerName: string, url: string };
-export type HookDeleteArg = { functionName: string } | { className: string, triggerName: string };
+export type HookDeclaration =
+  | { functionName: string; url: string }
+  | { className: string; triggerName: string; url: string };
+export type HookDeleteArg = { functionName: string } | { className: string; triggerName: string };
 
 export function getFunctions() {
   return CoreManager.getHooksController().get('functions');

--- a/src/ParseInstallation.ts
+++ b/src/ParseInstallation.ts
@@ -11,7 +11,7 @@ type DeviceInterface = {
   FCM: string;
   ANDROID: string;
   WEB: string;
-}
+};
 
 const DEVICE_TYPES: DeviceInterface = {
   IOS: 'ios',

--- a/src/ParseObject.ts
+++ b/src/ParseObject.ts
@@ -31,30 +31,30 @@ import type { AttributeMap, OpsMap } from './ObjectStateMutations';
 import type { RequestOptions, FullOptions } from './RESTController';
 
 export type Pointer = {
-  __type: string,
-  className: string,
-  objectId?: string,
-  _localId?: string,
+  __type: string;
+  className: string;
+  objectId?: string;
+  _localId?: string;
 };
 
 type SaveParams = {
-  method: string,
-  path: string,
-  body: AttributeMap,
+  method: string;
+  path: string;
+  body: AttributeMap;
 };
 
 export type SaveOptions = FullOptions & {
-  cascadeSave?: boolean,
-  context?: AttributeMap,
-  batchSize?: number,
+  cascadeSave?: boolean;
+  context?: AttributeMap;
+  batchSize?: number;
 };
 
 type FetchOptions = {
-  useMasterKey?: boolean,
-  sessionToken?: string,
-  include?: string | string[],
-  context?: AttributeMap,
-}
+  useMasterKey?: boolean;
+  sessionToken?: string;
+  include?: string | string[];
+  context?: AttributeMap;
+};
 
 // Mapping of class names to constructors, so we can populate objects from the
 // server with appropriate subclasses of ParseObject
@@ -104,10 +104,10 @@ class ParseObject {
    * @param {string} className The class name for the object
    * @param {object} attributes The initial set of data to store in the object.
    * @param {object} options The options for this object instance.
-   * @param {boolean} [options.ignoreValidation=false] Set to `true` ignore any attribute validation errors.
+   * @param {boolean} [options.ignoreValidation] Set to `true` ignore any attribute validation errors.
    */
   constructor(
-    className?: string | { className: string, [attr: string]: any },
+    className?: string | { className: string; [attr: string]: any },
     attributes?: { [attr: string]: any },
     options?: { ignoreValidation: boolean }
   ) {
@@ -201,7 +201,7 @@ class ParseObject {
    *
    * @returns {Parse.Object|object}
    */
-  _getStateIdentifier(): ParseObject | { id: string, className: string } {
+  _getStateIdentifier(): ParseObject | { id: string; className: string } {
     if (singleInstance) {
       let id = this.id;
       if (!id) {
@@ -349,10 +349,10 @@ class ParseObject {
     const stateController = CoreManager.getObjectStateController();
     stateController.initializeState(this._getStateIdentifier());
     const decoded: Partial<{
-      createdAt?: Date,
-      updatedAt?: Date,
-      ACL?: any,
-      [key: string]: any,
+      createdAt?: Date;
+      updatedAt?: Date;
+      ACL?: any;
+      [key: string]: any;
     }> = {};
     for (const attr in serverData) {
       if (attr === 'ACL') {
@@ -403,9 +403,9 @@ class ParseObject {
 
   _handleSaveResponse(response: AttributeMap, status: number) {
     const changes: Partial<{
-      createdAt: string,
-      updatedAt: string,
-      [key: string]: any
+      createdAt: string;
+      updatedAt: string;
+      [key: string]: any;
     }> = {};
     let attr;
     const stateController = CoreManager.getObjectStateController();
@@ -934,7 +934,9 @@ class ParseObject {
    * @returns {Parse.Object}
    */
   clone(): any {
-    const clone = new (this.constructor as new (...args: ConstructorParameters<typeof ParseObject>) => this)(this.className);
+    const clone = new (this.constructor as new (
+      ...args: ConstructorParameters<typeof ParseObject>
+    ) => this)(this.className);
     let attributes = this.attributes;
     if (typeof (this.constructor as any).readOnlyAttributes === 'function') {
       const readonly = (this.constructor as any).readOnlyAttributes() || [];
@@ -960,7 +962,9 @@ class ParseObject {
    * @returns {Parse.Object}
    */
   newInstance(): any {
-    const clone = new (this.constructor as new (...args: ConstructorParameters<typeof ParseObject>) => this)(this.className);
+    const clone = new (this.constructor as new (
+      ...args: ConstructorParameters<typeof ParseObject>
+    ) => this)(this.className);
     clone.id = this.id;
     if (singleInstance) {
       // Just return an object with the right id
@@ -1193,7 +1197,10 @@ class ParseObject {
    * @returns {Promise} A promise that is fulfilled when the fetch
    *     completes.
    */
-  fetchWithInclude(keys: string | Array<string | Array<string>>, options: RequestOptions): Promise<any> {
+  fetchWithInclude(
+    keys: string | Array<string | Array<string>>,
+    options: RequestOptions
+  ): Promise<any> {
     options = options || {};
     options.include = keys;
     return this.fetch(options);
@@ -2309,7 +2316,7 @@ const DefaultController = {
   async destroy(
     target: ParseObject | Array<ParseObject>,
     options: RequestOptions
-  ): Promise<ParseObject | Array<ParseObject>>{
+  ): Promise<ParseObject | Array<ParseObject>> {
     const batchSize =
       options && options.batchSize ? options.batchSize : CoreManager.get('REQUEST_BATCH_SIZE');
     const localDatastore = CoreManager.getLocalDatastore();
@@ -2386,7 +2393,10 @@ const DefaultController = {
     return Promise.resolve(target);
   },
 
-  save(target: ParseObject | null | Array<ParseObject | ParseFile>, options: RequestOptions): Promise<ParseObject | Array<ParseObject> | ParseFile | undefined> {
+  save(
+    target: ParseObject | null | Array<ParseObject | ParseFile>,
+    options: RequestOptions
+  ): Promise<ParseObject | Array<ParseObject> | ParseFile | undefined> {
     const batchSize =
       options && options.batchSize ? options.batchSize : CoreManager.get('REQUEST_BATCH_SIZE');
     const localDatastore = CoreManager.getLocalDatastore();

--- a/src/ParseOp.js
+++ b/src/ParseOp.js
@@ -134,7 +134,7 @@ export class IncrementOp extends Op {
     throw new Error('Cannot merge Increment Op with the previous Op');
   }
 
-  toJSON(): { __op: string, amount: number } {
+  toJSON(): { __op: string; amount: number } {
     return { __op: 'Increment', amount: this._amount };
   }
 }
@@ -173,7 +173,7 @@ export class AddOp extends Op {
     throw new Error('Cannot merge Add Op with the previous Op');
   }
 
-  toJSON(): { __op: string, objects: any } {
+  toJSON(): { __op: string; objects: any } {
     return { __op: 'Add', objects: encode(this._value, false, true) };
   }
 }
@@ -225,7 +225,7 @@ export class AddUniqueOp extends Op {
     throw new Error('Cannot merge AddUnique Op with the previous Op');
   }
 
-  toJSON(): { __op: string, objects: any } {
+  toJSON(): { __op: string; objects: any } {
     return { __op: 'AddUnique', objects: encode(this._value, false, true) };
   }
 }
@@ -295,7 +295,7 @@ export class RemoveOp extends Op {
     throw new Error('Cannot merge Remove Op with the previous Op');
   }
 
-  toJSON(): { __op: string, objects: any } {
+  toJSON(): { __op: string; objects: any } {
     return { __op: 'Remove', objects: encode(this._value, false, true) };
   }
 }
@@ -425,7 +425,7 @@ export class RelationOp extends Op {
     throw new Error('Cannot merge Relation Op with the previous Op');
   }
 
-  toJSON(): { __op?: string, objects?: any, ops?: any } {
+  toJSON(): { __op?: string; objects?: any; ops?: any } {
     const idToPointer = id => {
       return {
         __type: 'Pointer',
@@ -463,5 +463,5 @@ CoreManager.setParseOp({
   AddOp,
   RelationOp,
   RemoveOp,
-  AddUniqueOp
+  AddUniqueOp,
 });

--- a/src/ParsePolygon.js
+++ b/src/ParsePolygon.js
@@ -53,7 +53,7 @@ class ParsePolygon {
    *
    * @returns {object}
    */
-  toJSON(): { __type: string, coordinates: Array<Array<number>> } {
+  toJSON(): { __type: string; coordinates: Array<Array<number>> } {
     ParsePolygon._validate(this._coordinates);
     return {
       __type: 'Polygon',

--- a/src/ParseQuery.ts
+++ b/src/ParseQuery.ts
@@ -11,47 +11,47 @@ import type LiveQuerySubscription from './LiveQuerySubscription';
 import type { RequestOptions, FullOptions } from './RESTController';
 
 type BatchOptions = FullOptions & {
-  batchSize?: number
-  useMasterKey?: boolean,
-  sessionToken?: string,
-  context?: { [key: string]: any },
-  json?: boolean
+  batchSize?: number;
+  useMasterKey?: boolean;
+  sessionToken?: string;
+  context?: { [key: string]: any };
+  json?: boolean;
 };
 
 export type WhereClause = {
-  [attr: string]: any,
+  [attr: string]: any;
 };
 
 type QueryOptions = {
-  useMasterKey?: boolean,
-  sessionToken?: string,
-  context?: { [key: string]: any },
-  json?: boolean,
+  useMasterKey?: boolean;
+  sessionToken?: string;
+  context?: { [key: string]: any };
+  json?: boolean;
 };
 
 type FullTextQueryOptions = {
-  language?: string,
-  caseSensitive?: boolean,
-  diacriticSensitive?: boolean,
+  language?: string;
+  caseSensitive?: boolean;
+  diacriticSensitive?: boolean;
 };
 
 export type QueryJSON = {
-  where: WhereClause,
-  watch?: string,
-  include?: string,
-  excludeKeys?: string,
-  keys?: string,
-  limit?: number,
-  skip?: number,
-  order?: string,
-  className?: string,
-  count?: number,
-  hint?: any,
-  explain?: boolean,
-  readPreference?: string,
-  includeReadPreference?: string,
-  subqueryReadPreference?: string,
-  comment?: string,
+  where: WhereClause;
+  watch?: string;
+  include?: string;
+  excludeKeys?: string;
+  keys?: string;
+  limit?: number;
+  skip?: number;
+  order?: string;
+  className?: string;
+  count?: number;
+  hint?: any;
+  explain?: boolean;
+  readPreference?: string;
+  includeReadPreference?: string;
+  subqueryReadPreference?: string;
+  comment?: string;
 };
 
 /**
@@ -487,7 +487,7 @@ class ParseQuery {
     if (this._explain) {
       params.explain = true;
     }
-    if(this._comment) {
+    if (this._comment) {
       params.comment = this._comment;
     }
     for (const key in this._extraOptions) {
@@ -575,7 +575,7 @@ class ParseQuery {
       this._explain = !!json.explain;
     }
 
-    if(json.comment) {
+    if (json.comment) {
       this._comment = json.comment;
     }
 
@@ -773,10 +773,10 @@ class ParseQuery {
    * @returns {Promise} A promise that is resolved with the count when
    * the query completes.
    */
-  count(options?: { useMasterKey?: boolean, sessionToken?: string }): Promise<number> {
+  count(options?: { useMasterKey?: boolean; sessionToken?: string }): Promise<number> {
     options = options || {};
 
-    const findOptions: { useMasterKey?: boolean, sessionToken?: string } = {};
+    const findOptions: { useMasterKey?: boolean; sessionToken?: string } = {};
     if (options.hasOwnProperty('useMasterKey')) {
       findOptions.useMasterKey = options.useMasterKey;
     }
@@ -807,7 +807,9 @@ class ParseQuery {
   distinct(key: string, options?: { sessionToken?: string }): Promise<Array<any>> {
     options = options || {};
 
-    const distinctOptions: { sessionToken?: string, useMasterKey: boolean } = { useMasterKey: true};
+    const distinctOptions: { sessionToken?: string; useMasterKey: boolean } = {
+      useMasterKey: true,
+    };
 
     if (options.hasOwnProperty('sessionToken')) {
       distinctOptions.sessionToken = options.sessionToken;
@@ -835,7 +837,9 @@ class ParseQuery {
    */
   aggregate(pipeline: any, options?: { sessionToken?: string }): Promise<Array<any>> {
     options = options || {};
-    const aggregateOptions: { sessionToken?: string, useMasterKey: boolean } = { useMasterKey: true };
+    const aggregateOptions: { sessionToken?: string; useMasterKey: boolean } = {
+      useMasterKey: true,
+    };
 
     if (options.hasOwnProperty('sessionToken')) {
       aggregateOptions.sessionToken = options.sessionToken;
@@ -955,10 +959,7 @@ class ParseQuery {
    * @returns {Promise} A promise that will be fulfilled once the
    *     iteration has completed.
    */
-  eachBatch(
-    callback: (objs: Array<ParseObject>) => void,
-    options?: BatchOptions
-  ): Promise<void> {
+  eachBatch(callback: (objs: Array<ParseObject>) => void, options?: BatchOptions): Promise<void> {
     options = options || {};
 
     if (this._order || this._skip || this._limit >= 0) {
@@ -1550,7 +1551,12 @@ class ParseQuery {
       throw new Error('The value being searched for must be a string.');
     }
 
-    const fullOptions: { $term?: string, $language?: string, $caseSensitive?: boolean, $diacriticSensitive?: boolean } = {};
+    const fullOptions: {
+      $term?: string;
+      $language?: string;
+      $caseSensitive?: boolean;
+      $diacriticSensitive?: boolean;
+    } = {};
     fullOptions.$term = value;
 
     for (const option in options) {
@@ -2155,12 +2161,20 @@ class ParseQuery {
 }
 
 const DefaultController = {
-  find(className: string, params: QueryJSON, options: RequestOptions): Promise<{ results: Array<ParseObject> }> {
+  find(
+    className: string,
+    params: QueryJSON,
+    options: RequestOptions
+  ): Promise<{ results: Array<ParseObject> }> {
     const RESTController = CoreManager.getRESTController();
     return RESTController.request('GET', 'classes/' + className, params, options);
   },
 
-  aggregate(className: string, params: any, options: RequestOptions): Promise<{ results: Array<any> }> {
+  aggregate(
+    className: string,
+    params: any,
+    options: RequestOptions
+  ): Promise<{ results: Array<any> }> {
     const RESTController = CoreManager.getRESTController();
 
     return RESTController.request('GET', 'aggregate/' + className, params, options);

--- a/src/ParseRelation.js
+++ b/src/ParseRelation.js
@@ -108,7 +108,7 @@ class ParseRelation {
    *
    * @returns {object} JSON representation of Relation
    */
-  toJSON(): { __type: 'Relation', className: ?string } {
+  toJSON(): { __type: 'Relation'; className: ?string } {
     return {
       __type: 'Relation',
       className: this.targetClassName,

--- a/src/ParseRole.ts
+++ b/src/ParseRole.ts
@@ -112,7 +112,7 @@ class ParseRole extends ParseObject {
   }
 
   validate(attrs: AttributeMap, options?: any): ParseError | boolean {
-    const isInvalid = (super.validate as typeof this['validate'])(attrs, options);
+    const isInvalid = (super.validate as (typeof this)['validate'])(attrs, options);
     if (isInvalid) {
       return isInvalid;
     }

--- a/src/ParseSchema.js
+++ b/src/ParseSchema.js
@@ -24,8 +24,8 @@ const FIELD_TYPES = [
 ];
 
 type FieldOptions = {
-  required: boolean,
-  defaultValue: any,
+  required: boolean;
+  defaultValue: any;
 };
 
 /**

--- a/src/ParseUser.ts
+++ b/src/ParseUser.ts
@@ -10,9 +10,9 @@ import type { RequestOptions, FullOptions } from './RESTController';
 export type AuthData = { [key: string]: any };
 export type AuthProviderType = {
   authenticate?(options: {
-    error?: (provider: AuthProviderType, error: string | any) => void,
-    success?: (provider: AuthProviderType, result: AuthData) => void,
-  }): void,
+    error?: (provider: AuthProviderType, error: string | any) => void;
+    success?: (provider: AuthProviderType, result: AuthData) => void;
+  }): void;
   restoreAuthentication(authData: any): boolean;
   getAuthType(): string;
   deauthenticate?(): void;
@@ -118,7 +118,7 @@ class ParseUser extends ParseObject {
       this.stripAnonymity();
 
       const controller = CoreManager.getUserController();
-      return controller.linkWith(this, authData, saveOpts).catch((e) => {
+      return controller.linkWith(this, authData, saveOpts).catch(e => {
         delete authData[authType];
         this.restoreAnonimity(oldAnonymousData);
         throw e;
@@ -398,7 +398,7 @@ class ParseUser extends ParseObject {
    *
    * @returns {string} the session token, or undefined
    */
-  getSessionToken(): string | null{
+  getSessionToken(): string | null {
     const token = this.get('sessionToken');
     if (token == null || typeof token === 'string') {
       return token;
@@ -429,7 +429,10 @@ class ParseUser extends ParseObject {
    * @returns {Promise} A promise that is fulfilled when the signup
    *     finishes.
    */
-  signUp(attrs: AttributeMap, options?: FullOptions & { context?: AttributeMap }): Promise<ParseUser> {
+  signUp(
+    attrs: AttributeMap,
+    options?: FullOptions & { context?: AttributeMap }
+  ): Promise<ParseUser> {
     options = options || {};
 
     const signupOptions: FullOptions & { context?: AttributeMap } = {};
@@ -553,7 +556,7 @@ class ParseUser extends ParseObject {
    *
    * @param {string} password The password to be verified.
    * @param {object} options The options.
-   * @param {boolean} [options.ignoreEmailVerification=false] Set to `true` to bypass email verification and verify
+   * @param {boolean} [options.ignoreEmailVerification] Set to `true` to bypass email verification and verify
    * the password regardless of whether the email has been verified. This requires the master key.
    * @returns {Promise} A promise that is fulfilled with a user when the password is correct.
    */
@@ -693,7 +696,12 @@ class ParseUser extends ParseObject {
    * @returns {Promise} A promise that is fulfilled with the user when
    *     the login completes.
    */
-  static logInWithAdditionalAuth(username: string, password: string, authData: AuthData, options?: FullOptions) {
+  static logInWithAdditionalAuth(
+    username: string,
+    password: string,
+    authData: AuthData,
+    options?: FullOptions
+  ) {
     if (typeof username !== 'string') {
       return Promise.reject(new ParseError(ParseError.OTHER_CAUSE, 'Username must be a string.'));
     }
@@ -720,7 +728,10 @@ class ParseUser extends ParseObject {
    */
   static loginAs(userId: string) {
     if (!userId) {
-      throw new ParseError(ParseError.USERNAME_MISSING, 'Cannot log in as user with an empty user id');
+      throw new ParseError(
+        ParseError.USERNAME_MISSING,
+        'Cannot log in as user with an empty user id'
+      );
     }
     const controller = CoreManager.getUserController();
     const user = new this();
@@ -877,7 +888,7 @@ class ParseUser extends ParseObject {
    * @param {string} username  The username of the user whose password should be verified.
    * @param {string} password The password to be verified.
    * @param {object} options The options.
-   * @param {boolean} [options.ignoreEmailVerification=false] Set to `true` to bypass email verification and verify
+   * @param {boolean} [options.ignoreEmailVerification] Set to `true` to bypass email verification and verify
    * the password regardless of whether the email has been verified. This requires the master key.
    * @returns {Promise} A promise that is fulfilled with a user when the password is correct.
    */
@@ -1034,7 +1045,7 @@ const DefaultController = {
     return DefaultController.updateUserOnDisk(user);
   },
 
-  currentUser(): ParseUser | null{
+  currentUser(): ParseUser | null {
     if (currentUserCache) {
       return currentUserCache;
     }
@@ -1170,14 +1181,16 @@ const DefaultController = {
 
   loginAs(user: ParseUser, userId: string): Promise<ParseUser> {
     const RESTController = CoreManager.getRESTController();
-    return RESTController.request('POST', 'loginAs', { userId }, { useMasterKey: true }).then(response => {
-      user._finishFetch(response);
-      user._setExisted(true);
-      if (!canUseCurrentUser) {
-        return Promise.resolve(user);
+    return RESTController.request('POST', 'loginAs', { userId }, { useMasterKey: true }).then(
+      response => {
+        user._finishFetch(response);
+        user._setExisted(true);
+        if (!canUseCurrentUser) {
+          return Promise.resolve(user);
+        }
+        return DefaultController.setCurrentUser(user);
       }
-      return DefaultController.setCurrentUser(user);
-    });
+    );
   },
 
   become(user: ParseUser, options: RequestOptions): Promise<ParseUser> {
@@ -1272,7 +1285,9 @@ const DefaultController = {
     const data = {
       username,
       password,
-      ...(options.ignoreEmailVerification !== undefined && { ignoreEmailVerification: options.ignoreEmailVerification }),
+      ...(options.ignoreEmailVerification !== undefined && {
+        ignoreEmailVerification: options.ignoreEmailVerification,
+      }),
     };
     return RESTController.request('GET', 'verifyPassword', data, options);
   },

--- a/src/Push.ts
+++ b/src/Push.ts
@@ -6,10 +6,10 @@ import type { WhereClause } from './ParseQuery';
 import type { FullOptions } from './RESTController';
 
 export type PushData = {
-  where?: WhereClause | ParseQuery,
-  push_time?: Date | string,
-  expiration_time?: Date | string,
-  expiration_interval?: number,
+  where?: WhereClause | ParseQuery;
+  push_time?: Date | string;
+  expiration_time?: Date | string;
+  expiration_interval?: number;
 };
 
 /**
@@ -86,7 +86,10 @@ export function send(data: PushData, options: FullOptions = {}): Promise<string>
  * </ul>
  * @returns {Parse.Object} Status of Push.
  */
-export function getPushStatus(pushStatusId: string, options: FullOptions = {}): Promise<ParseObject> {
+export function getPushStatus(
+  pushStatusId: string,
+  options: FullOptions = {}
+): Promise<ParseObject> {
   const pushOptions = { useMasterKey: true };
   if (options.hasOwnProperty('useMasterKey')) {
     pushOptions.useMasterKey = options.useMasterKey;

--- a/src/RESTController.js
+++ b/src/RESTController.js
@@ -9,26 +9,26 @@ import ParseError from './ParseError';
 import { resolvingPromise } from './promiseUtils';
 
 export type RequestOptions = {
-  useMasterKey?: boolean,
-  sessionToken?: string,
-  installationId?: string,
-  returnStatus?: boolean,
-  batchSize?: number,
-  include?: any,
-  progress?: any,
-  context?: any,
-  usePost?: boolean,
-  ignoreEmailVerification?: boolean,
+  useMasterKey?: boolean;
+  sessionToken?: string;
+  installationId?: string;
+  returnStatus?: boolean;
+  batchSize?: number;
+  include?: any;
+  progress?: any;
+  context?: any;
+  usePost?: boolean;
+  ignoreEmailVerification?: boolean;
 };
 
 export type FullOptions = {
-  success?: any,
-  error?: any,
-  useMasterKey?: boolean,
-  sessionToken?: string,
-  installationId?: string,
-  progress?: any,
-  usePost?: boolean,
+  success?: any;
+  error?: any;
+  useMasterKey?: boolean;
+  sessionToken?: string;
+  installationId?: string;
+  progress?: any;
+  usePost?: boolean;
 };
 
 let XHR = null;
@@ -111,10 +111,16 @@ const RESTController = {
           let response;
           try {
             response = JSON.parse(xhr.responseText);
-            const availableHeaders = typeof xhr.getAllResponseHeaders === 'function' ? xhr.getAllResponseHeaders() : "";
+            const availableHeaders =
+              typeof xhr.getAllResponseHeaders === 'function' ? xhr.getAllResponseHeaders() : '';
             headers = {};
-            if (typeof xhr.getResponseHeader === 'function' && availableHeaders?.indexOf('access-control-expose-headers') >= 0) {
-              const responseHeaders = xhr.getResponseHeader('access-control-expose-headers').split(', ');
+            if (
+              typeof xhr.getResponseHeader === 'function' &&
+              availableHeaders?.indexOf('access-control-expose-headers') >= 0
+            ) {
+              const responseHeaders = xhr
+                .getResponseHeader('access-control-expose-headers')
+                .split(', ');
               responseHeaders.forEach(header => {
                 if (availableHeaders.indexOf(header.toLowerCase()) >= 0) {
                   headers[header] = xhr.getResponseHeader(header.toLowerCase());

--- a/src/SingleInstanceStateController.js
+++ b/src/SingleInstanceStateController.js
@@ -8,14 +8,14 @@ import type { Op } from './ParseOp';
 import type { AttributeMap, ObjectCache, OpsMap, State } from './ObjectStateMutations';
 
 type ObjectIdentifier = {
-  className: string,
-  id: string,
+  className: string;
+  id: string;
 };
 
 let objectState: {
   [className: string]: {
-    [id: string]: State,
-  },
+    [id: string]: State;
+  };
 } = {};
 
 export function getState(obj: ObjectIdentifier): ?State {

--- a/src/Socket.weapp.js
+++ b/src/Socket.weapp.js
@@ -13,7 +13,7 @@ module.exports = class SocketWeapp {
       this.onmessage(msg);
     });
 
-    wx.onSocketClose((event) => {
+    wx.onSocketClose(event => {
       this.onclose(event);
     });
 

--- a/src/TaskQueue.ts
+++ b/src/TaskQueue.ts
@@ -1,8 +1,8 @@
 import { resolvingPromise } from './promiseUtils';
 
 type Task = {
-  task: () => Promise<void>,
-  _completion: any,
+  task: () => Promise<void>;
+  _completion: any;
 };
 
 class TaskQueue {

--- a/src/WebSocketController.js
+++ b/src/WebSocketController.js
@@ -4,7 +4,8 @@ let WebSocketController;
 
 try {
   if (process.env.PARSE_BUILD === 'browser') {
-    WebSocketController = (typeof WebSocket === 'function' || typeof WebSocket === 'object' ? WebSocket : null);
+    WebSocketController =
+      typeof WebSocket === 'function' || typeof WebSocket === 'object' ? WebSocket : null;
   } else if (process.env.PARSE_BUILD === 'node') {
     WebSocketController = require('ws');
   } else if (process.env.PARSE_BUILD === 'weapp') {

--- a/src/__tests__/CoreManager-test.js
+++ b/src/__tests__/CoreManager-test.js
@@ -136,19 +136,19 @@ describe('CoreManager', () => {
       'InstallationController must implement currentInstallationId()'
     );
 
-    expect(CoreManager.setInstallationController.bind(null, {
-      currentInstallationId: function () {},
-      currentInstallation: function () {},
-    })).toThrow(
-      'InstallationController must implement updateInstallationOnDisk()'
-    );
+    expect(
+      CoreManager.setInstallationController.bind(null, {
+        currentInstallationId: function () {},
+        currentInstallation: function () {},
+      })
+    ).toThrow('InstallationController must implement updateInstallationOnDisk()');
 
-    expect(CoreManager.setInstallationController.bind(null, {
-      currentInstallationId: function () {},
-      updateInstallationOnDisk: function () {},
-    })).toThrow(
-      'InstallationController must implement currentInstallation()'
-    );
+    expect(
+      CoreManager.setInstallationController.bind(null, {
+        currentInstallationId: function () {},
+        updateInstallationOnDisk: function () {},
+      })
+    ).toThrow('InstallationController must implement currentInstallation()');
 
     expect(
       CoreManager.setInstallationController.bind(null, {

--- a/src/__tests__/Hooks-test.js
+++ b/src/__tests__/Hooks-test.js
@@ -132,80 +132,69 @@ describe('Hooks', () => {
 
   it('shoud throw invalid create', async () => {
     expect.assertions(10);
-    const p1 = Hooks.create({ functionName: 'myFunction' })
-      .catch(err => {
-        expect(err.code).toBe(143);
-        expect(err.error).toBe('invalid hook declaration');
-      });
+    const p1 = Hooks.create({ functionName: 'myFunction' }).catch(err => {
+      expect(err.code).toBe(143);
+      expect(err.error).toBe('invalid hook declaration');
+    });
 
-    const p2 = Hooks.create({ url: 'http://dummy.com' })
-      .catch(err => {
-        expect(err.code).toBe(143);
-        expect(err.error).toBe('invalid hook declaration');
-      });
+    const p2 = Hooks.create({ url: 'http://dummy.com' }).catch(err => {
+      expect(err.code).toBe(143);
+      expect(err.error).toBe('invalid hook declaration');
+    });
 
-    const p3 = Hooks.create({ className: 'MyClass' })
-      .catch(err => {
-        expect(err.code).toBe(143);
-        expect(err.error).toBe('invalid hook declaration');
-      });
+    const p3 = Hooks.create({ className: 'MyClass' }).catch(err => {
+      expect(err.code).toBe(143);
+      expect(err.error).toBe('invalid hook declaration');
+    });
 
-    const p4 = Hooks.create({ className: 'MyClass', url: 'http://dummy.com' })
-      .catch(err => {
-        expect(err.code).toBe(143);
-        expect(err.error).toBe('invalid hook declaration');
-      });
+    const p4 = Hooks.create({ className: 'MyClass', url: 'http://dummy.com' }).catch(err => {
+      expect(err.code).toBe(143);
+      expect(err.error).toBe('invalid hook declaration');
+    });
 
-    const p5 = Hooks.create({ className: 'MyClass', triggerName: 'beforeSave' })
-      .catch(err => {
-        expect(err.code).toBe(143);
-        expect(err.error).toBe('invalid hook declaration');
-      });
+    const p5 = Hooks.create({ className: 'MyClass', triggerName: 'beforeSave' }).catch(err => {
+      expect(err.code).toBe(143);
+      expect(err.error).toBe('invalid hook declaration');
+    });
 
     await Promise.all([p1, p2, p3, p4, p5]);
   });
 
   it('shoud throw invalid update', async () => {
     expect.assertions(6);
-    const p1 = Hooks.update({ functionssName: 'myFunction' })
-      .catch(err => {
-        expect(err.code).toBe(143);
-        expect(err.error).toBe('invalid hook declaration');
-      });
+    const p1 = Hooks.update({ functionssName: 'myFunction' }).catch(err => {
+      expect(err.code).toBe(143);
+      expect(err.error).toBe('invalid hook declaration');
+    });
 
-    const p2 = Hooks.update({ className: 'MyClass' })
-      .catch(err => {
-        expect(err.code).toBe(143);
-        expect(err.error).toBe('invalid hook declaration');
-      });
+    const p2 = Hooks.update({ className: 'MyClass' }).catch(err => {
+      expect(err.code).toBe(143);
+      expect(err.error).toBe('invalid hook declaration');
+    });
 
-    const p3 = Hooks.update({ className: 'MyClass', url: 'http://dummy.com' })
-      .catch(err => {
-        expect(err.code).toBe(143);
-        expect(err.error).toBe('invalid hook declaration');
-      });
+    const p3 = Hooks.update({ className: 'MyClass', url: 'http://dummy.com' }).catch(err => {
+      expect(err.code).toBe(143);
+      expect(err.error).toBe('invalid hook declaration');
+    });
     await Promise.all([p1, p2, p3]);
   });
 
   it('shoud throw invalid remove', async () => {
     expect.assertions(6);
-    const p1 = Hooks.remove({ functionssName: 'myFunction' })
-      .catch(err => {
-        expect(err.code).toBe(143);
-        expect(err.error).toBe('invalid hook declaration');
-      });
+    const p1 = Hooks.remove({ functionssName: 'myFunction' }).catch(err => {
+      expect(err.code).toBe(143);
+      expect(err.error).toBe('invalid hook declaration');
+    });
 
-    const p2 = Hooks.remove({ className: 'MyClass' })
-      .catch(err => {
-        expect(err.code).toBe(143);
-        expect(err.error).toBe('invalid hook declaration');
-      });
+    const p2 = Hooks.remove({ className: 'MyClass' }).catch(err => {
+      expect(err.code).toBe(143);
+      expect(err.error).toBe('invalid hook declaration');
+    });
 
-    const p3 = Hooks.remove({ className: 'MyClass', url: 'http://dummy.com' })
-      .catch(err => {
-        expect(err.code).toBe(143);
-        expect(err.error).toBe('invalid hook declaration');
-      });
+    const p3 = Hooks.remove({ className: 'MyClass', url: 'http://dummy.com' }).catch(err => {
+      expect(err.code).toBe(143);
+      expect(err.error).toBe('invalid hook declaration');
+    });
 
     await Promise.all([p1, p2, p3]);
   });

--- a/src/__tests__/InstallationController-test.js
+++ b/src/__tests__/InstallationController-test.js
@@ -44,7 +44,7 @@ describe('InstallationController', () => {
   });
 
   it('permanently stores the installation id', async () => {
-    const iid =  await InstallationController.currentInstallationId();
+    const iid = await InstallationController.currentInstallationId();
     InstallationController._clearCache();
     const i = await InstallationController.currentInstallationId();
     expect(i).toBe(iid);
@@ -76,7 +76,7 @@ describe('InstallationController', () => {
   it('permanently stores the current installation', async () => {
     const iid = 'stored-installation-id';
     InstallationController._setInstallationIdCache(iid);
-    const installation =  await InstallationController.currentInstallation();
+    const installation = await InstallationController.currentInstallation();
     InstallationController._clearCache();
     const i = await InstallationController.currentInstallation();
     expect(i.installationId).toEqual(installation.installationId);

--- a/src/__tests__/OfflineQuery-test.js
+++ b/src/__tests__/OfflineQuery-test.js
@@ -285,7 +285,10 @@ describe('OfflineQuery', () => {
 
   it('matches on inequalities', () => {
     const player = new ParseObject('Person');
-    player.set('score', 12).set('name', 'Bill').set('birthday', new Date(1980, 2, 4));
+    player
+      .set('score', 12)
+      .set('name', 'Bill')
+      .set('birthday', new Date(1980, 2, 4));
 
     let q = new ParseQuery('Person');
     q.lessThan('score', 15);

--- a/src/__tests__/Parse-test.js
+++ b/src/__tests__/Parse-test.js
@@ -96,9 +96,8 @@ describe('Parse module', () => {
   });
 
   it('cannot set EventuallyQueue controller with missing functions', () => {
-    const controller = {
-    };
-    expect(() => Parse.EventuallyQueue = controller).toThrow(
+    const controller = {};
+    expect(() => (Parse.EventuallyQueue = controller)).toThrow(
       'EventuallyQueue must implement poll()'
     );
   });
@@ -190,7 +189,7 @@ describe('Parse module', () => {
   it('can set and get live query', () => {
     const temp = Parse.LiveQuery;
     const LiveQuery = new ParseLiveQuery();
-    Parse.LiveQuery = LiveQuery
+    Parse.LiveQuery = LiveQuery;
     expect(Parse.LiveQuery).toEqual(LiveQuery);
     Parse.LiveQuery = temp;
   });

--- a/src/__tests__/ParseFile-test.js
+++ b/src/__tests__/ParseFile-test.js
@@ -24,7 +24,7 @@ const mockLocalDatastore = {
     const objectKey = mockLocalDatastore.getKeyForObject(object);
   }),
   _updateObjectIfPinned: jest.fn(),
-  getKeyForObject: jest.fn((object) => {
+  getKeyForObject: jest.fn(object => {
     // (Taken from LocalDataStore source) This fails for nested objects that are not ParseObject
     const OBJECT_PREFIX = 'Parse_LDS_';
     const objectId = object.objectId || object._getId();

--- a/src/__tests__/ParseGeoPoint-test.js
+++ b/src/__tests__/ParseGeoPoint-test.js
@@ -232,6 +232,8 @@ describe('GeoPoint', () => {
         expect(options).toEqual({ timeout: 5000 });
       },
     };
-    await expect(ParseGeoPoint.current({ timeout: 5000 })).rejects.toEqual({ message: 'PERMISSION_DENIED' });
+    await expect(ParseGeoPoint.current({ timeout: 5000 })).rejects.toEqual({
+      message: 'PERMISSION_DENIED',
+    });
   });
 });

--- a/src/__tests__/ParseInstallation-test.js
+++ b/src/__tests__/ParseInstallation-test.js
@@ -99,10 +99,7 @@ describe('ParseInstallation', () => {
           return Promise.resolve({}, 200);
         }
         once = false;
-        const parseError = new ParseError(
-          ParseError.OBJECT_NOT_FOUND,
-          'Object not found.'
-        );
+        const parseError = new ParseError(ParseError.OBJECT_NOT_FOUND, 'Object not found.');
         return Promise.reject(parseError);
       },
       ajax() {},
@@ -200,10 +197,7 @@ describe('ParseInstallation', () => {
         }
         once = false;
         // fetch() results
-        const parseError = new ParseError(
-          ParseError.OBJECT_NOT_FOUND,
-          'Object not found.'
-        );
+        const parseError = new ParseError(ParseError.OBJECT_NOT_FOUND, 'Object not found.');
         return Promise.reject(parseError);
       },
       ajax() {},

--- a/src/__tests__/ParseLiveQuery-test.js
+++ b/src/__tests__/ParseLiveQuery-test.js
@@ -19,7 +19,7 @@ const mockLiveQueryClient = {
   close: jest.fn(),
 };
 CoreManager.setEventEmitter(EventEmitter);
-const LiveQuery = new ParseLiveQuery()
+const LiveQuery = new ParseLiveQuery();
 
 describe('ParseLiveQuery', () => {
   beforeEach(() => {

--- a/src/__tests__/ParseObject-test.js
+++ b/src/__tests__/ParseObject-test.js
@@ -126,12 +126,13 @@ const mockLocalDatastore = {
     const objectKey = mockLocalDatastore.getKeyForObject(object);
   }),
   _updateObjectIfPinned: jest.fn(),
-  getKeyForObject: jest.fn((object) => {
+  getKeyForObject: jest.fn(object => {
     // (Taken from LocalDataStore source) This fails for nested objects that are not ParseObject
     const objectId = object.objectId || object._getId();
     const OBJECT_PREFIX = 'Parse_LDS_';
     return `${OBJECT_PREFIX}${object.className}_${objectId}`;
-  }), updateFromServer: jest.fn(),
+  }),
+  updateFromServer: jest.fn(),
   _clear: jest.fn(),
   checkIfEnabled: jest.fn(() => {
     if (!mockLocalDatastore.isEnabled) {
@@ -2440,7 +2441,7 @@ describe('ParseObject', () => {
     expect(controller.ajax).toHaveBeenCalledTimes(0);
   });
 
-  it('can save an array of objects', (done) => {
+  it('can save an array of objects', done => {
     const xhr = {
       setRequestHeader: jest.fn(),
       open: jest.fn(),
@@ -2478,7 +2479,7 @@ describe('ParseObject', () => {
     });
   });
 
-  it('can saveAll with batchSize', (done) => {
+  it('can saveAll with batchSize', done => {
     const xhrs = [];
     for (let i = 0; i < 2; i++) {
       xhrs[i] = {
@@ -2539,7 +2540,7 @@ describe('ParseObject', () => {
     });
   });
 
-  it('can saveAll with global batchSize', (done) => {
+  it('can saveAll with global batchSize', done => {
     const xhrs = [];
     for (let i = 0; i < 2; i++) {
       xhrs[i] = {
@@ -2600,7 +2601,7 @@ describe('ParseObject', () => {
     });
   });
 
-  it('returns the first error when saving an array of objects', (done) => {
+  it('returns the first error when saving an array of objects', done => {
     const xhrs = [];
     for (let i = 0; i < 2; i++) {
       xhrs[i] = {
@@ -2661,7 +2662,7 @@ describe('ObjectController', () => {
     jest.clearAllMocks();
   });
 
-  it('can fetch a single object', (done) => {
+  it('can fetch a single object', done => {
     const objectController = CoreManager.getObjectController();
     const xhr = {
       setRequestHeader: jest.fn(),

--- a/src/__tests__/ParseOp-test.js
+++ b/src/__tests__/ParseOp-test.js
@@ -33,7 +33,9 @@ const ParseObject = require('../ParseObject');
 const ParseOp = require('../ParseOp');
 const CoreManager = require('../CoreManager');
 jest.spyOn(CoreManager, 'getParseObject').mockImplementation(() => require('../ParseObject'));
-jest.spyOn(CoreManager, 'getEventuallyQueue').mockImplementation(() => require('../EventuallyQueue'));
+jest
+  .spyOn(CoreManager, 'getEventuallyQueue')
+  .mockImplementation(() => require('../EventuallyQueue'));
 
 const { Op, SetOp, UnsetOp, IncrementOp, AddOp, AddUniqueOp, RemoveOp, RelationOp, opFromJSON } =
   ParseOp;

--- a/src/__tests__/ParseQuery-test.js
+++ b/src/__tests__/ParseQuery-test.js
@@ -1803,7 +1803,7 @@ describe('ParseQuery', () => {
       q.select('size', 'name');
       q.includeAll();
       q.hint('_id_');
-      q.exclude('foo')
+      q.exclude('foo');
 
       await q.findAll();
       expect(findMock).toHaveBeenCalledTimes(1);
@@ -3857,5 +3857,4 @@ describe('ParseQuery LocalDatastore', () => {
     query.comment();
     expect(query._comment).toBeUndefined();
   });
-
 });

--- a/src/__tests__/ParseUser-test.js
+++ b/src/__tests__/ParseUser-test.js
@@ -354,9 +354,11 @@ describe('ParseUser', () => {
         },
         ajax() {},
       });
-      const response = await ParseUser.logInWithAdditionalAuth('username', 'password', {mfa: {key:'1234'}});
+      const response = await ParseUser.logInWithAdditionalAuth('username', 'password', {
+        mfa: { key: '1234' },
+      });
       expect(response instanceof ParseUser).toBe(true);
-      expect(response.get('authDataResponse')).toEqual({mfa: { enabled: true }});
+      expect(response.get('authDataResponse')).toEqual({ mfa: { enabled: true } });
     });
 
     it('loginWithAdditonal fails with invalid payload', async () => {
@@ -368,12 +370,11 @@ describe('ParseUser', () => {
       await expect(ParseUser.logInWithAdditionalAuth('username', {}, {})).rejects.toThrowError(
         new ParseError(ParseError.OTHER_CAUSE, 'Password must be a string.')
       );
-      await expect(ParseUser.logInWithAdditionalAuth('username', 'password', '')).rejects.toThrowError(
-        new ParseError(ParseError.OTHER_CAUSE, 'Auth must be an object.')
-      );
+      await expect(
+        ParseUser.logInWithAdditionalAuth('username', 'password', '')
+      ).rejects.toThrowError(new ParseError(ParseError.OTHER_CAUSE, 'Auth must be an object.'));
     });
   });
-
 
   it('preserves changes when logging in', done => {
     ParseUser.enableUnsafeCurrentUser();
@@ -409,11 +410,11 @@ describe('ParseUser', () => {
     });
   });
 
-  it('does not allow loginAs without id', (done) => {
+  it('does not allow loginAs without id', done => {
     try {
       ParseUser.loginAs(null, null);
     } catch (e) {
-      expect(e.message).toBe('Cannot log in as user with an empty user id')
+      expect(e.message).toBe('Cannot log in as user with an empty user id');
       done();
     }
   });

--- a/src/__tests__/RESTController-test.js
+++ b/src/__tests__/RESTController-test.js
@@ -223,8 +223,10 @@ describe('RESTController', () => {
       getResponseHeader: function (header) {
         return headers[header];
       },
-      getAllResponseHeaders: function() {
-        return Object.keys(headers).map(key => `${key}: ${headers[key]}`).join('\n');
+      getAllResponseHeaders: function () {
+        return Object.keys(headers)
+          .map(key => `${key}: ${headers[key]}`)
+          .join('\n');
       },
       send: function () {
         this.status = 200;
@@ -234,7 +236,12 @@ describe('RESTController', () => {
       },
     };
     RESTController._setXHR(XHR);
-    const response = await RESTController.request('GET', 'classes/MyObject', {}, { returnStatus: true });
+    const response = await RESTController.request(
+      'GET',
+      'classes/MyObject',
+      {},
+      { returnStatus: true }
+    );
     expect(response._headers['X-Parse-Job-Status-Id']).toBe('1234');
   });
 
@@ -246,8 +253,10 @@ describe('RESTController', () => {
       getResponseHeader: function (header) {
         return headers[header];
       },
-      getAllResponseHeaders: function() {
-        return Object.keys(headers).map(key => `${key}: ${headers[key]}`).join('\n');
+      getAllResponseHeaders: function () {
+        return Object.keys(headers)
+          .map(key => `${key}: ${headers[key]}`)
+          .join('\n');
       },
       send: function () {
         this.status = 200;
@@ -287,10 +296,10 @@ describe('RESTController', () => {
   it('does not invoke Chrome browser console error on getResponseHeader', async () => {
     const headers = {
       'access-control-expose-headers': 'a, b, c',
-      'a' : 'value',
-      'b' : 'value',
-      'c' : 'value',
-    }
+      a: 'value',
+      b: 'value',
+      c: 'value',
+    };
     const XHR = function () {};
     XHR.prototype = {
       open: function () {},
@@ -299,10 +308,12 @@ describe('RESTController', () => {
         if (Object.keys(headers).includes(key)) {
           return headers[key];
         }
-        throw new Error("Chrome creates a console error here.");
+        throw new Error('Chrome creates a console error here.');
       }),
       getAllResponseHeaders: jest.fn(() => {
-        return Object.keys(headers).map(key => `${key}: ${headers[key]}`).join('\r\n');
+        return Object.keys(headers)
+          .map(key => `${key}: ${headers[key]}`)
+          .join('\r\n');
       }),
       send: function () {
         this.status = 200;
@@ -316,7 +327,6 @@ describe('RESTController', () => {
     expect(XHR.prototype.getAllResponseHeaders.mock.calls.length).toBe(1);
     expect(XHR.prototype.getResponseHeader.mock.calls.length).toBe(4);
   });
-
 
   it('handles invalid header', async () => {
     const XHR = function () {};

--- a/src/__tests__/Storage-test.js
+++ b/src/__tests__/Storage-test.js
@@ -207,8 +207,9 @@ describe('IndexDB StorageController', () => {
   it('handle indexedDB is not accessible', async () => {
     jest.isolateModules(() => {
       global.indexedDB = mockIndexedDB;
-      jest.spyOn(idbKeyVal, 'createStore')
-        .mockImplementationOnce(() => { throw new Error('Protected'); });
+      jest.spyOn(idbKeyVal, 'createStore').mockImplementationOnce(() => {
+        throw new Error('Protected');
+      });
       const dbController = require('../IndexedDBStorageController');
       expect(dbController).toBeUndefined();
       expect(idbKeyVal.createStore).toHaveBeenCalled();

--- a/src/__tests__/test_helpers/flushPromises.js
+++ b/src/__tests__/test_helpers/flushPromises.js
@@ -3,7 +3,7 @@ const { setImmediate } = require('timers');
  * Wait for all asynchronous code to finish executing
  */
 function flushPromises() {
-  return new Promise((resolve) => setImmediate(resolve));
+  return new Promise(resolve => setImmediate(resolve));
 }
 
 module.exports = flushPromises;

--- a/src/promiseUtils.ts
+++ b/src/promiseUtils.ts
@@ -6,7 +6,8 @@ export function resolvingPromise<T = any>() {
     res = resolve;
     rej = reject;
   });
-  const defer: typeof promise & { resolve: (res: T) => void, reject: (err: any) => void } = promise as any;
+  const defer: typeof promise & { resolve: (res: T) => void; reject: (err: any) => void } =
+    promise as any;
   defer.resolve = res!;
   defer.reject = rej!;
   return defer;

--- a/src/unsavedChildren.ts
+++ b/src/unsavedChildren.ts
@@ -4,8 +4,8 @@ import type ParseObject from './ParseObject';
 import ParseRelation from './ParseRelation';
 
 type EncounterMap = {
-  objects: { [identifier: string]: ParseObject | boolean },
-  files: Array<ParseFile>,
+  objects: { [identifier: string]: ParseObject | boolean };
+  files: Array<ParseFile>;
 };
 
 /**


### PR DESCRIPTION
## Pull Request

- Report security issues [confidentially](https://github.com/parse-community/Parse-SDK-JS/security/policy).
- Any contribution is under this [license](https://github.com/parse-community/Parse-SDK-JS/blob/alpha/LICENSE).
- Link this pull request to an [issue](https://github.com/parse-community/Parse-SDK-JS/issues?q=is%3Aissue).

## Issue
<!-- Add the link to the issue that this PR closes. -->
After Husky updated to v8 it has been broken.

## Approach
<!-- Describe the changes in this PR. -->
Run the typescript parser for prettier, style and lint TS files. Prettier now runs before every commit and enforces the styling convention. No functional changes have been made.

## Tasks
<!-- Delete tasks that don't apply. -->

- [x] Add tests
- [x] Add changes to documentation (guides, repository pages, code comments)
