### PR TITLE
ci: Fix flaky test `invalid server state: initialized`

### DIFF
--- a/integration/test/ParseEventuallyQueueTest.js
+++ b/integration/test/ParseEventuallyQueueTest.js
@@ -193,6 +193,7 @@ describe('Parse EventuallyQueue', () => {
   it('can saveEventually', async () => {
     const parseServer = await reconfigureServer();
     const object = new TestObject({ hash: 'saveSecret' });
+    await parseServer.handleShutdown();
     await new Promise(resolve => parseServer.server.close(resolve));
     await object.saveEventually();
 
@@ -224,7 +225,7 @@ describe('Parse EventuallyQueue', () => {
     const acl = new Parse.ACL(user);
     const object = new TestObject({ hash: 'saveSecret' });
     object.setACL(acl);
-
+    await parseServer.handleShutdown();
     await new Promise(resolve => parseServer.server.close(resolve));
     await object.saveEventually();
 
@@ -232,7 +233,7 @@ describe('Parse EventuallyQueue', () => {
     assert(Parse.EventuallyQueue.isPolling());
     assert.strictEqual(length, 1);
 
-    await reconfigureServer({});
+    await reconfigureServer();
 
     while (Parse.EventuallyQueue.isPolling()) {
       await sleep(100);
@@ -250,6 +251,7 @@ describe('Parse EventuallyQueue', () => {
     const parseServer = await reconfigureServer();
     const object = new TestObject({ hash: 'deleteSecret' });
     await object.save();
+    await parseServer.handleShutdown();
     await new Promise(resolve => parseServer.server.close(resolve));
     await object.destroyEventually();
     const length = await Parse.EventuallyQueue.length();
@@ -257,7 +259,7 @@ describe('Parse EventuallyQueue', () => {
     assert(Parse.EventuallyQueue.isPolling());
     assert.strictEqual(length, 1);
 
-    await reconfigureServer({});
+    await reconfigureServer();
     while (Parse.EventuallyQueue.isPolling()) {
       await sleep(100);
     }

--- a/integration/test/ParseServerTest.js
+++ b/integration/test/ParseServerTest.js
@@ -6,6 +6,7 @@ describe('ParseServer', () => {
   it('can reconfigure server', async () => {
     const parseServer = await reconfigureServer({ serverURL: 'www.google.com' });
     assert.strictEqual(parseServer.config.serverURL, 'www.google.com');
+    await parseServer.handleShutdown();
     await new Promise(resolve => parseServer.server.close(resolve));
     await reconfigureServer();
   });

--- a/integration/test/helper.js
+++ b/integration/test/helper.js
@@ -121,7 +121,7 @@ const reconfigureServer = async (changedConfiguration = {}) => {
   parseServer = await ParseServer.startApp(newConfiguration);
   if (parseServer.config.state === 'initialized') {
     console.error('Failed to initialize Parse Server');
-    await reconfigureServer(newConfiguration);
+    return reconfigureServer(newConfiguration);
   }
   const app = parseServer.expressApp;
   for (const fileName of ['parse.js', 'parse.min.js']) {


### PR DESCRIPTION
## Pull Request

- Report security issues [confidentially](https://github.com/parse-community/Parse-SDK-JS/security/policy).
- Any contribution is under this [license](https://github.com/parse-community/Parse-SDK-JS/blob/alpha/LICENSE).
- Link this pull request to an [issue](https://github.com/parse-community/Parse-SDK-JS/issues?q=is%3Aissue).

## Issue
<!-- Add the link to the issue that this PR closes. -->
Attempt to fix flaky tests when the server isn't properly initialized. I believe this is caused by tests that shuts down the server to reproduce a disconnection and restarts. I am unable to reproduce this issue local so the CI should be ran a few times to ensure it works.

Closes: https://github.com/parse-community/parse-server/issues/9149

## Approach
<!-- Describe the changes in this PR. -->
* Properly handle server shutdown
* Refactor `helper.js`
* Add retry strategy if server isn't properly initialized
