### PR TITLE
test: Remove `Parse.Cloud.job` parameters from tests

### DIFF
--- a/integration/test/IdempotencyTest.js
+++ b/integration/test/IdempotencyTest.js
@@ -34,9 +34,8 @@ describe('Idempotency', () => {
 
   it('handle duplicate job request', async () => {
     DuplicateRequestId('1234');
-    const params = { startedBy: 'Monty Python' };
-    const jobStatusId = await Parse.Cloud.startJob('CloudJob1', params);
-    await expectAsync(Parse.Cloud.startJob('CloudJob1', params)).toBeRejectedWithError(
+    const jobStatusId = await Parse.Cloud.startJob('CloudJob1', {});
+    await expectAsync(Parse.Cloud.startJob('CloudJob1', {})).toBeRejectedWithError(
       'Duplicate request'
     );
 
@@ -49,7 +48,6 @@ describe('Idempotency', () => {
     }
     const jobStatus = await Parse.Cloud.getJobStatus(jobStatusId);
     expect(jobStatus.get('status')).toBe('succeeded');
-    expect(jobStatus.get('params').startedBy).toBe('Monty Python');
   });
 
   it('handle duplicate POST / PUT request', async () => {

--- a/integration/test/IdempotencyTest.js
+++ b/integration/test/IdempotencyTest.js
@@ -34,8 +34,9 @@ describe('Idempotency', () => {
 
   it('handle duplicate job request', async () => {
     DuplicateRequestId('1234');
-    const jobStatusId = await Parse.Cloud.startJob('CloudJob1', {});
-    await expectAsync(Parse.Cloud.startJob('CloudJob1', {})).toBeRejectedWithError(
+    const params = { startedBy: 'Monty Python' };
+    const jobStatusId = await Parse.Cloud.startJob('CloudJobParamsInMessage', params);
+    await expectAsync(Parse.Cloud.startJob('CloudJobParamsInMessage', params)).toBeRejectedWithError(
       'Duplicate request'
     );
 
@@ -48,6 +49,7 @@ describe('Idempotency', () => {
     }
     const jobStatus = await Parse.Cloud.getJobStatus(jobStatusId);
     expect(jobStatus.get('status')).toBe('succeeded');
+    expect(JSON.parse(jobStatus.get('message'))).toEqual(params);
   });
 
   it('handle duplicate POST / PUT request', async () => {

--- a/integration/test/ParseCloudTest.js
+++ b/integration/test/ParseCloudTest.js
@@ -137,7 +137,7 @@ describe('Parse Cloud', () => {
   it('get jobs data', done => {
     Parse.Cloud.getJobsData().then(result => {
       assert.equal(result.in_use.length, 0);
-      assert.equal(result.jobs.length, 3);
+      assert.equal(result.jobs.length, 4);
       done();
     });
   });

--- a/integration/test/ParseCloudTest.js
+++ b/integration/test/ParseCloudTest.js
@@ -94,12 +94,14 @@ describe('Parse Cloud', () => {
   });
 
   it('run job', async () => {
-    const jobStatusId = await Parse.Cloud.startJob('CloudJob1', {});
+    const params = { startedBy: 'Monty Python' };
+    const jobStatusId = await Parse.Cloud.startJob('CloudJobParamsInMessage', params);
     expect(jobStatusId).toBeDefined();
     await waitForJobStatus(jobStatusId, 'succeeded');
 
     const jobStatus = await Parse.Cloud.getJobStatus(jobStatusId);
-    assert.equal(jobStatus.get('status'), 'succeeded');
+    expect(jobStatus.get('status')).toBe('succeeded');
+    expect(JSON.parse(jobStatus.get('message'))).toEqual(params);
   });
 
   it('run long job', async () => {

--- a/integration/test/ParseCloudTest.js
+++ b/integration/test/ParseCloudTest.js
@@ -94,14 +94,12 @@ describe('Parse Cloud', () => {
   });
 
   it('run job', async () => {
-    const params = { startedBy: 'Monty Python' };
-    const jobStatusId = await Parse.Cloud.startJob('CloudJob1', params);
+    const jobStatusId = await Parse.Cloud.startJob('CloudJob1', {});
     expect(jobStatusId).toBeDefined();
     await waitForJobStatus(jobStatusId, 'succeeded');
 
     const jobStatus = await Parse.Cloud.getJobStatus(jobStatusId);
     assert.equal(jobStatus.get('status'), 'succeeded');
-    assert.equal(jobStatus.get('params').startedBy, 'Monty Python');
   });
 
   it('run long job', async () => {

--- a/integration/test/cloud/main.js
+++ b/integration/test/cloud/main.js
@@ -45,6 +45,10 @@ Parse.Cloud.job('CloudJob2', function () {
   });
 });
 
+Parse.Cloud.job('CloudJobParamsInMessage', request => {
+  request.message(JSON.stringify(request.params));
+});
+
 Parse.Cloud.job('CloudJobFailing', function () {
   throw 'cloud job failed';
 });

--- a/integration/test/helper.js
+++ b/integration/test/helper.js
@@ -74,7 +74,7 @@ const defaultConfiguration = {
     },
   },
   idempotencyOptions: {
-    paths: ['functions/CloudFunctionIdempotency', 'jobs/CloudJob1', 'classes/IdempotentTest'],
+    paths: ['functions/CloudFunctionIdempotency', 'jobs/CloudJob1', 'jobs/CloudJobParamsInMessage', 'classes/IdempotentTest'],
     ttl: 120,
   },
   fileUpload: {


### PR DESCRIPTION
## Pull Request

- Report security issues [confidentially](https://github.com/parse-community/Parse-SDK-JS/security/policy).
- Any contribution is under this [license](https://github.com/parse-community/Parse-SDK-JS/blob/alpha/LICENSE).
- Link this pull request to an [issue](https://github.com/parse-community/Parse-SDK-JS/issues?q=is%3Aissue).

## Issue

Tests fail because of https://github.com/parse-community/parse-server/pull/8343. 

## Approach

Remove expecting the param from the test.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a new cloud job that sends request parameters as a JSON message.
- **Tests**
  - Updated test cases to validate job parameters via JSON message parsing.
  - Included the new cloud job path in idempotency handling tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->