### PR TITLE
fix: `Parse.Query.findAll` not returning all objects with option `json: true`

### DIFF
--- a/integration/test/ParseQueryTest.js
+++ b/integration/test/ParseQueryTest.js
@@ -1493,13 +1493,17 @@ describe('Parse Query', () => {
 
   it('can return all objects with findAll', async () => {
     const objs = [...Array(101)].map(() => new Parse.Object('Container'));
-
     await Parse.Object.saveAll(objs);
-
     const query = new Parse.Query('Container');
-
     const result = await query.findAll();
+    assert.equal(result.length, 101);
+  });
 
+  it('can return all objects with findAll json option', async () => {
+    const objs = [...Array(101)].map(() => new Parse.Object('Container'));
+    await Parse.Object.saveAll(objs);
+    const query = new Parse.Query('Container');
+    const result = await query.findAll({ json: true, batchSize: 100 });
     assert.equal(result.length, 101);
   });
 

--- a/src/ParseQuery.ts
+++ b/src/ParseQuery.ts
@@ -721,6 +721,7 @@ class ParseQuery {
    *     be used for this request.
    *   <li>sessionToken: A valid session token, used for making a request on
    *       behalf of a specific user.
+   *   <li>json: Return raw json without converting to Parse.Object
    * </ul>
    * @returns {Promise} A promise that is resolved with the results when
    * the query completes.
@@ -924,33 +925,9 @@ class ParseQuery {
       return Promise.reject(error);
     }
 
-    const query = new ParseQuery(this.className);
-    query._limit = options.batchSize || 100;
-    query._include = [...this._include];
-    query._exclude = [...this._exclude];
-    if (this._select) {
-      query._select = [...this._select];
-    }
-    query._hint = this._hint;
-    query._where = {};
-    for (const attr in this._where) {
-      const val = this._where[attr];
-      if (Array.isArray(val)) {
-        query._where[attr] = val.map(v => {
-          return v;
-        });
-      } else if (val && typeof val === 'object') {
-        const conditionMap = {};
-        query._where[attr] = conditionMap;
-        for (const cond in val) {
-          conditionMap[cond] = val[cond];
-        }
-      } else {
-        query._where[attr] = val;
-      }
-    }
-
+    const query = ParseQuery.fromJSON(this.className, this.toJSON());
     query.ascending('objectId');
+    query._limit = options.batchSize || 100;
 
     const findOptions = ParseObject._getRequestOptions(options);
     let finished = false;
@@ -965,7 +942,11 @@ class ParseQuery {
           Promise.resolve(previousResults.length > 0 && callback(previousResults)),
         ]);
         if (results.length >= query._limit) {
-          query.greaterThan('objectId', results[results.length - 1].id);
+          if (findOptions.json) {
+            query.greaterThan('objectId', (results[results.length - 1] as any).objectId);
+          } else {
+            query.greaterThan('objectId', results[results.length - 1].id);
+          }
           previousResults = results;
         } else if (results.length > 0) {
           await Promise.resolve(callback(results));

--- a/src/ParseQuery.ts
+++ b/src/ParseQuery.ts
@@ -721,7 +721,7 @@ class ParseQuery {
    *     be used for this request.
    *   <li>sessionToken: A valid session token, used for making a request on
    *       behalf of a specific user.
-   *   <li>json: Return raw json without converting to Parse.Object
+   *   <li>json: Return raw JSON without converting to Parse.Object.
    * </ul>
    * @returns {Promise} A promise that is resolved with the results when
    * the query completes.

--- a/src/__tests__/ParseQuery-test.js
+++ b/src/__tests__/ParseQuery-test.js
@@ -1805,7 +1805,11 @@ describe('ParseQuery', () => {
       q.hint('_id_');
       q.exclude('foo');
 
-      await q.findAll();
+      const [result1, result2] = await q.findAll();
+      expect(result1.id).toBeDefined();
+      expect(result2.id).toBeDefined();
+      expect(result1.objectId).toBeUndefined();
+      expect(result2.objectId).toBeUndefined();
       expect(findMock).toHaveBeenCalledTimes(1);
       const [className, params, options] = findMock.mock.calls[0];
       expect(className).toBe('Item');
@@ -1835,6 +1839,9 @@ describe('ParseQuery', () => {
         },
       });
       expect(options.requestTask).toBeDefined();
+      const [json] = await q.findAll({ json: true });
+      expect(json.objectId).toBeDefined();
+      expect(json.id).toBeUndefined();
     });
 
     it('passes options through to the REST API', async () => {
@@ -1842,6 +1849,7 @@ describe('ParseQuery', () => {
         useMasterKey: true,
         sessionToken: '1234',
         batchSize: 50,
+        json: true,
       };
       const q = new ParseQuery('Item');
       await q.findAll(batchOptions);
@@ -1855,6 +1863,7 @@ describe('ParseQuery', () => {
       });
       expect(options.useMasterKey).toBe(true);
       expect(options.sessionToken).toEqual('1234');
+      expect(options.json).toEqual(true);
     });
 
     it('only makes one request when the results fit in one page', async () => {

--- a/src/__tests__/ParseQuery-test.js
+++ b/src/__tests__/ParseQuery-test.js
@@ -1805,11 +1805,7 @@ describe('ParseQuery', () => {
       q.hint('_id_');
       q.exclude('foo');
 
-      const [result1, result2] = await q.findAll();
-      expect(result1.id).toBeDefined();
-      expect(result2.id).toBeDefined();
-      expect(result1.objectId).toBeUndefined();
-      expect(result2.objectId).toBeUndefined();
+      await q.findAll();
       expect(findMock).toHaveBeenCalledTimes(1);
       const [className, params, options] = findMock.mock.calls[0];
       expect(className).toBe('Item');
@@ -1839,9 +1835,6 @@ describe('ParseQuery', () => {
         },
       });
       expect(options.requestTask).toBeDefined();
-      const [json] = await q.findAll({ json: true });
-      expect(json.objectId).toBeDefined();
-      expect(json.id).toBeUndefined();
     });
 
     it('passes options through to the REST API', async () => {
@@ -1882,6 +1875,17 @@ describe('ParseQuery', () => {
       const q = new ParseQuery('Item');
       const results = await q.findAll();
       expect(results.map(obj => obj.attributes.size)).toEqual(['medium', 'small']);
+    });
+
+    it('Returns all objects with json', async () => {
+      const q = new ParseQuery('Item');
+      const results = await q.findAll({ json: true, batchSize: 2 });
+      expect(results.length).toEqual(3);
+      expect(findMock).toHaveBeenCalledTimes(2);
+      results.map(result => {
+        expect(result.id).toBeUndefined();
+        expect(result.objectId).toBeDefined();
+      });
     });
   });
 


### PR DESCRIPTION
## Pull Request

- Report security issues [confidentially](https://github.com/parse-community/Parse-SDK-JS/security/policy).
- Any contribution is under this [license](https://github.com/parse-community/Parse-SDK-JS/blob/alpha/LICENSE).
- Link this pull request to an [issue](https://github.com/parse-community/Parse-SDK-JS/issues?q=is%3Aissue).

## Issue
<!-- Add the link to the issue that this PR closes. -->
Using json true option on findAll caps the results at the limit or batchSize option.
This is because `results[results.length - 1].id` the returned objects don't have `id` causing the loop to break.

## Approach
<!-- Describe the changes in this PR. -->
* Refactor query creation for future query operations
* Handle query for `json: true`
* Improve tests

## Tasks
<!-- Delete tasks that don't apply. -->

- [x] Add tests
- [x] Add changes to documentation (guides, repository pages, code comments)
