### PR TITLE
fix: Returned error for 5xx server response has incorrect format

### DIFF
--- a/src/RESTController.ts
+++ b/src/RESTController.ts
@@ -214,7 +214,8 @@ const RESTController = {
             promise.reject('Unable to connect to the Parse API');
           } else {
             // After the retry limit is reached, fail
-            promise.reject(response);
+            const error = await response.json();
+            promise.reject(error);
           }
         } else {
           promise.reject(response);

--- a/src/__tests__/RESTController-test.js
+++ b/src/__tests__/RESTController-test.js
@@ -84,19 +84,21 @@ describe('RESTController', () => {
   });
 
   it('aborts after too many failures', async () => {
-    expect.assertions(1);
+    expect.assertions(3);
     mockFetch([
-      { status: 500 },
-      { status: 500 },
-      { status: 500 },
-      { status: 500 },
-      { status: 500 },
+      { status: 500, response: { code: 1, error: 'Internal server error.' } },
+      { status: 500, response: { code: 1, error: 'Internal server error.' } },
+      { status: 500, response: { code: 1, error: 'Internal server error.' } },
+      { status: 500, response: { code: 1, error: 'Internal server error.' } },
+      { status: 500, response: { code: 1, error: 'Internal server error.' } },
       { status: 200, response: { success: true } },
     ]);
     try {
       await RESTController.ajax('POST', 'users', {});
     } catch (fetchError) {
       expect(fetchError).not.toBe(undefined);
+      expect(fetchError.code).toBe(1);
+      expect(fetchError.error).toBe('Internal server error.');
     }
   });
 
@@ -175,6 +177,23 @@ describe('RESTController', () => {
     } catch (error) {
       expect(error.code).toBe(100);
       expect(error.message.indexOf('XMLHttpRequest failed')).toBe(0);
+    }
+  });
+
+  it('handles 5xx errors after retries', async () => {
+    expect.assertions(2);
+    mockFetch([
+      { status: 500, response: { code: 1, error: 'Internal server error.' } },
+      { status: 500, response: { code: 1, error: 'Internal server error.' } },
+      { status: 500, response: { code: 1, error: 'Internal server error.' } },
+      { status: 500, response: { code: 1, error: 'Internal server error.' } },
+      { status: 500, response: { code: 1, error: 'Internal server error.' } },
+    ]);
+    try {
+      await RESTController.request('GET', 'classes/MyObject', {}, {});
+    } catch (error) {
+      expect(error.code).toBe(1);
+      expect(error.message).toBe('Internal server error.');
     }
   });
 


### PR DESCRIPTION
## Pull Request

- Report security issues [confidentially](https://github.com/parse-community/Parse-SDK-JS/security/policy).
- Any contribution is under this [license](https://github.com/parse-community/Parse-SDK-JS/blob/alpha/LICENSE).
- Link this pull request to an [issue](https://github.com/parse-community/Parse-SDK-JS/issues?q=is%3Aissue).

## Issue
<!-- Add the link to the issue that this PR closes. -->

Parse SDK V7 introduce a regression about 500 errors. The issue was introduced in https://github.com/parse-community/Parse-SDK-JS/issues/2503.

## Approach

Fix to so that server 500 responses are returned in same format as pre v7 release. Even though this is technically a breaking change compared to Parse JS SDK 7.0.0, we don't release it as such, as it is a correction of the accidental breaking change released in 7.0.0.

