### PR TITLE
feat: Add support for `Parse.Query.include` in LiveQuery

### DIFF
--- a/src/LiveQueryClient.ts
+++ b/src/LiveQueryClient.ts
@@ -183,8 +183,8 @@ class LiveQueryClient {
    * <a href="https://github.com/parse-community/parse-server/wiki/Parse-LiveQuery-Protocol-Specification">here</a> for more details. The subscription you get is the same subscription you get
    * from our Standard API.
    *
-   * @param {ParseQuery} query - the ParseQuery you want to subscribe to
-   * @param {string} sessionToken (optional)
+   * @param {ParseQuery} query The `Parse.Query` to subscribe to.
+   * @param {string} [sessionToken] Optional session token to use for the subscription.
    * @returns {LiveQuerySubscription | undefined}
    */
   subscribe(query: ParseQuery, sessionToken?: string): LiveQuerySubscription | undefined {

--- a/src/LiveQueryClient.ts
+++ b/src/LiveQueryClient.ts
@@ -196,6 +196,7 @@ class LiveQueryClient {
     const where = queryJSON.where;
     const keys = queryJSON.keys?.split(',');
     const watch = queryJSON.watch?.split(',');
+    const include = queryJSON.include?.split(',');
     const subscribeRequest = {
       op: OP_TYPES.SUBSCRIBE,
       requestId: this.requestId,
@@ -204,6 +205,7 @@ class LiveQueryClient {
         where,
         keys,
         watch,
+        include,
       },
       sessionToken: undefined as string | undefined,
     };
@@ -294,6 +296,7 @@ class LiveQueryClient {
       const where = queryJSON.where;
       const keys = queryJSON.keys?.split(',');
       const watch = queryJSON.watch?.split(',');
+      const include = queryJSON.include?.split(',');
       const className = query.className;
       const sessionToken = subscription.sessionToken;
       const subscribeRequest = {
@@ -304,6 +307,7 @@ class LiveQueryClient {
           where,
           keys,
           watch,
+          include,
         },
         sessionToken: undefined as string | undefined,
       };

--- a/src/__tests__/LiveQueryClient-test.js
+++ b/src/__tests__/LiveQueryClient-test.js
@@ -789,6 +789,7 @@ describe('LiveQueryClient', () => {
     };
     const query = new ParseQuery('Test');
     query.equalTo('key', 'value');
+    query.include(['key']);
 
     const subscribePromise = liveQueryClient.subscribe(query);
     const clientSub = liveQueryClient.subscriptions.get(1);
@@ -809,6 +810,7 @@ describe('LiveQueryClient', () => {
         where: {
           key: 'value',
         },
+        include: ['key'],
       },
     });
   });
@@ -826,6 +828,7 @@ describe('LiveQueryClient', () => {
     };
     const query = new ParseQuery('Test');
     query.equalTo('key', 'value');
+    query.include(['key']);
 
     const subscribePromise = liveQueryClient.subscribe(query, 'mySessionToken');
     const clientSub = liveQueryClient.subscriptions.get(1);
@@ -848,6 +851,7 @@ describe('LiveQueryClient', () => {
         where: {
           key: 'value',
         },
+        include: ['key'],
       },
     });
   });
@@ -946,6 +950,7 @@ describe('LiveQueryClient', () => {
     query.equalTo('key', 'value');
     query.select(['key']);
     query.watch(['key']);
+    query.include(['key']);
     liveQueryClient.subscribe(query);
     liveQueryClient.connectPromise.resolve();
 
@@ -965,6 +970,7 @@ describe('LiveQueryClient', () => {
         },
         keys: ['key'],
         watch: ['key'],
+        include: ['key'],
       },
     });
   });
@@ -984,6 +990,7 @@ describe('LiveQueryClient', () => {
     query.equalTo('key', 'value');
     query.select(['key']);
     query.watch(['key']);
+    query.include(['key']);
     liveQueryClient.subscribe(query, 'mySessionToken');
     liveQueryClient.connectPromise.resolve();
 
@@ -1004,6 +1011,7 @@ describe('LiveQueryClient', () => {
         },
         keys: ['key'],
         watch: ['key'],
+        include: ['key'],
       },
     });
   });

--- a/types/LiveQueryClient.d.ts
+++ b/types/LiveQueryClient.d.ts
@@ -92,8 +92,8 @@ declare class LiveQueryClient {
      * <a href="https://github.com/parse-community/parse-server/wiki/Parse-LiveQuery-Protocol-Specification">here</a> for more details. The subscription you get is the same subscription you get
      * from our Standard API.
      *
-     * @param {ParseQuery} query - the ParseQuery you want to subscribe to
-     * @param {string} sessionToken (optional)
+     * @param {ParseQuery} query The `Parse.Query` to subscribe to.
+     * @param {string} [sessionToken] Optional session token to use for the subscription.
      * @returns {LiveQuerySubscription | undefined}
      */
     subscribe(query: ParseQuery, sessionToken?: string): LiveQuerySubscription | undefined;


### PR DESCRIPTION
## Pull Request

- Report security issues [confidentially](https://github.com/parse-community/Parse-SDK-JS/security/policy).
- Any contribution is under this [license](https://github.com/parse-community/Parse-SDK-JS/blob/alpha/LICENSE).
- Link this pull request to an [issue](https://github.com/parse-community/Parse-SDK-JS/issues?q=is%3Aissue).

## Issue

Add support for `Parse.Query.include` in LiveQuery. Requires a Parse Server version that also supports this, see https://github.com/parse-community/parse-server/pull/9827.

## Approach

Pass include param on to server.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for handling the `include` field in live query subscriptions, allowing related data to be included in real-time updates.

* **Tests**
  * Updated tests to verify correct handling of the `include` field in live query subscription payloads.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->