### PR TITLE
feat: Enable `Parse.idempotency` by default

### DIFF
--- a/integration/test/IdempotencyTest.js
+++ b/integration/test/IdempotencyTest.js
@@ -22,7 +22,12 @@ function DuplicateXHR(requestId) {
 
 describe('Idempotency', () => {
   beforeEach(() => {
+    Parse.idempotency = false;
     RESTController._setXHR(XHR);
+  });
+
+  afterEach(() => {
+    Parse.idempotency = true;
   });
 
   it('handle duplicate cloud code function request', async () => {

--- a/src/CoreManager.ts
+++ b/src/CoreManager.ts
@@ -325,7 +325,7 @@ const config: Config & { [key: string]: any } = {
   PERFORM_USER_REWRITE: true,
   FORCE_REVOCABLE_SESSION: false,
   ENCRYPTED_USER: false,
-  IDEMPOTENCY: false,
+  IDEMPOTENCY: true,
   ALLOW_CUSTOM_OBJECT_ID: false,
   PARSE_ERRORS: [],
 };

--- a/src/RESTController.ts
+++ b/src/RESTController.ts
@@ -103,6 +103,7 @@ const RESTController = {
       return ajaxIE9(method, url, data, headers, options);
     }
     const promise = resolvingPromise();
+    const requestId = CoreManager.get('IDEMPOTENCY') ? uuidv4() : '';
     let attempts = 0;
 
     const dispatch = function () {
@@ -169,8 +170,8 @@ const RESTController = {
         headers['User-Agent'] =
           'Parse/' + CoreManager.get('VERSION') + ' (NodeJS ' + process.versions.node + ')';
       }
-      if (CoreManager.get('IDEMPOTENCY')) {
-        headers['X-Parse-Request-Id'] = uuidv4();
+      if (requestId) {
+        headers['X-Parse-Request-Id'] = requestId;
       }
       if (CoreManager.get('SERVER_AUTH_TYPE') && CoreManager.get('SERVER_AUTH_TOKEN')) {
         headers['Authorization'] =

--- a/src/RESTController.ts
+++ b/src/RESTController.ts
@@ -103,8 +103,6 @@ const RESTController = {
       return ajaxIE9(method, url, data, headers, options);
     }
     const promise = resolvingPromise();
-    const isIdempotent = CoreManager.get('IDEMPOTENCY') && ['POST', 'PUT'].includes(method);
-    const requestId = isIdempotent ? uuidv4() : '';
     let attempts = 0;
 
     const dispatch = function () {
@@ -171,8 +169,8 @@ const RESTController = {
         headers['User-Agent'] =
           'Parse/' + CoreManager.get('VERSION') + ' (NodeJS ' + process.versions.node + ')';
       }
-      if (isIdempotent) {
-        headers['X-Parse-Request-Id'] = requestId;
+      if (CoreManager.get('IDEMPOTENCY')) {
+        headers['X-Parse-Request-Id'] = uuidv4();
       }
       if (CoreManager.get('SERVER_AUTH_TYPE') && CoreManager.get('SERVER_AUTH_TOKEN')) {
         headers['Authorization'] =

--- a/src/__tests__/Parse-test.js
+++ b/src/__tests__/Parse-test.js
@@ -75,12 +75,12 @@ describe('Parse module', () => {
   });
 
   it('can set idempotency', () => {
-    expect(Parse.idempotency).toBe(false);
-    Parse.idempotency = true;
-    expect(CoreManager.get('IDEMPOTENCY')).toBe(true);
     expect(Parse.idempotency).toBe(true);
     Parse.idempotency = false;
+    expect(CoreManager.get('IDEMPOTENCY')).toBe(false);
     expect(Parse.idempotency).toBe(false);
+    Parse.idempotency = true;
+    expect(Parse.idempotency).toBe(true);
   });
 
   it('can set LocalDatastoreController', () => {

--- a/src/__tests__/RESTController-test.js
+++ b/src/__tests__/RESTController-test.js
@@ -393,22 +393,6 @@ describe('RESTController', () => {
     jest.runAllTimers();
   });
 
-  it('idempotency - should properly handle url method not POST / PUT', () => {
-    const xhr = {
-      setRequestHeader: jest.fn(),
-      open: jest.fn(),
-      send: jest.fn(),
-    };
-    RESTController._setXHR(function () {
-      return xhr;
-    });
-    RESTController.ajax('GET', 'users/me', {}, {});
-    const requestIdHeaders = xhr.setRequestHeader.mock.calls.filter(
-      header => 'X-Parse-Request-Id' === header[0]
-    );
-    expect(requestIdHeaders.length).toBe(0);
-  });
-
   it('handles aborted requests', done => {
     const XHR = function () {};
     XHR.prototype = {
@@ -679,7 +663,10 @@ describe('RESTController', () => {
       return xhr;
     });
     RESTController.ajax('GET', 'users/me', {}, { 'X-Parse-Session-Token': '123' });
-    expect(xhr.setRequestHeader.mock.calls[3]).toEqual(['Cache-Control', 'max-age=3600']);
+    const cacheHeader = header => 'Cache-Control' === header[0];
+    const [header, value] = xhr.setRequestHeader.mock.calls.filter(cacheHeader)[0];
+    expect(header).toBe('Cache-Control');
+    expect(value).toBe('max-age=3600');
     expect(xhr.open.mock.calls[0]).toEqual(['GET', 'users/me', true]);
     expect(xhr.send.mock.calls[0][0]).toEqual({});
     CoreManager.set('REQUEST_HEADERS', {});


### PR DESCRIPTION
## Pull Request

- Report security issues [confidentially](https://github.com/parse-community/Parse-SDK-JS/security/policy).
- Any contribution is under this [license](https://github.com/parse-community/Parse-SDK-JS/blob/alpha/LICENSE).
- Link this pull request to an [issue](https://github.com/parse-community/Parse-SDK-JS/issues?q=is%3Aissue).

## Issue
<!-- Add the link to the issue that this PR closes. -->
There isn't a well documented way to turn idempotency on, enabling it by default only requires configuration on the server side. This is how it is handled in other SDKs

https://github.com/parse-community/Parse-Swift/pull/62
https://github.com/parse-community/Parse-SDK-iOS-OSX/pull/1790
https://github.com/parse-community/Parse-SDK-Android/pull/1190

## Approach
* Remove check for `POST` / `PUT` request method as they are handled by servers
* Add requestId to every request by default

## Tasks
<!-- Delete tasks that don't apply. -->

- [x] Add tests
- [x] Add changes to documentation (guides, repository pages, code comments)
