### PR TITLE
feat: Allow `Parse.Object` field names to begin with underscore `_` to access internal fields of Parse Server

### DIFF
--- a/integration/test/ParseObjectTest.js
+++ b/integration/test/ParseObjectTest.js
@@ -547,7 +547,7 @@ describe('Parse Object', () => {
   });
 
   it('cannot create invalid key names', async () => {
-    const error = new Parse.Error(Parse.Error.INVALID_KEY_NAME, `Invalid key name: "foo^bar"`);
+    const error = new Parse.Error(Parse.Error.INVALID_KEY_NAME, 'Invalid field name: foo^bar');
     const item = new Parse.Object('Item');
     expect(() => {
       item.set({ 'foo^bar': 'baz' });
@@ -559,7 +559,7 @@ describe('Parse Object', () => {
     const item = new Parse.Object('Item');
     expect(() => {
       item.set({ foobar: 'baz', 'foo^bar': 'baz' });
-    }).toThrow(new Parse.Error(Parse.Error.INVALID_KEY_NAME, `Invalid key name: "foo^bar"`));
+    }).toThrow(new Parse.Error(Parse.Error.INVALID_KEY_NAME, 'Invalid field name: foo^bar'));
   });
 
   it('can unset fields', done => {

--- a/integration/test/ParseObjectTest.js
+++ b/integration/test/ParseObjectTest.js
@@ -547,7 +547,7 @@ describe('Parse Object', () => {
   });
 
   it('cannot create invalid key names', async () => {
-    const error = new Parse.Error(Parse.Error.INVALID_KEY_NAME, 'Invalid field name: foo^bar');
+    const error = new Parse.Error(Parse.Error.INVALID_KEY_NAME, 'Invalid key name: foo^bar');
     const item = new Parse.Object('Item');
     expect(() => {
       item.set({ 'foo^bar': 'baz' });
@@ -559,7 +559,7 @@ describe('Parse Object', () => {
     const item = new Parse.Object('Item');
     expect(() => {
       item.set({ foobar: 'baz', 'foo^bar': 'baz' });
-    }).toThrow(new Parse.Error(Parse.Error.INVALID_KEY_NAME, 'Invalid field name: foo^bar'));
+    }).toThrow(new Parse.Error(Parse.Error.INVALID_KEY_NAME, 'Invalid key name: foo^bar'));
   });
 
   it('can unset fields', done => {

--- a/src/ParseObject.ts
+++ b/src/ParseObject.ts
@@ -1099,8 +1099,8 @@ class ParseObject {
       return new ParseError(ParseError.OTHER_CAUSE, 'ACL must be a Parse ACL.');
     }
     for (const key in attrs) {
-      if (!/^[A-Za-z][0-9A-Za-z_.]*$/.test(key)) {
-        return new ParseError(ParseError.INVALID_KEY_NAME, `Invalid key name: "${key}"`);
+      if (!/^[A-Za-z_][0-9A-Za-z_.]*$/.test(key)) {
+        return new ParseError(ParseError.INVALID_KEY_NAME, `Invalid field name: ${key}`);
       }
     }
     return false;

--- a/src/ParseObject.ts
+++ b/src/ParseObject.ts
@@ -1100,7 +1100,7 @@ class ParseObject {
     }
     for (const key in attrs) {
       if (!/^[A-Za-z_][0-9A-Za-z_.]*$/.test(key)) {
-        return new ParseError(ParseError.INVALID_KEY_NAME, `Invalid field name: ${key}`);
+        return new ParseError(ParseError.INVALID_KEY_NAME, `Invalid key name: ${key}`);
       }
     }
     return false;

--- a/src/__tests__/ParseObject-test.js
+++ b/src/__tests__/ParseObject-test.js
@@ -965,7 +965,7 @@ describe('ParseObject', () => {
       o.validate({
         'invalid!key': 12,
       })
-    ).toEqual(new ParseError(ParseError.INVALID_KEY_NAME, `Invalid key name: "invalid!key"`));
+    ).toEqual(new ParseError(ParseError.INVALID_KEY_NAME, 'Invalid field name: invalid!key'));
 
     expect(
       o.validate({
@@ -988,7 +988,7 @@ describe('ParseObject', () => {
     expect(o.set('ACL', { '*': { read: true, write: false } })).toBe(o);
     expect(() => {
       o.set('$$$', 'o_O');
-    }).toThrow(new ParseError(ParseError.INVALID_KEY_NAME, `Invalid key name: "$$$"`));
+    }).toThrow(new ParseError(ParseError.INVALID_KEY_NAME, 'Invalid field name: $$$'));
   });
 
   it('ignores validation if ignoreValidation option is passed to set()', () => {
@@ -1002,6 +1002,8 @@ describe('ParseObject', () => {
     const o = new ParseObject('Item');
     expect(o.isValid()).toBe(true);
     o.set('someKey', 'someValue');
+    expect(o.isValid()).toBe(true);
+    o.set('_internalField', 'allow_underscore');
     expect(o.isValid()).toBe(true);
     o._finishFetch({
       objectId: 'O3',

--- a/src/__tests__/ParseObject-test.js
+++ b/src/__tests__/ParseObject-test.js
@@ -965,7 +965,7 @@ describe('ParseObject', () => {
       o.validate({
         'invalid!key': 12,
       })
-    ).toEqual(new ParseError(ParseError.INVALID_KEY_NAME, 'Invalid field name: invalid!key'));
+    ).toEqual(new ParseError(ParseError.INVALID_KEY_NAME, 'Invalid key name: invalid!key'));
 
     expect(
       o.validate({
@@ -988,7 +988,7 @@ describe('ParseObject', () => {
     expect(o.set('ACL', { '*': { read: true, write: false } })).toBe(o);
     expect(() => {
       o.set('$$$', 'o_O');
-    }).toThrow(new ParseError(ParseError.INVALID_KEY_NAME, 'Invalid field name: $$$'));
+    }).toThrow(new ParseError(ParseError.INVALID_KEY_NAME, 'Invalid key name: $$$'));
   });
 
   it('ignores validation if ignoreValidation option is passed to set()', () => {


### PR DESCRIPTION
## Pull Request

- Report security issues [confidentially](https://github.com/parse-community/Parse-SDK-JS/security/policy).
- Any contribution is under this [license](https://github.com/parse-community/Parse-SDK-JS/blob/alpha/LICENSE).
- Link this pull request to an [issue](https://github.com/parse-community/Parse-SDK-JS/issues?q=is%3Aissue).

## Issue
<!-- Add the link to the issue that this PR closes. -->
With the introduction of [access scopes](https://github.com/parse-community/parse-server?tab=readme-ov-file#access-scopes), internal fields can be read from and written to.

Closes: https://github.com/parse-community/Parse-SDK-JS/issues/2474

## Approach
<!-- Describe the changes in this PR. -->
* Allow fields to start with underscore
* Match invalid key error message to the server

## Tasks
<!-- Delete tasks that don't apply. -->

- [ ] Add tests
- [ ] Add changes to documentation (guides, repository pages, code comments)
