### PR TITLE
ci: Remove `husky` and `prettier` in favor of `eslint`

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,1 +1,0 @@
-npm run pre-commit

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,6 +1,0 @@
-semi: true
-trailingComma: "es5"
-singleQuote: true
-arrowParens: "avoid"
-printWidth: 100
-parser: "typescript"

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -14,7 +14,7 @@ module.exports = tseslint.config({
     jsdoc,
   },
   "rules": {
-    "indent": ["error", 2],
+    "indent": ["error", 2, { "SwitchCase": 1 }],
     "linebreak-style": ["error", "unix"],
     "no-trailing-spaces": 2,
     "eol-last": 2,

--- a/package-lock.json
+++ b/package-lock.json
@@ -52,7 +52,6 @@
         "gulp-rename": "2.0.0",
         "gulp-uglify": "3.0.2",
         "gulp-watch": "5.0.1",
-        "husky": "9.1.7",
         "jasmine": "5.6.0",
         "jasmine-reporters": "2.5.2",
         "jasmine-spec-reporter": "7.0.0",
@@ -65,7 +64,6 @@
         "metro-react-native-babel-preset": "0.77.0",
         "mongodb-runner": "5.8.0",
         "parse-server": "7.3.0",
-        "prettier": "3.5.2",
         "puppeteer": "24.4.0",
         "regenerator-runtime": "0.14.1",
         "semantic-release": "24.2.3",
@@ -16244,21 +16242,6 @@
         "node": ">=10.17.0"
       }
     },
-    "node_modules/husky": {
-      "version": "9.1.7",
-      "resolved": "https://registry.npmjs.org/husky/-/husky-9.1.7.tgz",
-      "integrity": "sha512-5gs5ytaNjBrh5Ow3zrvdUUY+0VxIuWVL4i9irt6friV+BqdCfmV11CQTWMiBYWHbXhco+J1kHfTOUkePhCDvMA==",
-      "dev": true,
-      "bin": {
-        "husky": "bin.js"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/typicode"
-      }
-    },
     "node_modules/iconv-lite": {
       "version": "0.4.24",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
@@ -25981,22 +25964,6 @@
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/prettier": {
-      "version": "3.5.2",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.5.2.tgz",
-      "integrity": "sha512-lc6npv5PH7hVqozBR7lkBNOGXV9vMwROAPlumdBkX0wTbbzPu/U1hk5yL8p2pt4Xoc+2mkT8t/sow2YrV/M5qg==",
-      "dev": true,
-      "license": "MIT",
-      "bin": {
-        "prettier": "bin/prettier.cjs"
-      },
-      "engines": {
-        "node": ">=14"
-      },
-      "funding": {
-        "url": "https://github.com/prettier/prettier?sponsor=1"
       }
     },
     "node_modules/pretty-format": {
@@ -43371,12 +43338,6 @@
       "integrity": "sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==",
       "dev": true
     },
-    "husky": {
-      "version": "9.1.7",
-      "resolved": "https://registry.npmjs.org/husky/-/husky-9.1.7.tgz",
-      "integrity": "sha512-5gs5ytaNjBrh5Ow3zrvdUUY+0VxIuWVL4i9irt6friV+BqdCfmV11CQTWMiBYWHbXhco+J1kHfTOUkePhCDvMA==",
-      "dev": true
-    },
     "iconv-lite": {
       "version": "0.4.24",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
@@ -50412,12 +50373,6 @@
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/preserve/-/preserve-0.2.0.tgz",
       "integrity": "sha1-gV7R9uvGWSb4ZbMQwHE7yzMVzks=",
-      "dev": true
-    },
-    "prettier": {
-      "version": "3.5.2",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.5.2.tgz",
-      "integrity": "sha512-lc6npv5PH7hVqozBR7lkBNOGXV9vMwROAPlumdBkX0wTbbzPu/U1hk5yL8p2pt4Xoc+2mkT8t/sow2YrV/M5qg==",
       "dev": true
     },
     "pretty-format": {

--- a/package.json
+++ b/package.json
@@ -74,7 +74,6 @@
     "gulp-rename": "2.0.0",
     "gulp-uglify": "3.0.2",
     "gulp-watch": "5.0.1",
-    "husky": "9.1.7",
     "jasmine": "5.6.0",
     "jasmine-reporters": "2.5.2",
     "jasmine-spec-reporter": "7.0.0",
@@ -87,7 +86,6 @@
     "metro-react-native-babel-preset": "0.77.0",
     "mongodb-runner": "5.8.0",
     "parse-server": "7.3.0",
-    "prettier": "3.5.2",
     "puppeteer": "24.4.0",
     "regenerator-runtime": "0.14.1",
     "semantic-release": "24.2.3",
@@ -117,19 +115,10 @@
     "integration": "cross-env TESTING=1 jasmine --config=jasmine.json",
     "docs": "jsdoc -c ./jsdoc-conf.json ./src",
     "madge:circular": "madge ./src --extensions js,ts --circular",
-    "prepare": "husky && npm run build",
-    "pre-commit": "lint-staged",
+    "prepare": "npm run build",
     "release_docs": "./release_docs.sh",
     "gulp": "gulp",
-    "prettier": "prettier --write '{src,integration,types}/{**/*,*}.{js,ts}' && npm run lint:fix",
     "cross-env": "cross-env"
-  },
-  "lint-staged": {
-    "{src,integration}/{**/*,*}.{js,ts}": [
-      "prettier --write",
-      "eslint --fix --cache",
-      "git add"
-    ]
   },
   "engines": {
     "node": "18 || 19 || 20 || 22"

--- a/src/EventuallyQueue.ts
+++ b/src/EventuallyQueue.ts
@@ -246,33 +246,33 @@ const EventuallyQueue = {
       return this.remove(queueObject.queueId);
     }
     switch (queueObject.action) {
-    case 'save':
-      // Queued update was overwritten by other request. Do not save
-      if (
-        typeof object.updatedAt !== 'undefined' &&
+      case 'save':
+        // Queued update was overwritten by other request. Do not save
+        if (
+          typeof object.updatedAt !== 'undefined' &&
           object.updatedAt > new Date(queueObject.object.createdAt as Date)
-      ) {
-        return this.remove(queueObject.queueId);
-      }
-      try {
-        await object.save(queueObject.object, queueObject.serverOptions);
-        await this.remove(queueObject.queueId);
-      } catch (e) {
-        if (e.code !== ParseError.CONNECTION_FAILED) {
-          await this.remove(queueObject.queueId);
+        ) {
+          return this.remove(queueObject.queueId);
         }
-      }
-      break;
-    case 'destroy':
-      try {
-        await object.destroy(queueObject.serverOptions);
-        await this.remove(queueObject.queueId);
-      } catch (e) {
-        if (e.code !== ParseError.CONNECTION_FAILED) {
+        try {
+          await object.save(queueObject.object, queueObject.serverOptions);
           await this.remove(queueObject.queueId);
+        } catch (e) {
+          if (e.code !== ParseError.CONNECTION_FAILED) {
+            await this.remove(queueObject.queueId);
+          }
         }
-      }
-      break;
+        break;
+      case 'destroy':
+        try {
+          await object.destroy(queueObject.serverOptions);
+          await this.remove(queueObject.queueId);
+        } catch (e) {
+          if (e.code !== ParseError.CONNECTION_FAILED) {
+            await this.remove(queueObject.queueId);
+          }
+        }
+        break;
     }
   },
 

--- a/src/LiveQueryClient.ts
+++ b/src/LiveQueryClient.ts
@@ -378,87 +378,87 @@ class LiveQueryClient {
       installationId: data.installationId,
     };
     switch (data.op) {
-    case OP_EVENTS.CONNECTED:
-      if (this.state === CLIENT_STATE.RECONNECTING) {
-        this.resubscribe();
-      }
-      this.emit(CLIENT_EMMITER_TYPES.OPEN);
-      this.id = data.clientId;
-      this.connectPromise.resolve();
-      this.state = CLIENT_STATE.CONNECTED;
-      break;
-    case OP_EVENTS.SUBSCRIBED:
-      if (subscription) {
-        this.attempts = 1;
-        subscription.subscribed = true;
-        subscription.subscribePromise.resolve();
-        setTimeout(() => subscription.emit(SUBSCRIPTION_EMMITER_TYPES.OPEN, response), 200);
-      }
-      break;
-    case OP_EVENTS.ERROR: {
-      const parseError = new ParseError(data.code, data.error);
-      if (!this.id) {
-        this.connectPromise.reject(parseError);
-        this.state = CLIENT_STATE.DISCONNECTED;
-      }
-      if (data.requestId) {
-        if (subscription) {
-          subscription.subscribePromise.reject(parseError);
-          setTimeout(() => subscription.emit(SUBSCRIPTION_EMMITER_TYPES.ERROR, data.error), 200);
+      case OP_EVENTS.CONNECTED:
+        if (this.state === CLIENT_STATE.RECONNECTING) {
+          this.resubscribe();
         }
-      } else {
-        this.emit(CLIENT_EMMITER_TYPES.ERROR, data.error);
-      }
-      if (data.error === 'Additional properties not allowed') {
-        this.additionalProperties = false;
-      }
-      if (data.reconnect) {
-        this._handleReconnect();
-      }
-      break;
-    }
-    case OP_EVENTS.UNSUBSCRIBED: {
-      if (subscription) {
-        this.subscriptions.delete(data.requestId);
-        subscription.subscribed = false;
-        subscription.unsubscribePromise.resolve();
-      }
-      break;
-    }
-    default: {
-      // create, update, enter, leave, delete cases
-      if (!subscription) {
+        this.emit(CLIENT_EMMITER_TYPES.OPEN);
+        this.id = data.clientId;
+        this.connectPromise.resolve();
+        this.state = CLIENT_STATE.CONNECTED;
+        break;
+      case OP_EVENTS.SUBSCRIBED:
+        if (subscription) {
+          this.attempts = 1;
+          subscription.subscribed = true;
+          subscription.subscribePromise.resolve();
+          setTimeout(() => subscription.emit(SUBSCRIPTION_EMMITER_TYPES.OPEN, response), 200);
+        }
+        break;
+      case OP_EVENTS.ERROR: {
+        const parseError = new ParseError(data.code, data.error);
+        if (!this.id) {
+          this.connectPromise.reject(parseError);
+          this.state = CLIENT_STATE.DISCONNECTED;
+        }
+        if (data.requestId) {
+          if (subscription) {
+            subscription.subscribePromise.reject(parseError);
+            setTimeout(() => subscription.emit(SUBSCRIPTION_EMMITER_TYPES.ERROR, data.error), 200);
+          }
+        } else {
+          this.emit(CLIENT_EMMITER_TYPES.ERROR, data.error);
+        }
+        if (data.error === 'Additional properties not allowed') {
+          this.additionalProperties = false;
+        }
+        if (data.reconnect) {
+          this._handleReconnect();
+        }
         break;
       }
-      let override = false;
-      if (data.original) {
-        override = true;
-        delete data.original.__type;
-        // Check for removed fields
-        for (const field in data.original) {
-          if (!(field in data.object)) {
-            data.object[field] = undefined;
-          }
+      case OP_EVENTS.UNSUBSCRIBED: {
+        if (subscription) {
+          this.subscriptions.delete(data.requestId);
+          subscription.subscribed = false;
+          subscription.unsubscribePromise.resolve();
         }
-        data.original = ParseObject.fromJSON(data.original, false);
+        break;
       }
-      delete data.object.__type;
-      const parseObject = ParseObject.fromJSON(
-        data.object,
-        !(subscription.query && subscription.query._select) ? override : false
-      );
+      default: {
+        // create, update, enter, leave, delete cases
+        if (!subscription) {
+          break;
+        }
+        let override = false;
+        if (data.original) {
+          override = true;
+          delete data.original.__type;
+          // Check for removed fields
+          for (const field in data.original) {
+            if (!(field in data.object)) {
+              data.object[field] = undefined;
+            }
+          }
+          data.original = ParseObject.fromJSON(data.original, false);
+        }
+        delete data.object.__type;
+        const parseObject = ParseObject.fromJSON(
+          data.object,
+          !(subscription.query && subscription.query._select) ? override : false
+        );
 
-      if (data.original) {
-        subscription.emit(data.op, parseObject, data.original, response);
-      } else {
-        subscription.emit(data.op, parseObject, response);
-      }
+        if (data.original) {
+          subscription.emit(data.op, parseObject, data.original, response);
+        } else {
+          subscription.emit(data.op, parseObject, response);
+        }
 
-      const localDatastore = CoreManager.getLocalDatastore();
-      if (override && localDatastore.isEnabled) {
-        localDatastore._updateObjectIfPinned(parseObject).then(() => {});
+        const localDatastore = CoreManager.getLocalDatastore();
+        if (override && localDatastore.isEnabled) {
+          localDatastore._updateObjectIfPinned(parseObject).then(() => {});
+        }
       }
-    }
     }
   }
 

--- a/src/OfflineQuery.ts
+++ b/src/OfflineQuery.ts
@@ -160,52 +160,52 @@ function relativeTimeToDate(text, now = new Date()) {
     }
 
     switch (interval) {
-    case 'yr':
-    case 'yrs':
-    case 'year':
-    case 'years':
-      seconds += val * 31536000; // 365 * 24 * 60 * 60
-      break;
+      case 'yr':
+      case 'yrs':
+      case 'year':
+      case 'years':
+        seconds += val * 31536000; // 365 * 24 * 60 * 60
+        break;
 
-    case 'wk':
-    case 'wks':
-    case 'week':
-    case 'weeks':
-      seconds += val * 604800; // 7 * 24 * 60 * 60
-      break;
+      case 'wk':
+      case 'wks':
+      case 'week':
+      case 'weeks':
+        seconds += val * 604800; // 7 * 24 * 60 * 60
+        break;
 
-    case 'd':
-    case 'day':
-    case 'days':
-      seconds += val * 86400; // 24 * 60 * 60
-      break;
+      case 'd':
+      case 'day':
+      case 'days':
+        seconds += val * 86400; // 24 * 60 * 60
+        break;
 
-    case 'hr':
-    case 'hrs':
-    case 'hour':
-    case 'hours':
-      seconds += val * 3600; // 60 * 60
-      break;
+      case 'hr':
+      case 'hrs':
+      case 'hour':
+      case 'hours':
+        seconds += val * 3600; // 60 * 60
+        break;
 
-    case 'min':
-    case 'mins':
-    case 'minute':
-    case 'minutes':
-      seconds += val * 60;
-      break;
+      case 'min':
+      case 'mins':
+      case 'minute':
+      case 'minutes':
+        seconds += val * 60;
+        break;
 
-    case 'sec':
-    case 'secs':
-    case 'second':
-    case 'seconds':
-      seconds += val;
-      break;
+      case 'sec':
+      case 'secs':
+      case 'second':
+      case 'seconds':
+        seconds += val;
+        break;
 
-    default:
-      return {
-        status: 'error',
-        info: `Invalid interval: '${interval}'`,
-      };
+      default:
+        return {
+          status: 'error',
+          info: `Invalid interval: '${interval}'`,
+        };
     }
   }
 
@@ -338,213 +338,213 @@ function matchesKeyConstraints(className, object, objects, key, constraints) {
     }
 
     switch (condition) {
-    case '$lt':
-      if (object[key] >= compareTo) {
-        return false;
-      }
-      break;
-    case '$lte':
-      if (object[key] > compareTo) {
-        return false;
-      }
-      break;
-    case '$gt':
-      if (object[key] <= compareTo) {
-        return false;
-      }
-      break;
-    case '$gte':
-      if (object[key] < compareTo) {
-        return false;
-      }
-      break;
-    case '$ne':
-      if (equalObjects(object[key], compareTo)) {
-        return false;
-      }
-      break;
-    case '$in':
-      if (!contains(compareTo, object[key])) {
-        return false;
-      }
-      break;
-    case '$nin':
-      if (contains(compareTo, object[key])) {
-        return false;
-      }
-      break;
-    case '$all':
-      for (i = 0; i < compareTo.length; i++) {
-        if (object[key].indexOf(compareTo[i]) < 0) {
+      case '$lt':
+        if (object[key] >= compareTo) {
           return false;
         }
-      }
-      break;
-    case '$exists': {
-      const propertyExists = typeof object[key] !== 'undefined';
-      const existenceIsRequired = constraints['$exists'];
-      if (typeof constraints['$exists'] !== 'boolean') {
-        // The SDK will never submit a non-boolean for $exists, but if someone
-        // tries to submit a non-boolean for $exits outside the SDKs, just ignore it.
+        break;
+      case '$lte':
+        if (object[key] > compareTo) {
+          return false;
+        }
+        break;
+      case '$gt':
+        if (object[key] <= compareTo) {
+          return false;
+        }
+        break;
+      case '$gte':
+        if (object[key] < compareTo) {
+          return false;
+        }
+        break;
+      case '$ne':
+        if (equalObjects(object[key], compareTo)) {
+          return false;
+        }
+        break;
+      case '$in':
+        if (!contains(compareTo, object[key])) {
+          return false;
+        }
+        break;
+      case '$nin':
+        if (contains(compareTo, object[key])) {
+          return false;
+        }
+        break;
+      case '$all':
+        for (i = 0; i < compareTo.length; i++) {
+          if (object[key].indexOf(compareTo[i]) < 0) {
+            return false;
+          }
+        }
+        break;
+      case '$exists': {
+        const propertyExists = typeof object[key] !== 'undefined';
+        const existenceIsRequired = constraints['$exists'];
+        if (typeof constraints['$exists'] !== 'boolean') {
+          // The SDK will never submit a non-boolean for $exists, but if someone
+          // tries to submit a non-boolean for $exits outside the SDKs, just ignore it.
+          break;
+        }
+        if ((!propertyExists && existenceIsRequired) || (propertyExists && !existenceIsRequired)) {
+          return false;
+        }
         break;
       }
-      if ((!propertyExists && existenceIsRequired) || (propertyExists && !existenceIsRequired)) {
-        return false;
-      }
-      break;
-    }
-    case '$regex': {
-      if (typeof compareTo === 'object') {
-        return compareTo.test(object[key]);
-      }
-      // JS doesn't support perl-style escaping
-      let expString = '';
-      let escapeEnd = -2;
-      let escapeStart = compareTo.indexOf('\\Q');
-      while (escapeStart > -1) {
-        // Add the unescaped portion
-        expString += compareTo.substring(escapeEnd + 2, escapeStart);
-        escapeEnd = compareTo.indexOf('\\E', escapeStart);
-        if (escapeEnd > -1) {
-          expString += compareTo
-            .substring(escapeStart + 2, escapeEnd)
-            .replace(/\\\\\\\\E/g, '\\E')
-            .replace(/\W/g, '\\$&');
+      case '$regex': {
+        if (typeof compareTo === 'object') {
+          return compareTo.test(object[key]);
         }
+        // JS doesn't support perl-style escaping
+        let expString = '';
+        let escapeEnd = -2;
+        let escapeStart = compareTo.indexOf('\\Q');
+        while (escapeStart > -1) {
+          // Add the unescaped portion
+          expString += compareTo.substring(escapeEnd + 2, escapeStart);
+          escapeEnd = compareTo.indexOf('\\E', escapeStart);
+          if (escapeEnd > -1) {
+            expString += compareTo
+              .substring(escapeStart + 2, escapeEnd)
+              .replace(/\\\\\\\\E/g, '\\E')
+              .replace(/\W/g, '\\$&');
+          }
 
-        escapeStart = compareTo.indexOf('\\Q', escapeEnd);
+          escapeStart = compareTo.indexOf('\\Q', escapeEnd);
+        }
+        expString += compareTo.substring(Math.max(escapeStart, escapeEnd + 2));
+        let modifiers = constraints.$options || '';
+        modifiers = modifiers.replace('x', '').replace('s', '');
+        // Parse Server / Mongo support x and s modifiers but JS RegExp doesn't
+        const exp = new RegExp(expString, modifiers);
+        if (!exp.test(object[key])) {
+          return false;
+        }
+        break;
       }
-      expString += compareTo.substring(Math.max(escapeStart, escapeEnd + 2));
-      let modifiers = constraints.$options || '';
-      modifiers = modifiers.replace('x', '').replace('s', '');
-      // Parse Server / Mongo support x and s modifiers but JS RegExp doesn't
-      const exp = new RegExp(expString, modifiers);
-      if (!exp.test(object[key])) {
-        return false;
+      case '$nearSphere': {
+        if (!compareTo || !object[key]) {
+          return false;
+        }
+        const distance = compareTo.radiansTo(object[key]);
+        const max = constraints.$maxDistance || Infinity;
+        return distance <= max;
       }
-      break;
-    }
-    case '$nearSphere': {
-      if (!compareTo || !object[key]) {
-        return false;
-      }
-      const distance = compareTo.radiansTo(object[key]);
-      const max = constraints.$maxDistance || Infinity;
-      return distance <= max;
-    }
-    case '$within': {
-      if (!compareTo || !object[key]) {
-        return false;
-      }
-      const southWest = compareTo.$box[0];
-      const northEast = compareTo.$box[1];
-      if (southWest.latitude > northEast.latitude || southWest.longitude > northEast.longitude) {
-        // Invalid box, crosses the date line
-        return false;
-      }
-      return (
-        object[key].latitude > southWest.latitude &&
+      case '$within': {
+        if (!compareTo || !object[key]) {
+          return false;
+        }
+        const southWest = compareTo.$box[0];
+        const northEast = compareTo.$box[1];
+        if (southWest.latitude > northEast.latitude || southWest.longitude > northEast.longitude) {
+          // Invalid box, crosses the date line
+          return false;
+        }
+        return (
+          object[key].latitude > southWest.latitude &&
           object[key].latitude < northEast.latitude &&
           object[key].longitude > southWest.longitude &&
           object[key].longitude < northEast.longitude
-      );
-    }
-    case '$options':
-      // Not a query type, but a way to add options to $regex. Ignore and
-      // avoid the default
-      break;
-    case '$maxDistance':
-      // Not a query type, but a way to add a cap to $nearSphere. Ignore and
-      // avoid the default
-      break;
-    case '$select': {
-      const subQueryObjects = objects.filter((obj, _index, arr) => {
-        return matchesQuery(compareTo.query.className, obj, arr, compareTo.query.where);
-      });
-      for (let i = 0; i < subQueryObjects.length; i += 1) {
-        const subObject = transformObject(subQueryObjects[i]);
-        return equalObjects(object[key], subObject[compareTo.key]);
+        );
       }
-      return false;
-    }
-    case '$dontSelect': {
-      const subQueryObjects = objects.filter((obj, _index, arr) => {
-        return matchesQuery(compareTo.query.className, obj, arr, compareTo.query.where);
-      });
-      for (let i = 0; i < subQueryObjects.length; i += 1) {
-        const subObject = transformObject(subQueryObjects[i]);
-        return !equalObjects(object[key], subObject[compareTo.key]);
-      }
-      return false;
-    }
-    case '$inQuery': {
-      const subQueryObjects = objects.filter((obj, _index, arr) => {
-        return matchesQuery(compareTo.className, obj, arr, compareTo.where);
-      });
-
-      for (let i = 0; i < subQueryObjects.length; i += 1) {
-        const subObject = transformObject(subQueryObjects[i]);
-        if (
-          object[key].className === subObject.className &&
-            object[key].objectId === subObject.objectId
-        ) {
-          return true;
-        }
-      }
-      return false;
-    }
-    case '$notInQuery': {
-      const subQueryObjects = objects.filter((obj, _index, arr) => {
-        return matchesQuery(compareTo.className, obj, arr, compareTo.where);
-      });
-
-      for (let i = 0; i < subQueryObjects.length; i += 1) {
-        const subObject = transformObject(subQueryObjects[i]);
-        if (
-          object[key].className === subObject.className &&
-            object[key].objectId === subObject.objectId
-        ) {
-          return false;
-        }
-      }
-      return true;
-    }
-    case '$containedBy': {
-      for (const value of object[key]) {
-        if (!contains(compareTo, value)) {
-          return false;
-        }
-      }
-      return true;
-    }
-    case '$geoWithin': {
-      if (compareTo.$polygon) {
-        const points = compareTo.$polygon.map(geoPoint => [
-          geoPoint.latitude,
-          geoPoint.longitude,
-        ]);
-        const polygon = new ParsePolygon(points);
-        return polygon.containsPoint(object[key]);
-      }
-      if (compareTo.$centerSphere) {
-        const [WGS84Point, maxDistance] = compareTo.$centerSphere;
-        const centerPoint = new ParseGeoPoint({
-          latitude: WGS84Point[1],
-          longitude: WGS84Point[0],
+      case '$options':
+        // Not a query type, but a way to add options to $regex. Ignore and
+        // avoid the default
+        break;
+      case '$maxDistance':
+        // Not a query type, but a way to add a cap to $nearSphere. Ignore and
+        // avoid the default
+        break;
+      case '$select': {
+        const subQueryObjects = objects.filter((obj, _index, arr) => {
+          return matchesQuery(compareTo.query.className, obj, arr, compareTo.query.where);
         });
-        const point = new ParseGeoPoint(object[key]);
-        const distance = point.radiansTo(centerPoint);
-        return distance <= maxDistance;
+        for (let i = 0; i < subQueryObjects.length; i += 1) {
+          const subObject = transformObject(subQueryObjects[i]);
+          return equalObjects(object[key], subObject[compareTo.key]);
+        }
+        return false;
       }
-      return false;
-    }
-    case '$geoIntersects': {
-      const polygon = new ParsePolygon(object[key].coordinates);
-      const point = new ParseGeoPoint(compareTo.$point);
-      return polygon.containsPoint(point);
-    }
-    default:
-      return false;
+      case '$dontSelect': {
+        const subQueryObjects = objects.filter((obj, _index, arr) => {
+          return matchesQuery(compareTo.query.className, obj, arr, compareTo.query.where);
+        });
+        for (let i = 0; i < subQueryObjects.length; i += 1) {
+          const subObject = transformObject(subQueryObjects[i]);
+          return !equalObjects(object[key], subObject[compareTo.key]);
+        }
+        return false;
+      }
+      case '$inQuery': {
+        const subQueryObjects = objects.filter((obj, _index, arr) => {
+          return matchesQuery(compareTo.className, obj, arr, compareTo.where);
+        });
+
+        for (let i = 0; i < subQueryObjects.length; i += 1) {
+          const subObject = transformObject(subQueryObjects[i]);
+          if (
+            object[key].className === subObject.className &&
+            object[key].objectId === subObject.objectId
+          ) {
+            return true;
+          }
+        }
+        return false;
+      }
+      case '$notInQuery': {
+        const subQueryObjects = objects.filter((obj, _index, arr) => {
+          return matchesQuery(compareTo.className, obj, arr, compareTo.where);
+        });
+
+        for (let i = 0; i < subQueryObjects.length; i += 1) {
+          const subObject = transformObject(subQueryObjects[i]);
+          if (
+            object[key].className === subObject.className &&
+            object[key].objectId === subObject.objectId
+          ) {
+            return false;
+          }
+        }
+        return true;
+      }
+      case '$containedBy': {
+        for (const value of object[key]) {
+          if (!contains(compareTo, value)) {
+            return false;
+          }
+        }
+        return true;
+      }
+      case '$geoWithin': {
+        if (compareTo.$polygon) {
+          const points = compareTo.$polygon.map(geoPoint => [
+            geoPoint.latitude,
+            geoPoint.longitude,
+          ]);
+          const polygon = new ParsePolygon(points);
+          return polygon.containsPoint(object[key]);
+        }
+        if (compareTo.$centerSphere) {
+          const [WGS84Point, maxDistance] = compareTo.$centerSphere;
+          const centerPoint = new ParseGeoPoint({
+            latitude: WGS84Point[1],
+            longitude: WGS84Point[0],
+          });
+          const point = new ParseGeoPoint(object[key]);
+          const distance = point.radiansTo(centerPoint);
+          return distance <= maxDistance;
+        }
+        return false;
+      }
+      case '$geoIntersects': {
+        const polygon = new ParsePolygon(object[key].coordinates);
+        const point = new ParseGeoPoint(compareTo.$point);
+        return polygon.containsPoint(point);
+      }
+      default:
+        return false;
     }
   }
   return true;

--- a/src/ParseObject.ts
+++ b/src/ParseObject.ts
@@ -1012,7 +1012,7 @@ class ParseObject<T extends Attributes = Attributes> {
    */
   op<K extends AttributeKey<T>>(attr: K): Op | undefined {
     const pending = this._getPendingOps();
-    for (let i = pending.length; i--;) {
+    for (let i = 0; i < pending.length; i += 1) {
       if (pending[i][attr]) {
         return pending[i][attr];
       }

--- a/src/ParseOp.ts
+++ b/src/ParseOp.ts
@@ -12,42 +12,42 @@ export function opFromJSON(json: Record<string, any>): Op | null {
     return null;
   }
   switch (json.__op) {
-  case 'Delete':
-    return new UnsetOp();
-  case 'Increment':
-    return new IncrementOp(json.amount);
-  case 'Add':
-    return new AddOp(decode(json.objects));
-  case 'AddUnique':
-    return new AddUniqueOp(decode(json.objects));
-  case 'Remove':
-    return new RemoveOp(decode(json.objects));
-  case 'AddRelation': {
-    const toAdd = decode(json.objects);
-    if (!Array.isArray(toAdd)) {
-      return new RelationOp([], []);
-    }
-    return new RelationOp(toAdd, []);
-  }
-  case 'RemoveRelation': {
-    const toRemove = decode(json.objects);
-    if (!Array.isArray(toRemove)) {
-      return new RelationOp([], []);
-    }
-    return new RelationOp([], toRemove);
-  }
-  case 'Batch': {
-    let toAdd = [];
-    let toRemove = [];
-    for (let i = 0; i < json.ops.length; i++) {
-      if (json.ops[i].__op === 'AddRelation') {
-        toAdd = toAdd.concat(decode(json.ops[i].objects));
-      } else if (json.ops[i].__op === 'RemoveRelation') {
-        toRemove = toRemove.concat(decode(json.ops[i].objects));
+    case 'Delete':
+      return new UnsetOp();
+    case 'Increment':
+      return new IncrementOp(json.amount);
+    case 'Add':
+      return new AddOp(decode(json.objects));
+    case 'AddUnique':
+      return new AddUniqueOp(decode(json.objects));
+    case 'Remove':
+      return new RemoveOp(decode(json.objects));
+    case 'AddRelation': {
+      const toAdd = decode(json.objects);
+      if (!Array.isArray(toAdd)) {
+        return new RelationOp([], []);
       }
+      return new RelationOp(toAdd, []);
     }
-    return new RelationOp(toAdd, toRemove);
-  }
+    case 'RemoveRelation': {
+      const toRemove = decode(json.objects);
+      if (!Array.isArray(toRemove)) {
+        return new RelationOp([], []);
+      }
+      return new RelationOp([], toRemove);
+    }
+    case 'Batch': {
+      let toAdd = [];
+      let toRemove = [];
+      for (let i = 0; i < json.ops.length; i++) {
+        if (json.ops[i].__op === 'AddRelation') {
+          toAdd = toAdd.concat(decode(json.ops[i].objects));
+        } else if (json.ops[i].__op === 'RemoveRelation') {
+          toRemove = toRemove.concat(decode(json.ops[i].objects));
+        }
+      }
+      return new RelationOp(toAdd, toRemove);
+    }
   }
   return null;
 }

--- a/src/ParseQuery.ts
+++ b/src/ParseQuery.ts
@@ -1545,17 +1545,17 @@ class ParseQuery<T extends ParseObject = ParseObject> {
 
     for (const option in options) {
       switch (option) {
-      case 'language':
-        fullOptions.$language = options[option];
-        break;
-      case 'caseSensitive':
-        fullOptions.$caseSensitive = options[option];
-        break;
-      case 'diacriticSensitive':
-        fullOptions.$diacriticSensitive = options[option];
-        break;
-      default:
-        throw new Error(`Unknown option: ${option}`);
+        case 'language':
+          fullOptions.$language = options[option];
+          break;
+        case 'caseSensitive':
+          fullOptions.$caseSensitive = options[option];
+          break;
+        case 'diacriticSensitive':
+          fullOptions.$diacriticSensitive = options[option];
+          break;
+        default:
+          throw new Error(`Unknown option: ${option}`);
       }
     }
 

--- a/src/equals.ts
+++ b/src/equals.ts
@@ -27,7 +27,7 @@ export default function equals(a: any, b: any): boolean {
     if (a.length !== b.length) {
       return false;
     }
-    for (let i = a.length; i--;) {
+    for (let i = 0; i < a.length; i += 1) {
       if (!equals(a[i], b[i])) {
         return false;
       }


### PR DESCRIPTION
## Pull Request

- Report security issues [confidentially](https://github.com/parse-community/Parse-SDK-JS/security/policy).
- Any contribution is under this [license](https://github.com/parse-community/Parse-SDK-JS/blob/alpha/LICENSE).
- Link this pull request to an [issue](https://github.com/parse-community/Parse-SDK-JS/issues?q=is%3Aissue).

## Issue
<!-- Add the link to the issue that this PR closes. -->
Using husky adds significant time when committing code. Per commit can take up to 10 seconds of wait time.  

Prettier formats the code which can managed by eslint.
Running prettier then eslint has errors which required `--fix`. This PR fixes those lint issues so prettier can be removed.

Closes: https://github.com/parse-community/Parse-SDK-JS/pull/2251

## Approach
<!-- Describe the changes in this PR. -->
* Update eslint config to match prettier switch statements indents
* Refactor reverse order for loops
* Runs prettier one last time without eslint --fix, basically eslint now has prettier rules without the need for prettier.