### PR TITLE
feat: Add `Uint8Array` support for `Parse.File` data

### DIFF
--- a/integration/test/ParseDistTest.js
+++ b/integration/test/ParseDistTest.js
@@ -8,6 +8,7 @@ for (const fileName of ['parse.js', 'parse.min.js']) {
     beforeEach(async () => {
       browser = await puppeteer.launch({
         args: ['--disable-web-security', '--incognito', '--no-sandbox'],
+        devtools: false,
       });
       const context = await browser.createBrowserContext();
       page = await context.newPage();
@@ -42,7 +43,7 @@ for (const fileName of ['parse.js', 'parse.min.js']) {
       expect(obj.id).toEqual(response);
     });
 
-    it('can cancel save file with uri', async () => {
+    it('can cancel save file', async () => {
       let requestsCount = 0;
       let abortedCount = 0;
       const promise = resolvingPromise();
@@ -63,11 +64,11 @@ for (const fileName of ['parse.js', 'parse.min.js']) {
         }
       });
       await page.evaluate(async () => {
-        const parseLogo =
-          'https://raw.githubusercontent.com/parse-community/parse-server/master/.github/parse-server-logo.png';
-        const file = new Parse.File('parse-server-logo', { uri: parseLogo });
-        file.save().then(() => {});
-
+        const SIZE_10_MB = 10 * 1024 * 1024;
+        const file = new Parse.File('test_file.txt', new Uint8Array(SIZE_10_MB));
+        file.save().then(() => {
+          fail('should not save');
+        });
         return new Promise(resolve => {
           const intervalId = setInterval(() => {
             if (file._requestTask && typeof file._requestTask.abort === 'function') {

--- a/src/ParseFile.ts
+++ b/src/ParseFile.ts
@@ -113,7 +113,7 @@ class ParseFile {
     this._tags = tags || {};
 
     if (data !== undefined) {
-      if (Array.isArray(data)) {
+      if (Array.isArray(data) || data instanceof Uint8Array) {
         this._data = ParseFile.encodeBase64(data);
         this._source = {
           format: 'base64',

--- a/src/ParseFile.ts
+++ b/src/ParseFile.ts
@@ -81,7 +81,7 @@ class ParseFile {
    *     an alphanumeric character, and consist of alphanumeric characters,
    *     periods, spaces, underscores, or dashes.
    * @param data {Array} The data for the file, as either:
-   *     1. an Array of byte value Numbers, or
+   *     1. an Array of byte value Numbers or Uint8Array.
    *     2. an Object like { base64: "..." } with a base64-encoded String.
    *     3. an Object like { uri: "..." } with a uri String.
    *     4. a File object selected with a file upload control. (3) only works

--- a/src/__tests__/ParseFile-test.js
+++ b/src/__tests__/ParseFile-test.js
@@ -156,6 +156,13 @@ describe('ParseFile', () => {
     expect(file._data).toBe('ParseA==');
   });
 
+  it('can create files with  Uint8Arrays', () => {
+    const file = new ParseFile('parse.txt', new Uint8Array([61, 170, 236, 120]));
+    expect(file._source.base64).toBe('ParseA==');
+    expect(file._source.type).toBe('');
+    expect(file._data).toBe('ParseA==');
+  });
+
   it('can create files with all types of characters', () => {
     const file = new ParseFile('parse.txt', [11, 239, 191, 215, 80, 52]);
     expect(file._source.base64).toBe('C++/11A0');

--- a/types/ParseFile.d.ts
+++ b/types/ParseFile.d.ts
@@ -44,7 +44,7 @@ declare class ParseFile {
      *     an alphanumeric character, and consist of alphanumeric characters,
      *     periods, spaces, underscores, or dashes.
      * @param data {Array} The data for the file, as either:
-     *     1. an Array of byte value Numbers, or
+     *     1. an Array of byte value Numbers or Uint8Array.
      *     2. an Object like { base64: "..." } with a base64-encoded String.
      *     3. an Object like { uri: "..." } with a uri String.
      *     4. a File object selected with a file upload control. (3) only works


### PR DESCRIPTION
## Pull Request

- Report security issues [confidentially](https://github.com/parse-community/Parse-SDK-JS/security/policy).
- Any contribution is under this [license](https://github.com/parse-community/Parse-SDK-JS/blob/alpha/LICENSE).
- Link this pull request to an [issue](https://github.com/parse-community/Parse-SDK-JS/issues?q=is%3Aissue).

## Issue
<!-- Add the link to the issue that this PR closes. -->
Parse.File.encodeBase64 accepts both number[] and Uint8Array but there is no way to pass Uint8Array to Parse.File.

There is also a flaky test https://github.com/parse-community/Parse-SDK-JS/issues/2530. I believe it occurs because those files are so small in size they save before you get a chance to cancel which causes the timeout.

Closes: https://github.com/parse-community/Parse-SDK-JS/issues/2530

## Approach
<!-- Describe the changes in this PR. -->
* Add check for Uint8Arrays
* Fix flaky test

## Tasks
<!-- Delete tasks that don't apply. -->

- [x] Add tests
- [x] Add changes to documentation (guides, repository pages, code comments)
