### PR TITLE
fix: `Parse.Query` throws error when no response header

### DIFF
--- a/src/RESTController.ts
+++ b/src/RESTController.ts
@@ -158,7 +158,7 @@ const RESTController = {
           const responseHeaders = {};
           const availableHeaders = response.headers.get('access-control-expose-headers') || '';
           availableHeaders.split(', ').forEach((header: string) => {
-            if (response.headers.has(header)) {
+            if (header && response.headers.has(header)) {
               responseHeaders[header] = response.headers.get(header);
             }
           });

--- a/src/__tests__/RESTController-test.js
+++ b/src/__tests__/RESTController-test.js
@@ -55,6 +55,20 @@ describe('RESTController', () => {
     expect(status).toBe(200);
   });
 
+  it('resolves without error when access-control-expose-headers header is missing', async () => {
+    mockFetch([{ status: 200, response: { success: true } }], {});
+    const { response, status } = await RESTController.ajax('POST', 'users', {});
+    expect(response).toEqual({ success: true });
+    expect(status).toBe(200);
+  });
+
+  it('resolves without error when access-control-expose-headers header is empty', async () => {
+    mockFetch([{ status: 200, response: { success: true } }], { 'access-control-expose-headers': '' });
+    const { response, status } = await RESTController.ajax('POST', 'users', {});
+    expect(response).toEqual({ success: true });
+    expect(status).toBe(200);
+  });
+
   it('retries on 5XX errors', async () => {
     mockFetch([{ status: 500 }, { status: 500 }, { status: 200, response: { success: true } }])
     const { response, status } = await RESTController.ajax('POST', 'users', {});

--- a/src/__tests__/test_helpers/mockFetch.js
+++ b/src/__tests__/test_helpers/mockFetch.js
@@ -25,7 +25,12 @@ function mockFetch(results, headers = {}, error) {
       },
       headers: {
         get: header => headers[header],
-        has: header => headers[header] !== undefined,
+        has: header => {
+          if (header === '') {
+            throw new TypeError('Headers.has: "" is an invalid header name.');
+          }
+          return headers[header] !== undefined;
+        },
       },
       body: {
         getReader: () => ({

--- a/src/__tests__/test_helpers/mockFetch.js
+++ b/src/__tests__/test_helpers/mockFetch.js
@@ -27,7 +27,7 @@ function mockFetch(results, headers = {}, error) {
         get: header => headers[header],
         has: header => {
           if (header === '') {
-            throw new TypeError('Headers.has: "" is an invalid header name.');
+            throw new TypeError('Invalid empty header name.');
           }
           return headers[header] !== undefined;
         },

--- a/src/__tests__/test_helpers/mockFetch.js
+++ b/src/__tests__/test_helpers/mockFetch.js
@@ -27,7 +27,7 @@ function mockFetch(results, headers = {}, error) {
         get: header => headers[header],
         has: header => {
           if (header === '') {
-            throw new TypeError('Invalid empty header name.');
+            throw new TypeError('Headers.has: "" is an invalid header name.');
           }
           return headers[header] !== undefined;
         },


### PR DESCRIPTION
## Pull Request

- Report security issues [confidentially](https://github.com/parse-community/Parse-SDK-JS/security/policy).
- Any contribution is under this [license](https://github.com/parse-community/Parse-SDK-JS/blob/alpha/LICENSE).
- Link this pull request to an [issue](https://github.com/parse-community/Parse-SDK-JS/issues?q=is%3Aissue).

## Issue
<!-- Add the link to the issue that this PR closes. -->

Closes: #2753

## Approach
<!-- Describe the changes in this PR. -->

When parsing response headers in RESTController, the header key check is no longer performed if there are no headers.

To ensure this issue can be detected, the unit test `mockFetch` was updated to throw an exception—just like the actual runtime—when an empty string is passed to `headers.has`.

## Tasks
<!-- Delete tasks that don't apply. -->

- [x] Add tests
- [x] Add changes to documentation (guides, repository pages, code comments)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Avoid checking empty header names when reading response headers, reducing errors and improving stability when handling exposed headers.

- **Tests**
  - Test helpers now raise a clear TypeError for empty header names.
  - Added tests to confirm AJAX requests succeed when the exposed-headers value is missing or empty.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->