### PR TITLE
fix: `Parse.Hooks` requests have double forward slash in URL

### DIFF
--- a/src/ParseHooks.ts
+++ b/src/ParseHooks.ts
@@ -61,7 +61,7 @@ export function remove(hook: HookDeleteArg) {
 
 const DefaultController = {
   get(type: string, functionName?: string, triggerName?: string) {
-    let url = '/hooks/' + type;
+    let url = 'hooks/' + type;
     if (functionName) {
       url += '/' + functionName;
       if (triggerName) {
@@ -74,9 +74,9 @@ const DefaultController = {
   create(hook) {
     let url;
     if (hook.functionName && hook.url) {
-      url = '/hooks/functions';
+      url = 'hooks/functions';
     } else if (hook.className && hook.triggerName && hook.url) {
-      url = '/hooks/triggers';
+      url = 'hooks/triggers';
     } else {
       return Promise.reject({ error: 'invalid hook declaration', code: 143 });
     }
@@ -86,10 +86,10 @@ const DefaultController = {
   remove(hook) {
     let url;
     if (hook.functionName) {
-      url = '/hooks/functions/' + hook.functionName;
+      url = 'hooks/functions/' + hook.functionName;
       delete hook.functionName;
     } else if (hook.className && hook.triggerName) {
-      url = '/hooks/triggers/' + hook.className + '/' + hook.triggerName;
+      url = 'hooks/triggers/' + hook.className + '/' + hook.triggerName;
       delete hook.className;
       delete hook.triggerName;
     } else {
@@ -101,10 +101,10 @@ const DefaultController = {
   update(hook) {
     let url;
     if (hook.functionName && hook.url) {
-      url = '/hooks/functions/' + hook.functionName;
+      url = 'hooks/functions/' + hook.functionName;
       delete hook.functionName;
     } else if (hook.className && hook.triggerName && hook.url) {
-      url = '/hooks/triggers/' + hook.className + '/' + hook.triggerName;
+      url = 'hooks/triggers/' + hook.className + '/' + hook.triggerName;
       delete hook.className;
       delete hook.triggerName;
     } else {

--- a/src/__tests__/Hooks-test.js
+++ b/src/__tests__/Hooks-test.js
@@ -98,23 +98,23 @@ describe('Hooks', () => {
   });
 
   it('should properly build POST function', async () => {
-    Hooks.createFunction('myFunction', 'https://dummy.com');
+    Hooks.createFunction('myFunction', 'https://example.com');
 
     expect(CoreManager.getHooksController().sendRequest.mock.calls[0]).toEqual([
       'POST',
       'hooks/functions',
       {
         functionName: 'myFunction',
-        url: 'https://dummy.com',
+        url: 'https://example.com',
       },
     ]);
     defaultController.sendRequest = sendRequest;
-    await Hooks.createFunction('myFunction', 'https://dummy.com');
+    await Hooks.createFunction('myFunction', 'https://example.com');
     expect(RESTController.ajax.mock.calls[0][1]).toBe('https://api.parse.com/1/hooks/functions');
   });
 
   it('should properly build POST trigger', async () => {
-    Hooks.createTrigger('MyClass', 'beforeSave', 'https://dummy.com');
+    Hooks.createTrigger('MyClass', 'beforeSave', 'https://example.com');
 
     expect(CoreManager.getHooksController().sendRequest.mock.calls[0]).toEqual([
       'POST',
@@ -122,43 +122,43 @@ describe('Hooks', () => {
       {
         className: 'MyClass',
         triggerName: 'beforeSave',
-        url: 'https://dummy.com',
+        url: 'https://example.com',
       },
     ]);
     defaultController.sendRequest = sendRequest;
-    await Hooks.createTrigger('MyClass', 'beforeSave', 'https://dummy.com');
+    await Hooks.createTrigger('MyClass', 'beforeSave', 'https://example.com');
     expect(RESTController.ajax.mock.calls[0][1]).toBe('https://api.parse.com/1/hooks/triggers');
   });
 
   it('should properly build PUT function', async () => {
-    Hooks.updateFunction('myFunction', 'https://dummy.com');
+    Hooks.updateFunction('myFunction', 'https://example.com');
 
     expect(CoreManager.getHooksController().sendRequest.mock.calls[0]).toEqual([
       'PUT',
       'hooks/functions/myFunction',
       {
-        url: 'https://dummy.com',
+        url: 'https://example.com',
       },
     ]);
     defaultController.sendRequest = sendRequest;
-    await Hooks.updateFunction('myFunction', 'https://dummy.com');
+    await Hooks.updateFunction('myFunction', 'https://example.com');
     expect(RESTController.ajax.mock.calls[0][1]).toBe(
       'https://api.parse.com/1/hooks/functions/myFunction'
     );
   });
 
   it('should properly build PUT trigger', async () => {
-    Hooks.updateTrigger('MyClass', 'beforeSave', 'https://dummy.com');
+    Hooks.updateTrigger('MyClass', 'beforeSave', 'https://example.com');
 
     expect(CoreManager.getHooksController().sendRequest.mock.calls[0]).toEqual([
       'PUT',
       'hooks/triggers/MyClass/beforeSave',
       {
-        url: 'https://dummy.com',
+        url: 'https://example.com',
       },
     ]);
     defaultController.sendRequest = sendRequest;
-    await Hooks.updateTrigger('MyClass', 'beforeSave', 'https://dummy.com');
+    await Hooks.updateTrigger('MyClass', 'beforeSave', 'https://example.com');
     expect(RESTController.ajax.mock.calls[0][1]).toBe(
       'https://api.parse.com/1/hooks/triggers/MyClass/beforeSave'
     );
@@ -202,7 +202,7 @@ describe('Hooks', () => {
       expect(err.error).toBe('invalid hook declaration');
     });
 
-    const p2 = Hooks.create({ url: 'http://dummy.com' }).catch(err => {
+    const p2 = Hooks.create({ url: 'http://example.com' }).catch(err => {
       expect(err.code).toBe(143);
       expect(err.error).toBe('invalid hook declaration');
     });
@@ -212,7 +212,7 @@ describe('Hooks', () => {
       expect(err.error).toBe('invalid hook declaration');
     });
 
-    const p4 = Hooks.create({ className: 'MyClass', url: 'http://dummy.com' }).catch(err => {
+    const p4 = Hooks.create({ className: 'MyClass', url: 'http://example.com' }).catch(err => {
       expect(err.code).toBe(143);
       expect(err.error).toBe('invalid hook declaration');
     });
@@ -237,7 +237,7 @@ describe('Hooks', () => {
       expect(err.error).toBe('invalid hook declaration');
     });
 
-    const p3 = Hooks.update({ className: 'MyClass', url: 'http://dummy.com' }).catch(err => {
+    const p3 = Hooks.update({ className: 'MyClass', url: 'http://example.com' }).catch(err => {
       expect(err.code).toBe(143);
       expect(err.error).toBe('invalid hook declaration');
     });
@@ -256,7 +256,7 @@ describe('Hooks', () => {
       expect(err.error).toBe('invalid hook declaration');
     });
 
-    const p3 = Hooks.remove({ className: 'MyClass', url: 'http://dummy.com' }).catch(err => {
+    const p3 = Hooks.remove({ className: 'MyClass', url: 'http://example.com' }).catch(err => {
       expect(err.code).toBe(143);
       expect(err.error).toBe('invalid hook declaration');
     });


### PR DESCRIPTION
## Pull Request

- Report security issues [confidentially](https://github.com/parse-community/Parse-SDK-JS/security/policy).
- Any contribution is under this [license](https://github.com/parse-community/Parse-SDK-JS/blob/alpha/LICENSE).
- Link this pull request to an [issue](https://github.com/parse-community/Parse-SDK-JS/issues?q=is%3Aissue).

## Issue
<!-- Add the link to the issue that this PR closes. -->

Closes: https://github.com/parse-community/Parse-SDK-JS/issues/2406

## Approach
<!-- Describe the changes in this PR. -->
Remove extra slash

## Tasks
<!-- Delete tasks that don't apply. -->

- [x] Add tests
- [x] Add changes to documentation (guides, repository pages, code comments)
