### PR TITLE
fix: `LiveQueryClient.resubscribe` with Parse Server 7 causes many open connections

### DIFF
--- a/integration/test/ParseLiveQueryTest.js
+++ b/integration/test/ParseLiveQueryTest.js
@@ -100,7 +100,6 @@ describe('Parse LiveQuery', () => {
     });
     client.open();
     const resubscribeSpy = spyOn(client, 'resubscribe').and.callThrough();
-    const consoleSpy = spyOn(console, 'error').and.callFake(() => {});
     const subscribeRequest = {
       op: 'subscribe',
       requestId: 1,
@@ -117,12 +116,6 @@ describe('Parse LiveQuery', () => {
     client.socket.send(JSON.stringify(subscribeRequest));
     await sleep(1000);
     expect(resubscribeSpy).toHaveBeenCalled();
-    expect(consoleSpy).toHaveBeenCalledWith(
-      'LiveQuery reconnecting with error:',
-      'Additional properties not allowed',
-      'code:',
-      1
-    );
     await client.close();
   });
 

--- a/integration/test/helper.js
+++ b/integration/test/helper.js
@@ -5,7 +5,6 @@ jasmine.getEnv().addReporter(new SpecReporter());
 
 const ParseServer = require('parse-server').default;
 const CustomAuth = require('./CustomAuth');
-const sleep = require('./sleep');
 const { TestUtils } = require('parse-server');
 const Parse = require('../../node');
 const fs = require('fs');

--- a/src/LiveQueryClient.ts
+++ b/src/LiveQueryClient.ts
@@ -413,7 +413,6 @@ class LiveQueryClient {
         this.additionalProperties = false;
       }
       if (data.reconnect) {
-        console.error('LiveQuery reconnecting with error:', data.error, 'code:', data.code);
         this._handleReconnect();
       }
       break;

--- a/src/__tests__/LiveQueryClient-test.js
+++ b/src/__tests__/LiveQueryClient-test.js
@@ -748,6 +748,7 @@ describe('LiveQueryClient', () => {
       expect(error).toEqual(data.error);
     });
     const spy = jest.spyOn(liveQueryClient, '_handleReconnect');
+    jest.spyOn(console, 'error').mockImplementationOnce(() => {});
     try {
       liveQueryClient._handleWebSocketMessage(event);
       await liveQueryClient.connectPromise;
@@ -944,6 +945,8 @@ describe('LiveQueryClient', () => {
     };
     const query = new ParseQuery('Test');
     query.equalTo('key', 'value');
+    query.select(['key']);
+    query.watch(['key']);
     liveQueryClient.subscribe(query);
     liveQueryClient.connectPromise.resolve();
 
@@ -961,6 +964,8 @@ describe('LiveQueryClient', () => {
         where: {
           key: 'value',
         },
+        keys: ['key'],
+        watch: ['key'],
       },
     });
   });
@@ -978,6 +983,8 @@ describe('LiveQueryClient', () => {
     };
     const query = new ParseQuery('Test');
     query.equalTo('key', 'value');
+    query.select(['key']);
+    query.watch(['key']);
     liveQueryClient.subscribe(query, 'mySessionToken');
     liveQueryClient.connectPromise.resolve();
 
@@ -996,6 +1003,8 @@ describe('LiveQueryClient', () => {
         where: {
           key: 'value',
         },
+        keys: ['key'],
+        watch: ['key'],
       },
     });
   });

--- a/src/__tests__/LiveQueryClient-test.js
+++ b/src/__tests__/LiveQueryClient-test.js
@@ -748,7 +748,6 @@ describe('LiveQueryClient', () => {
       expect(error).toEqual(data.error);
     });
     const spy = jest.spyOn(liveQueryClient, '_handleReconnect');
-    jest.spyOn(console, 'error').mockImplementationOnce(() => {});
     try {
       liveQueryClient._handleWebSocketMessage(event);
       await liveQueryClient.connectPromise;


### PR DESCRIPTION
## Pull Request

- Report security issues [confidentially](https://github.com/parse-community/Parse-SDK-JS/security/policy).
- Any contribution is under this [license](https://github.com/parse-community/Parse-SDK-JS/blob/alpha/LICENSE).
- Link this pull request to an [issue](https://github.com/parse-community/Parse-SDK-JS/issues?q=is%3Aissue).

## Issue
<!-- Add the link to the issue that this PR closes. -->
The `fields` attribute was changed to `keys` in Parse Server 7, `watch` was added in version 6. Resubscribing doesn't subscribe to the same query as the initial subscription. It was discovered that resubscribing with `fields` on version 7 will caused resubscribing every second which lead to many connections to the server ultimately resulting in a crash.

Closes: https://github.com/parse-community/Parse-SDK-JS/issues/2180

## Approach
<!-- Describe the changes in this PR. -->
* Add keys and watch to resubscribe
* Fix the delay interval between resubscriptions

## Tasks
<!-- Delete tasks that don't apply. -->

- [x] Add tests
- [x] Add changes to documentation (guides, repository pages, code comments)
