### PR TITLE
fix: Cannot pass `useMasterKey: false` to `Parse.Cloud.run`

### DIFF
--- a/src/Cloud.ts
+++ b/src/Cloud.ts
@@ -37,8 +37,8 @@ export function run(name: string, data: any, options: RequestOptions): Promise<a
   }
 
   const requestOptions: RequestOptions = {};
-  if (options.useMasterKey) {
-    requestOptions.useMasterKey = options.useMasterKey;
+  if (options.hasOwnProperty('useMasterKey')) {
+    requestOptions.useMasterKey = !!options.useMasterKey;
   }
   if (options.sessionToken) {
     requestOptions.sessionToken = options.sessionToken;

--- a/src/__tests__/Cloud-test.js
+++ b/src/__tests__/Cloud-test.js
@@ -55,7 +55,11 @@ describe('Cloud', () => {
   it('run passes options', () => {
     Cloud.run('myfunction', {}, { useMasterKey: false });
 
-    expect(CoreManager.getCloudController().run.mock.calls[0]).toEqual(['myfunction', {}, {}]);
+    expect(CoreManager.getCloudController().run.mock.calls[0]).toEqual([
+      'myfunction',
+      {},
+      { useMasterKey: false },
+    ]);
 
     Cloud.run('myfunction', {}, { useMasterKey: true });
 


### PR DESCRIPTION
## Pull Request

- Report security issues [confidentially](https://github.com/parse-community/Parse-SDK-JS/security/policy).
- Any contribution is under this [license](https://github.com/parse-community/Parse-SDK-JS/blob/alpha/LICENSE).
- Link this pull request to an [issue](https://github.com/parse-community/Parse-SDK-JS/issues?q=is%3Aissue).

## Issue
<!-- Add the link to the issue that this PR closes. -->
useMasterKey false is omitted meaning using`Parse.cloud.run` in a node or cloud environment will always results in useMasterKey true to be passed.

```
// RESTController.ts
let useMasterKey = options.useMasterKey;
if (typeof useMasterKey === 'undefined') {
  useMasterKey = CoreManager.get('USE_MASTER_KEY');
}
```

## Approach
<!-- Describe the changes in this PR. -->
Properly handle useMasterKey check

## Tasks
<!-- Delete tasks that don't apply. -->

- [x] Add tests
- [x] Add changes to documentation (guides, repository pages, code comments)
