### PR TITLE
fix: Sets default value for missing options parameter

### DIFF
--- a/src/Cloud.ts
+++ b/src/Cloud.ts
@@ -46,6 +46,7 @@ export function run<
   T extends (param: { [P in keyof Parameters<T>[0]]: Parameters<T>[0][P] }) => any,
 >(name: string, data: Parameters<T>[0], options?: RequestOptions): Promise<ReturnType<T>>;
 export function run(name: string, data?: any, options?: RequestOptions): Promise<any> {
+  options = options || {}; 
   if (typeof name !== 'string' || name.length === 0) {
     throw new TypeError('Cloud function name must be a string.');
   }

--- a/src/Cloud.ts
+++ b/src/Cloud.ts
@@ -46,7 +46,7 @@ export function run<
   T extends (param: { [P in keyof Parameters<T>[0]]: Parameters<T>[0][P] }) => any,
 >(name: string, data: Parameters<T>[0], options?: RequestOptions): Promise<ReturnType<T>>;
 export function run(name: string, data?: any, options?: RequestOptions): Promise<any> {
-  options = options || {}; 
+  options = options || {};
   if (typeof name !== 'string' || name.length === 0) {
     throw new TypeError('Cloud function name must be a string.');
   }

--- a/src/__tests__/Cloud-test.js
+++ b/src/__tests__/Cloud-test.js
@@ -357,8 +357,8 @@ describe('CloudController', () => {
     expect(options.useMasterKey).toBe(false);
   });
 
-  it('run passes with empty options', () => {
-    const values = [undefined, {}];
+  it('run passes with undefined, null or empty options', () => {
+    const values = [undefined, null, {}];
 
     const mockRun = jest.fn();
     mockRun.mockReturnValue(Promise.resolve({ result: {} }));
@@ -377,7 +377,7 @@ describe('CloudController', () => {
   });
 
   it('run throws with invalid options', () => {
-    const values = [null, []];
+    const values = [[]];
     for (const value of values) {
       expect(() => Cloud.run('myfunction', {}, value)).toThrow();
     }


### PR DESCRIPTION
## Pull Request

- Report security issues [confidentially](https://github.com/parse-community/Parse-SDK-JS/security/policy).
- Any contribution is under this [license](https://github.com/parse-community/Parse-SDK-JS/blob/alpha/LICENSE).
- Link this pull request to an [issue](https://github.com/parse-community/Parse-SDK-JS/issues?q=is%3Aissue).

## Issue
<!-- Add the link to the issue that this PR closes. -->

Closes: https://github.com/parse-community/Parse-SDK-JS/issues/2773

Relates to: https://github.com/parse-community/Parse-SDK-JS/issues/2622


## Approach
<!-- Describe the changes in this PR. -->

This Pull Request puts back a line of code that existed in `Cloud.ts` in [v5.3.0](https://github.com/parse-community/Parse-SDK-JS/blob/5.3.0/src/Cloud.ts) but was removed in [v6.0.0](https://github.com/parse-community/Parse-SDK-JS/blob/6.0.0/src/Cloud.ts).

This removal added a breaking change of the code with different behaviour when the options parameter was null.

## Tasks
<!-- Delete tasks that don't apply. -->

- [ ] Add tests
- [ ] Add changes to documentation (guides, repository pages, code comments)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Cloud.run now tolerates undefined, null, or empty options without causing errors, improving stability when callers omit options. Tests updated to cover these cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->