### PR TITLE
fix: Remove unused option `sessionToken` from `Parse.Query.aggregate`

### DIFF
--- a/src/ParseQuery.ts
+++ b/src/ParseQuery.ts
@@ -780,29 +780,17 @@ class ParseQuery<T extends ParseObject = ParseObject> {
    * Executes a distinct query and returns unique values
    *
    * @param {string} key A field to find distinct values
-   * @param {object} options
-   * @param {string} [options.sessionToken] A valid session token, used for making a request on behalf of a specific user.
    * @returns {Promise} A promise that is resolved with the query completes.
    */
-  distinct<K extends keyof T['attributes'], V = T['attributes'][K]>(
-    key: K,
-    options?: { sessionToken?: string }
-  ): Promise<V[]> {
-    options = options || {};
-    const distinctOptions: { sessionToken?: string; useMasterKey: boolean } = {
-      useMasterKey: true,
-    };
-    if (Object.hasOwn(options, 'sessionToken')) {
-      distinctOptions.sessionToken = options.sessionToken;
-    }
+  distinct<K extends keyof T['attributes'], V = T['attributes'][K]>(key: K): Promise<V[]> {
+    const distinctOptions = { useMasterKey: true };
     this._setRequestTask(distinctOptions);
-
-    const controller = CoreManager.getQueryController();
     const params = {
       distinct: key,
       where: this._where,
       hint: this._hint,
     };
+    const controller = CoreManager.getQueryController();
     return controller.aggregate(this.className, params, distinctOptions).then(results => {
       return results.results!;
     });
@@ -812,39 +800,28 @@ class ParseQuery<T extends ParseObject = ParseObject> {
    * Executes an aggregate query and returns aggregate results
    *
    * @param {(Array|object)} pipeline Array or Object of stages to process query
-   * @param {object} options
-   * @param {string} [options.sessionToken] A valid session token, used for making a request on behalf of a specific user.
    * @returns {Promise} A promise that is resolved with the query completes.
    */
-  aggregate(pipeline: any, options?: { sessionToken?: string }): Promise<any[]> {
-    options = options || {};
-    const aggregateOptions: { sessionToken?: string; useMasterKey: boolean } = {
-      useMasterKey: true,
-    };
-    if (Object.hasOwn(options, 'sessionToken')) {
-      aggregateOptions.sessionToken = options.sessionToken;
-    }
-    this._setRequestTask(aggregateOptions);
-
-    const controller = CoreManager.getQueryController();
-
+  aggregate(pipeline: any): Promise<any[]> {
     if (!Array.isArray(pipeline) && typeof pipeline !== 'object') {
       throw new Error('Invalid pipeline must be Array or Object');
     }
-
     if (Object.keys(this._where || {}).length) {
       if (!Array.isArray(pipeline)) {
         pipeline = [pipeline];
       }
       pipeline.unshift({ $match: this._where });
     }
-
     const params = {
       pipeline,
       hint: this._hint,
       explain: this._explain,
       readPreference: this._readPreference,
     };
+    const aggregateOptions = { useMasterKey: true };
+    this._setRequestTask(aggregateOptions);
+
+    const controller = CoreManager.getQueryController();
     return controller.aggregate(this.className, params, aggregateOptions).then(results => {
       return results.results!;
     });

--- a/src/__tests__/ParseQuery-test.js
+++ b/src/__tests__/ParseQuery-test.js
@@ -2619,7 +2619,6 @@ describe('ParseQuery', () => {
           },
         });
         expect(options.useMasterKey).toEqual(true);
-        expect(options.sessionToken).toEqual('1234');
         expect(options.requestTask).toBeDefined();
         return Promise.resolve({
           results: ['L'],
@@ -2629,9 +2628,7 @@ describe('ParseQuery', () => {
 
     const q = new ParseQuery('Item');
     q.equalTo('size', 'small')
-      .distinct('size', {
-        sessionToken: '1234',
-      })
+      .distinct('size')
       .then(results => {
         expect(results[0]).toBe('L');
         done();
@@ -2651,7 +2648,6 @@ describe('ParseQuery', () => {
           hint: '_id_',
         });
         expect(options.useMasterKey).toEqual(true);
-        expect(options.sessionToken).toEqual('1234');
         expect(options.requestTask).toBeDefined();
         return Promise.resolve({
           results: ['L'],
@@ -2662,9 +2658,7 @@ describe('ParseQuery', () => {
     const q = new ParseQuery('Item');
     q.equalTo('size', 'small')
       .hint('_id_')
-      .distinct('size', {
-        sessionToken: '1234',
-      })
+      .distinct('size')
       .then(results => {
         expect(results[0]).toBe('L');
         done();
@@ -2799,7 +2793,6 @@ describe('ParseQuery', () => {
         expect(className).toBe('Item');
         expect(params.pipeline).toEqual([{ group: { objectId: '$name' } }]);
         expect(options.useMasterKey).toEqual(true);
-        expect(options.sessionToken).toEqual('1234');
         return Promise.resolve({
           results: [],
         });
@@ -2807,9 +2800,7 @@ describe('ParseQuery', () => {
     });
 
     const q = new ParseQuery('Item');
-    q.aggregate(pipeline, {
-      sessionToken: '1234',
-    }).then(results => {
+    q.aggregate(pipeline).then(results => {
       expect(results).toEqual([]);
       done();
     });
@@ -2831,7 +2822,7 @@ describe('ParseQuery', () => {
     // Query
     const q = new ParseQuery('Item');
     q.readPreference('SECONDARY');
-    const results = await q.aggregate([], { sessionToken: '1234' });
+    const results = await q.aggregate([]);
     // Validate
     expect(results).toEqual([]);
   });
@@ -2845,7 +2836,6 @@ describe('ParseQuery', () => {
         expect(params.pipeline).toEqual([{ group: { objectId: '$name' } }]);
         expect(params.hint).toEqual('_id_');
         expect(options.useMasterKey).toEqual(true);
-        expect(options.sessionToken).toEqual('1234');
         return Promise.resolve({
           results: [],
         });
@@ -2854,9 +2844,7 @@ describe('ParseQuery', () => {
 
     const q = new ParseQuery('Item');
     q.hint('_id_')
-      .aggregate(pipeline, {
-        sessionToken: '1234',
-      })
+      .aggregate(pipeline)
       .then(results => {
         expect(results).toEqual([]);
         done();

--- a/types/ParseQuery.d.ts
+++ b/types/ParseQuery.d.ts
@@ -265,24 +265,16 @@ declare class ParseQuery<T extends ParseObject = ParseObject> {
      * Executes a distinct query and returns unique values
      *
      * @param {string} key A field to find distinct values
-     * @param {object} options
-     * @param {string} [options.sessionToken] A valid session token, used for making a request on behalf of a specific user.
      * @returns {Promise} A promise that is resolved with the query completes.
      */
-    distinct<K extends keyof T['attributes'], V = T['attributes'][K]>(key: K, options?: {
-        sessionToken?: string;
-    }): Promise<V[]>;
+    distinct<K extends keyof T['attributes'], V = T['attributes'][K]>(key: K): Promise<V[]>;
     /**
      * Executes an aggregate query and returns aggregate results
      *
      * @param {(Array|object)} pipeline Array or Object of stages to process query
-     * @param {object} options
-     * @param {string} [options.sessionToken] A valid session token, used for making a request on behalf of a specific user.
      * @returns {Promise} A promise that is resolved with the query completes.
      */
-    aggregate(pipeline: any, options?: {
-        sessionToken?: string;
-    }): Promise<any[]>;
+    aggregate(pipeline: any): Promise<any[]>;
     /**
      * Retrieves at most one Parse.Object that satisfies this query.
      *


### PR DESCRIPTION
## Pull Request

- Report security issues [confidentially](https://github.com/parse-community/Parse-SDK-JS/security/policy).
- Any contribution is under this [license](https://github.com/parse-community/Parse-SDK-JS/blob/alpha/LICENSE).
- Link this pull request to an [issue](https://github.com/parse-community/Parse-SDK-JS/issues?q=is%3Aissue).

## Issue
<!-- Add the link to the issue that this PR closes. -->
Aggregate queries don't use sessionTokens and most likely never will.

Closes: https://github.com/parse-community/Parse-SDK-JS/issues/1393

## Approach
<!-- Describe the changes in this PR. -->
Remove options from `distinct` and `aggregate` queries

## Tasks
<!-- Delete tasks that don't apply. -->

- [x] Add tests
- [x] Add changes to documentation (guides, repository pages, code comments)
