### PR TITLE
fix: Internal server error on `set` followed by `unset`

### DIFF
--- a/integration/test/cloud/main.js
+++ b/integration/test/cloud/main.js
@@ -13,16 +13,16 @@ Parse.Cloud.define('TestFetchFromLocalDatastore', function (request) {
   return object.save();
 });
 
-Parse.Cloud.define('UpdateUser', function (request) {
+Parse.Cloud.define('UpdateUser', async function (request) {
   const user = new Parse.User();
   user.id = request.params.id;
   user.set('foo', 'changed');
-  return user.save(null, { useMasterKey: true });
+  return await user.save(null, { useMasterKey: true });
 });
 
-Parse.Cloud.define('CloudFunctionIdempotency', function () {
+Parse.Cloud.define('CloudFunctionIdempotency', async function () {
   const object = new Parse.Object('IdempotencyItem');
-  return object.save(null, { useMasterKey: true });
+  return await object.save(null, { useMasterKey: true });
 });
 
 Parse.Cloud.define('CloudFunctionUndefined', function () {


### PR DESCRIPTION
## Pull Request

- Report security issues [confidentially](https://github.com/parse-community/Parse-SDK-JS/security/policy).
- Any contribution is under this [license](https://github.com/parse-community/Parse-SDK-JS/blob/alpha/LICENSE).
- Link this pull request to an [issue](https://github.com/parse-community/Parse-SDK-JS/issues?q=is%3Aissue).

## Issue
Closes: #1798

## Approach
In main.js I found 2 mistake 

![before](https://github.com/user-attachments/assets/802ec659-a8d2-4486-b449-8baa4ab1ac68)

Now: 

![after](https://github.com/user-attachments/assets/32bfeba0-225d-4f18-815a-f91cacd05ddc)

Because it returns promise and this is best practice to use async await  to handle promise o/w use .then and catch.

## Tasks
Handle internal server error.


