### PR TITLE
refactor: Add missing git enforcement of line endings to be Line Feed for TypeScript files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,6 +1,8 @@
 * text=auto eol=lf
 
 *.js text
+*.ts text
+*.mjs text
 *.html text
 *.less text
 *.json text


### PR DESCRIPTION
## Pull Request

- Report security issues [confidentially](https://github.com/parse-community/Parse-SDK-JS/security/policy).
- Any contribution is under this [license](https://github.com/parse-community/Parse-SDK-JS/blob/alpha/LICENSE).
- Link this pull request to an [issue](https://github.com/parse-community/Parse-SDK-JS/issues?q=is%3Aissue).

## Issue
<!-- Add the link to the issue that this PR closes. -->
Default eol for typescript files are missing.
