### PR TITLE
fix: Missing error message when returning an internal server error

### DIFF
--- a/src/RESTController.ts
+++ b/src/RESTController.ts
@@ -334,7 +334,7 @@ const RESTController = {
     if (response && response.responseText) {
       try {
         const errorJSON = JSON.parse(response.responseText);
-        error = new ParseError(errorJSON.code, errorJSON.error);
+        error = new ParseError(errorJSON.code, errorJSON.error || errorJSON.message);
       } catch (_) {
         // If we fail to parse the error text, that's okay.
         error = new ParseError(

--- a/src/__tests__/RESTController-test.js
+++ b/src/__tests__/RESTController-test.js
@@ -175,6 +175,25 @@ describe('RESTController', () => {
     });
   });
 
+  it('handles request errors with message', done => {
+    RESTController._setXHR(
+      mockXHR([
+        {
+          status: 400,
+          response: {
+            code: 1,
+            message: 'Internal server error.',
+          },
+        },
+      ])
+    );
+    RESTController.request('GET', 'classes/MyObject', {}, {}).then(null, error => {
+      expect(error.code).toBe(1);
+      expect(error.message).toBe('Internal server error.');
+      done();
+    });
+  });
+
   it('handles invalid responses', done => {
     const XHR = function () {};
     XHR.prototype = {


### PR DESCRIPTION
## Pull Request

- Report security issues [confidentially](https://github.com/parse-community/Parse-SDK-JS/security/policy).
- Any contribution is under this [license](https://github.com/parse-community/Parse-SDK-JS/blob/alpha/LICENSE).
- Link this pull request to an [issue](https://github.com/parse-community/Parse-SDK-JS/issues?q=is%3Aissue).

## Issue
<!-- Add the link to the issue that this PR closes. -->
Error message was undefined when server returned a Internal Server Error message.

## Tasks
<!-- Delete tasks that don't apply. -->

- [x] Add tests
- [x] Add changes to documentation (guides, repository pages, code comments)
