### PR TITLE
docs: Improve Typescript JSDocs support

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -55,6 +55,7 @@ module.exports = tseslint.config({
     "jsdoc/require-param-description": 0,
     "jsdoc/require-property-description": 0,
     "jsdoc/require-param-type": 0,
+    "jsdoc/require-param": 1,
     "jsdoc/tag-lines": 0,
     "jsdoc/check-param-names": [
       "error",
@@ -73,6 +74,15 @@ module.exports = tseslint.config({
         ]
       }
     ]
+  },
+  settings: {
+    jsdoc: {
+      tagNamePreference: {
+        member: false,
+        memberof: false,
+        yield: false,
+      },
+    },
   },
   languageOptions: {
     parser: tseslint.parser,

--- a/src/Parse.ts
+++ b/src/Parse.ts
@@ -77,7 +77,7 @@ const Parse = {
   Parse: undefined,
 
   /**
-   * @member {EventuallyQueue} Parse.EventuallyQueue
+   * @property {EventuallyQueue} Parse.EventuallyQueue
    * @static
    */
   set EventuallyQueue(queue: EventuallyQueue) {
@@ -172,7 +172,7 @@ const Parse = {
   },
 
   /**
-   * @member {string} Parse.applicationId
+   * @property {string} Parse.applicationId
    * @static
    */
   set applicationId(value) {
@@ -183,7 +183,7 @@ const Parse = {
   },
 
   /**
-   * @member {string} Parse.javaScriptKey
+   * @property {string} Parse.javaScriptKey
    * @static
    */
   set javaScriptKey(value) {
@@ -194,7 +194,7 @@ const Parse = {
   },
 
   /**
-   * @member {string} Parse.masterKey
+   * @property {string} Parse.masterKey
    * @static
    */
   set masterKey(value) {
@@ -205,7 +205,7 @@ const Parse = {
   },
 
   /**
-   * @member {string} Parse.maintenanceKey
+   * @property {string} Parse.maintenanceKey
    * @static
    */
   set maintenanceKey(value) {
@@ -216,7 +216,7 @@ const Parse = {
   },
 
   /**
-   * @member {string} Parse.serverURL
+   * @property {string} Parse.serverURL
    * @static
    */
   set serverURL(value) {
@@ -227,7 +227,7 @@ const Parse = {
   },
 
   /**
-   * @member {string} Parse.serverAuthToken
+   * @property {string} Parse.serverAuthToken
    * @static
    */
   set serverAuthToken(value) {
@@ -238,7 +238,7 @@ const Parse = {
   },
 
   /**
-   * @member {string} Parse.serverAuthType
+   * @property {string} Parse.serverAuthType
    * @static
    */
   set serverAuthType(value) {
@@ -249,7 +249,7 @@ const Parse = {
   },
 
   /**
-   * @member {ParseLiveQuery} Parse.LiveQuery
+   * @property {ParseLiveQuery} Parse.LiveQuery
    * @static
    */
   set LiveQuery(liveQuery: ParseLiveQuery) {
@@ -260,7 +260,7 @@ const Parse = {
   },
 
   /**
-   * @member {string} Parse.liveQueryServerURL
+   * @property {string} Parse.liveQueryServerURL
    * @static
    */
   set liveQueryServerURL(value) {
@@ -271,7 +271,7 @@ const Parse = {
   },
 
   /**
-   * @member {boolean} Parse.encryptedUser
+   * @property {boolean} Parse.encryptedUser
    * @static
    */
   set encryptedUser(value: boolean) {
@@ -282,7 +282,7 @@ const Parse = {
   },
 
   /**
-   * @member {string} Parse.secret
+   * @property {string} Parse.secret
    * @static
    */
   set secret(value) {
@@ -293,7 +293,7 @@ const Parse = {
   },
 
   /**
-   * @member {boolean} Parse.idempotency
+   * @property {boolean} Parse.idempotency
    * @static
    */
   set idempotency(value) {
@@ -304,7 +304,7 @@ const Parse = {
   },
 
   /**
-   * @member {boolean} Parse.allowCustomObjectId
+   * @property {boolean} Parse.allowCustomObjectId
    * @static
    */
   set allowCustomObjectId(value) {

--- a/src/__tests__/test_helpers/mockXHR.js
+++ b/src/__tests__/test_helpers/mockXHR.js
@@ -6,6 +6,7 @@
  * where status is a HTTP status number and result is a JSON object to pass
  * alongside it.
  * `upload` can be provided to mock the XMLHttpRequest.upload property.
+ * @ignore
  */
 function mockXHR(results, options = {}) {
   const XHR = function () {};

--- a/types/Parse.d.ts
+++ b/types/Parse.d.ts
@@ -219,7 +219,7 @@ declare const Parse: {
     Hooks: any;
     Parse: any;
     /**
-     * @member {EventuallyQueue} Parse.EventuallyQueue
+     * @property {EventuallyQueue} Parse.EventuallyQueue
      * @static
      */
     EventuallyQueue: EventuallyQueue;
@@ -258,67 +258,67 @@ declare const Parse: {
      */
     getServerHealth(): Promise<any>;
     /**
-     * @member {string} Parse.applicationId
+     * @property {string} Parse.applicationId
      * @static
      */
     applicationId: any;
     /**
-     * @member {string} Parse.javaScriptKey
+     * @property {string} Parse.javaScriptKey
      * @static
      */
     javaScriptKey: any;
     /**
-     * @member {string} Parse.masterKey
+     * @property {string} Parse.masterKey
      * @static
      */
     masterKey: any;
     /**
-     * @member {string} Parse.maintenanceKey
+     * @property {string} Parse.maintenanceKey
      * @static
      */
     maintenanceKey: any;
     /**
-     * @member {string} Parse.serverURL
+     * @property {string} Parse.serverURL
      * @static
      */
     serverURL: any;
     /**
-     * @member {string} Parse.serverAuthToken
+     * @property {string} Parse.serverAuthToken
      * @static
      */
     serverAuthToken: any;
     /**
-     * @member {string} Parse.serverAuthType
+     * @property {string} Parse.serverAuthType
      * @static
      */
     serverAuthType: any;
     /**
-     * @member {ParseLiveQuery} Parse.LiveQuery
+     * @property {ParseLiveQuery} Parse.LiveQuery
      * @static
      */
     LiveQuery: ParseLiveQuery;
     /**
-     * @member {string} Parse.liveQueryServerURL
+     * @property {string} Parse.liveQueryServerURL
      * @static
      */
     liveQueryServerURL: any;
     /**
-     * @member {boolean} Parse.encryptedUser
+     * @property {boolean} Parse.encryptedUser
      * @static
      */
     encryptedUser: boolean;
     /**
-     * @member {string} Parse.secret
+     * @property {string} Parse.secret
      * @static
      */
     secret: any;
     /**
-     * @member {boolean} Parse.idempotency
+     * @property {boolean} Parse.idempotency
      * @static
      */
     idempotency: any;
     /**
-     * @member {boolean} Parse.allowCustomObjectId
+     * @property {boolean} Parse.allowCustomObjectId
      * @static
      */
     allowCustomObjectId: any;


### PR DESCRIPTION
## Pull Request

- Report security issues [confidentially](https://github.com/parse-community/Parse-SDK-JS/security/policy).
- Any contribution is under this [license](https://github.com/parse-community/Parse-SDK-JS/blob/alpha/LICENSE).
- Link this pull request to an [issue](https://github.com/parse-community/Parse-SDK-JS/issues?q=is%3Aissue).

## Issue
<!-- Add the link to the issue that this PR closes. -->
JSDocs `@member` tag is unsupported in typescript.

https://www.typescriptlang.org/docs/handbook/jsdoc-supported-types.html#unsupported-tags

## Approach
<!-- Describe the changes in this PR. -->
* Replace `@member` with `@property`
* Blacklist unsupported tags
