### PR TITLE
fix: Duplicate pending operations on nested fields

### DIFF
--- a/src/ParseObject.ts
+++ b/src/ParseObject.ts
@@ -482,7 +482,12 @@ class ParseObject {
         json[attr] = encode(attrs[attr], false, false, seen, offline);
       }
     }
-
+    const pending = this._getPendingOps();
+    for (const attr in pending[0]) {
+      if (attr.indexOf('.') < 0) {
+        json[attr] = pending[0][attr].toJSON(offline);
+      }
+    }
     if (this.id) {
       json.objectId = this.id;
     }


### PR DESCRIPTION
## Pull Request

- Report security issues [confidentially](https://github.com/parse-community/Parse-SDK-JS/security/policy).
- Any contribution is under this [license](https://github.com/parse-community/Parse-SDK-JS/blob/alpha/LICENSE).
- Link this pull request to an [issue](https://github.com/parse-community/Parse-SDK-JS/issues?q=is%3Aissue).

## Issue
<!-- Add the link to the issue that this PR closes. -->
#1453 Introduced a bug that effected all fields not just nested fields. This results in breaking cloud code and prevents the latest SDK version from merging with the server.

Closes: https://github.com/parse-community/parse-server/issues/9131

## Approach
<!-- Describe the changes in this PR. -->
Revert changes in #1453 and properly handle pending operations on nested fields only as the are handled by `get attributes`.

## Tasks
<!-- Delete tasks that don't apply. -->

- [x] Add tests
- [x] Add changes to documentation (guides, repository pages, code comments)
