### PR TITLE
fix: Dot notation on JSON arrays doesn't work on `PushStatus` offset fields

### DIFF
--- a/src/ObjectStateMutations.ts
+++ b/src/ObjectStateMutations.ts
@@ -186,7 +186,6 @@ export function commitServerChanges(
   for (const attr in changes) {
     let val = changes[attr];
     // Check for JSON array { '0': { something }, '1': { something } }
-    // TODO: Improve JSON array check with a more robust method (consecutive indexes)
     if (
       val &&
       typeof val === 'object' &&

--- a/src/ObjectStateMutations.ts
+++ b/src/ObjectStateMutations.ts
@@ -186,12 +186,14 @@ export function commitServerChanges(
   for (const attr in changes) {
     let val = changes[attr];
     // Check for JSON array { '0': { something }, '1': { something } }
+    // TODO: Improve JSON array check with a more robust method (consecutive indexes)
     if (
       val &&
       typeof val === 'object' &&
       !Array.isArray(val) &&
       Object.keys(val).length > 0 &&
-      Object.keys(val).some(k => !isNaN(parseInt(k)))
+      Object.keys(val).some(k => !isNaN(parseInt(k))) &&
+      !['sentPerUTCOffset', 'failedPerUTCOffset'].includes(attr)
     ) {
       val = Object.values(val);
     }

--- a/src/__tests__/ObjectStateMutations-test.js
+++ b/src/__tests__/ObjectStateMutations-test.js
@@ -323,6 +323,17 @@ describe('ObjectStateMutations', () => {
     expect(objectCache).toEqual({ items: '[{"count":20},{"count":5}]' });
   });
 
+  it('can commit json array with missing indexes', () => {
+    const serverData = {};
+    const objectCache = {};
+    ObjectStateMutations.commitServerChanges(serverData, objectCache, {
+      sentPerUTCOffset: { '1': { count: 20 } },
+    });
+    // Should not transform to an array
+    expect(serverData).toEqual({ sentPerUTCOffset: { '1': { count: 20 } } });
+    expect(objectCache).toEqual({ sentPerUTCOffset: '{"1":{"count":20}}' });
+  });
+
   it('can generate a default state for implementations', () => {
     expect(ObjectStateMutations.defaultState()).toEqual({
       serverData: {},

--- a/src/__tests__/ObjectStateMutations-test.js
+++ b/src/__tests__/ObjectStateMutations-test.js
@@ -323,15 +323,22 @@ describe('ObjectStateMutations', () => {
     expect(objectCache).toEqual({ items: '[{"count":20},{"count":5}]' });
   });
 
-  it('can commit json array with missing indexes', () => {
+  it('can commit json array with PushStatus offset fields', () => {
     const serverData = {};
     const objectCache = {};
     ObjectStateMutations.commitServerChanges(serverData, objectCache, {
       sentPerUTCOffset: { '1': { count: 20 } },
+      failedPerUTCOffset: { '5': { count: 25 } },
     });
     // Should not transform to an array
-    expect(serverData).toEqual({ sentPerUTCOffset: { '1': { count: 20 } } });
-    expect(objectCache).toEqual({ sentPerUTCOffset: '{"1":{"count":20}}' });
+    expect(serverData).toEqual({
+      sentPerUTCOffset: { '1': { count: 20 } },
+      failedPerUTCOffset: { '5': { count: 25 } },
+    });
+    expect(objectCache).toEqual({
+      sentPerUTCOffset: '{"1":{"count":20}}',
+      failedPerUTCOffset: '{"5":{"count":25}}',
+    });
   });
 
   it('can generate a default state for implementations', () => {


### PR DESCRIPTION
…fset fields

## Pull Request

- Report security issues [confidentially](https://github.com/parse-community/Parse-SDK-JS/security/policy).
- Any contribution is under this [license](https://github.com/parse-community/Parse-SDK-JS/blob/alpha/LICENSE).
- Link this pull request to an [issue](https://github.com/parse-community/Parse-SDK-JS/issues?q=is%3Aissue).

## Issue
<!-- Add the link to the issue that this PR closes. -->
With the introduction of dot notation on array fields. https://github.com/parse-community/Parse-SDK-JS/pull/2120 doesn't include a check for `PushStatus.sentPerUTCOffset` and `PushStatus.failedPerUTCOffset`.  These fields are a weird mix of dot notation, JSON arrays with numeric offset and dynamic indexes (not a zero indexed json array like the check). 

<img width="502" alt="Screenshot 2024-06-27 at 8 43 53 PM" src="https://github.com/parse-community/Parse-SDK-JS/assets/9830365/f8325e39-00cd-4879-8acc-b8a830d111f2">


This should allow merging the JS SDK to the server, https://github.com/parse-community/parse-server/pull/9128

<img width="407" alt="Screenshot 2024-06-27 at 2 02 28 PM" src="https://github.com/parse-community/Parse-SDK-JS/assets/9830365/f7c53ccf-fe22-464f-81a8-91bd8d9ec975">


## Approach
<!-- Describe the changes in this PR. -->
Check for PushStatus dot notation fields

## Tasks
<!-- Delete tasks that don't apply. -->

- [x] Add tests
- [x] Add changes to documentation (guides, repository pages, code comments)
