### PR TITLE
test: Fix flaky tests

### DIFF
--- a/integration/test/ParseDistTest.js
+++ b/integration/test/ParseDistTest.js
@@ -32,9 +32,9 @@ for (const fileName of ['parse.js', 'parse.min.js']) {
     });
 
     it('can query an object', async () => {
-      const obj = await new Parse.Object('TestObject').save();
+      const obj = await new Parse.Object('TestObjects').save();
       const response = await page.evaluate(async () => {
-        const object = await new Parse.Query('TestObject').first();
+        const object = await new Parse.Query('TestObjects').first();
         return object.id;
       });
       expect(response).toBeDefined();

--- a/integration/test/ParseLiveQueryTest.js
+++ b/integration/test/ParseLiveQueryTest.js
@@ -112,9 +112,15 @@ describe('Parse LiveQuery', () => {
       },
       sessionToken: undefined,
     };
+    const openPromise = resolvingPromise();
+    client.on('open', () => {
+      if (client.state === 'reconnecting') {
+        openPromise.resolve();
+      }
+    });
     await client.connectPromise;
     client.socket.send(JSON.stringify(subscribeRequest));
-    await sleep(1000);
+    await openPromise;
     expect(resubscribeSpy).toHaveBeenCalled();
     await client.close();
   });


### PR DESCRIPTION
## Pull Request

- Report security issues [confidentially](https://github.com/parse-community/Parse-SDK-JS/security/policy).
- Any contribution is under this [license](https://github.com/parse-community/Parse-SDK-JS/blob/alpha/LICENSE).
- Link this pull request to an [issue](https://github.com/parse-community/Parse-SDK-JS/issues?q=is%3Aissue).

## Issue
<!-- Add the link to the issue that this PR closes. -->

Removed 1 second sleep for reconnecting event
https://github.com/parse-community/Parse-SDK-JS/actions/runs/13862939621/job/38795542303?pr=2499
```
Parse LiveQuery can resubscribe
  - Expected spy resubscribe to have been called.
```

Objects should be destroyed after every test not sure why it's not for this test. I change the query class name to ensure this is the only object.
```
Parse Dist Test parse.js can query an object
  - Expected '4DgFKxysTh' to equal '76ZO8TNp9m'.
```
