### PR TITLE
fix: HTTP status code 3XX redirection for Parse Server URL not handled properly

### DIFF
--- a/integration/test/ParseServerTest.js
+++ b/integration/test/ParseServerTest.js
@@ -39,11 +39,11 @@ describe('ParseServer', () => {
   });
 
   it('can forward redirect', async () => {
+    const serverURL = Parse.serverURL;
     http.createServer(function(_, res) {
-      res.writeHead(301, { Location: 'http://localhost:1337/parse' });
+      res.writeHead(301, { Location: serverURL });
       res.end();
     }).listen(8080);
-    const serverURL = Parse.serverURL;
     Parse.CoreManager.set('SERVER_URL', 'http://localhost:8080/api');
     const object = new TestObject({ foo: 'bar' });
     await object.save();

--- a/integration/test/ParseServerTest.js
+++ b/integration/test/ParseServerTest.js
@@ -40,7 +40,7 @@ describe('ParseServer', () => {
 
   it('can forward redirect', async () => {
     const serverURL = Parse.serverURL;
-    http.createServer(function(_, res) {
+    const redirectServer = http.createServer(function(_, res) {
       res.writeHead(301, { Location: serverURL });
       res.end();
     }).listen(8080);
@@ -52,5 +52,6 @@ describe('ParseServer', () => {
     expect(result.id).toBe(object.id);
     expect(result.get('foo')).toBe('bar');
     Parse.serverURL = serverURL;
+    redirectServer.close();
   });
 });

--- a/integration/test/ParseServerTest.js
+++ b/integration/test/ParseServerTest.js
@@ -1,5 +1,8 @@
 'use strict';
 
+const http = require('http');
+const Parse = require('../../node');
+
 describe('ParseServer', () => {
   it('can reconfigure server', async () => {
     let parseServer = await reconfigureServer({ serverURL: 'www.google.com' });
@@ -33,5 +36,21 @@ describe('ParseServer', () => {
     await reconfigureServer({});
     await object.save();
     expect(object.id).toBeDefined();
+  });
+
+  it('can forward redirect', async () => {
+    http.createServer(function(_, res) {
+      res.writeHead(301, { Location: 'http://localhost:1337/parse' });
+      res.end();
+    }).listen(8080);
+    const serverURL = Parse.serverURL;
+    Parse.CoreManager.set('SERVER_URL', 'http://localhost:8080/api');
+    const object = new TestObject({ foo: 'bar' });
+    await object.save();
+    const query = new Parse.Query(TestObject);
+    const result = await query.get(object.id);
+    expect(result.id).toBe(object.id);
+    expect(result.get('foo')).toBe('bar');
+    Parse.serverURL = serverURL;
   });
 });

--- a/src/RESTController.ts
+++ b/src/RESTController.ts
@@ -54,6 +54,13 @@ if (typeof XDomainRequest !== 'undefined' && !('withCredentials' in new XMLHttpR
   useXDomainRequest = true;
 }
 
+function getPath(url: string, path: string) {
+  if (url[url.length - 1] !== '/') {
+    url += '/';
+  }
+  return url + path;
+}
+
 function ajaxIE9(method: string, url: string, data: any, _headers?: any, options?: FullOptions) {
   return new Promise((resolve, reject) => {
     // @ts-ignore
@@ -140,6 +147,7 @@ const RESTController = {
           method,
           headers,
           signal,
+          redirect: 'manual',
         };
         if (data) {
           fetchOptions.body = data;
@@ -189,6 +197,9 @@ const RESTController = {
         } else if (status >= 400 && status < 500) {
           const error = await response.json();
           promise.reject(error);
+        } else if (status === 301 || status === 302 || status === 303 || status === 307) {
+          const location = response.headers.get('location');
+          promise.resolve({ status, location, method: status === 303 ? 'GET' : method });
         } else if (status >= 500 || status === 0) {
           // retry on 5XX or library error
           if (++attempts < CoreManager.get('REQUEST_ATTEMPT_LIMIT')) {
@@ -221,12 +232,7 @@ const RESTController = {
 
   request(method: string, path: string, data: any, options?: RequestOptions) {
     options = options || {};
-    let url = CoreManager.get('SERVER_URL');
-    if (url[url.length - 1] !== '/') {
-      url += '/';
-    }
-    url += path;
-
+    const url = getPath(CoreManager.get('SERVER_URL'), path);
     const payload: Partial<PayloadType> = {};
     if (data && typeof data === 'object') {
       for (const k in data) {
@@ -302,15 +308,18 @@ const RESTController = {
         }
 
         const payloadString = JSON.stringify(payload);
-        return RESTController.ajax(method, url, payloadString, {}, options).then(
-          ({ response, status, headers }) => {
-            if (options.returnStatus) {
-              return { ...response, _status: status, _headers: headers };
-            } else {
-              return response;
-            }
+        return RESTController.ajax(method, url, payloadString, {}, options).then(async (result) => {
+          if (result.location) {
+            const newURL = getPath(result.location, path);
+            result = await RESTController.ajax(result.method, newURL, payloadString, {}, options);
           }
-        );
+          const { response, status, headers } = result;
+          if (options.returnStatus) {
+            return { ...response, _status: status, _headers: headers };
+          } else {
+            return response;
+          }
+        });
       })
       .catch(RESTController.handleError);
   },

--- a/src/RESTController.ts
+++ b/src/RESTController.ts
@@ -197,9 +197,14 @@ const RESTController = {
         } else if (status >= 400 && status < 500) {
           const error = await response.json();
           promise.reject(error);
-        } else if (status === 301 || status === 302 || status === 303 || status === 307) {
+        } else if ([301, 302, 303, 307, 308].includes(status)) {
           const location = response.headers.get('location');
-          promise.resolve({ status, location, method: status === 303 ? 'GET' : method });
+          promise.resolve({
+            status,
+            location,
+            method: status === 303 ? 'GET' : method,
+            body: status === 303 ? null : data,
+          });
         } else if (status >= 500 || status === 0) {
           // retry on 5XX or library error
           if (++attempts < CoreManager.get('REQUEST_ATTEMPT_LIMIT')) {
@@ -311,7 +316,7 @@ const RESTController = {
         return RESTController.ajax(method, url, payloadString, {}, options).then(async (result) => {
           if (result.location) {
             const newURL = getPath(result.location, path);
-            result = await RESTController.ajax(result.method, newURL, payloadString, {}, options);
+            result = await RESTController.ajax(result.method, newURL, result.body, {}, options);
           }
           const { response, status, headers } = result;
           if (options.returnStatus) {

--- a/src/RESTController.ts
+++ b/src/RESTController.ts
@@ -54,11 +54,14 @@ if (typeof XDomainRequest !== 'undefined' && !('withCredentials' in new XMLHttpR
   useXDomainRequest = true;
 }
 
-function getPath(url: string, path: string) {
-  if (url[url.length - 1] !== '/') {
-    url += '/';
+function getPath(base: string, pathname: string) {
+  if (base.endsWith('/')) {
+    base = base.slice(0, -1);
   }
-  return url + path;
+  if (!pathname.startsWith('/')) {
+    pathname = '/' + pathname;
+  }
+  return base + pathname;
 }
 
 function ajaxIE9(method: string, url: string, data: any, _headers?: any, options?: FullOptions) {
@@ -203,7 +206,7 @@ const RESTController = {
             status,
             location,
             method: status === 303 ? 'GET' : method,
-            body: status === 303 ? null : data,
+            dropBody: status === 303,
           });
         } else if (status >= 500 || status === 0) {
           // retry on 5XX or library error
@@ -315,8 +318,21 @@ const RESTController = {
         const payloadString = JSON.stringify(payload);
         return RESTController.ajax(method, url, payloadString, {}, options).then(async (result) => {
           if (result.location) {
-            const newURL = getPath(result.location, path);
-            result = await RESTController.ajax(result.method, newURL, result.body, {}, options);
+            let newURL = getPath(result.location, path);
+            let newMethod = result.method;
+            let newBody = result.dropBody ? undefined : payloadString;
+
+            // Follow up to 5 redirects to avoid loops
+            for (let i = 0; i < 5; i += 1) {
+              const r = await RESTController.ajax(newMethod, newURL, newBody, {}, options);
+              if (!r.location) {
+                result = r;
+                break;
+              }
+              newURL = getPath(r.location, path);
+              newMethod = r.method;
+              newBody = r.dropBody ? undefined : payloadString;
+            }
           }
           const { response, status, headers } = result;
           if (options.returnStatus) {

--- a/src/__tests__/RESTController-test.js
+++ b/src/__tests__/RESTController-test.js
@@ -433,4 +433,41 @@ describe('RESTController', () => {
       _SessionToken: '1234',
     });
   });
+
+  it('follows HTTP redirects for batch requests when using a custom SERVER_URL', async () => {
+    // Configure a reverse-proxy style SERVER_URL
+    CoreManager.set('SERVER_URL', 'http://test.host/api');
+
+    // Prepare a minimal batch payload
+    const batchData = {
+      requests: [{
+        method: 'POST',
+        path: '/classes/TestObject',
+        body: { foo: 'bar' }
+      }]
+    };
+
+    // First response: 301 redirect to /parse/batch; second: successful response
+    mockFetch(
+      [
+        { status: 301, response: {} },
+        { status: 200, response: { success: true } }
+      ],
+      { location: 'http://test.host/parse/' }
+    );
+
+    // Issue the batch request
+    const result = await RESTController.request('POST', 'batch', batchData);
+
+    // We expect two fetch calls: one to the original URL, then one to the Location header
+    expect(fetch.mock.calls.length).toBe(2);
+    expect(fetch.mock.calls[0][0]).toEqual('http://test.host/api/batch');
+    expect(fetch.mock.calls[1][0]).toEqual('http://test.host/parse/batch');
+
+    // The final result should be the JSON from the second (successful) response
+    expect(result).toEqual({ success: true });
+
+    // Clean up the custom SERVER_URL
+    CoreManager.set('SERVER_URL', undefined);
+  });
 });

--- a/src/__tests__/RESTController-test.js
+++ b/src/__tests__/RESTController-test.js
@@ -468,6 +468,45 @@ describe('RESTController', () => {
     expect(result).toEqual({ success: true });
 
     // Clean up the custom SERVER_URL
-    CoreManager.set('SERVER_URL', undefined);
+    CoreManager.set('SERVER_URL', 'https://api.parse.com/1');
+  });
+
+  it('follows multiple HTTP redirects', async () => {
+    // Configure a reverse-proxy style SERVER_URL
+    CoreManager.set('SERVER_URL', 'http://test.host/api');
+
+    // Prepare a minimal batch payload
+    const batchData = {
+      requests: [{
+        method: 'POST',
+        path: '/classes/TestObject',
+        body: { foo: 'bar' }
+      }]
+    };
+
+    // First response: 301 redirect to /parse/batch; second: successful response
+    mockFetch(
+      [
+        { status: 301, response: {} },
+        { status: 301, response: {} },
+        { status: 200, response: { success: true } }
+      ],
+      { location: 'http://test.host/parse/' }
+    );
+
+    // Issue the batch request
+    const result = await RESTController.request('POST', 'batch', batchData);
+
+    // We expect three fetch calls: one to the original URL, then two to the Location header
+    expect(fetch.mock.calls.length).toBe(3);
+    expect(fetch.mock.calls[0][0]).toEqual('http://test.host/api/batch');
+    expect(fetch.mock.calls[1][0]).toEqual('http://test.host/parse/batch');
+    expect(fetch.mock.calls[2][0]).toEqual('http://test.host/parse/batch');
+
+    // The final result should be the JSON from the second (successful) response
+    expect(result).toEqual({ success: true });
+
+    // Clean up the custom SERVER_URL
+    CoreManager.set('SERVER_URL', 'https://api.parse.com/1');
   });
 });


### PR DESCRIPTION
## Pull Request

- Report security issues [confidentially](https://github.com/parse-community/Parse-SDK-JS/security/policy).
- Any contribution is under this [license](https://github.com/parse-community/Parse-SDK-JS/blob/alpha/LICENSE).
- Link this pull request to an [issue](https://github.com/parse-community/Parse-SDK-JS/issues?q=is%3Aissue).

## Issue
<!-- Add the link to the issue that this PR closes. -->
The SDK doesn't support 3XX redirection status codes

https://en.wikipedia.org/wiki/List_of_HTTP_status_codes#3xx_redirection

Closes: https://github.com/parse-community/Parse-SDK-JS/issues/1945

## Approach
<!-- Describe the changes in this PR. -->
* Resend request when new redirection url
* Handle redirection loops

## Tasks
<!-- Delete tasks that don't apply. -->

- [x] Add tests
- [x] Add changes to documentation (guides, repository pages, code comments)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
  - Added support for manual handling of HTTP redirects in network requests, ensuring correct processing of redirects during server communication.

- **Bug Fixes**
  - Improved reliability when interacting with servers or proxies that return HTTP redirects.

- **Tests**
  - Introduced new test cases to verify correct handling of HTTP redirects in both general and batch request scenarios.
  - Added test to confirm redirect forwarding works correctly with object saving and querying.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->