### PR TITLE
fix: Missing dependencies in transpiled browser code

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,5 @@ out/
 docs/
 .eslintcache
 
+# AI agents
+/.claude

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,8 +10,9 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@babel/runtime-corejs3": "7.28.4",
+        "crypto-js": "4.2.0",
+        "idb-keyval": "6.2.2",
         "react-native-crypto-js": "1.0.0",
-        "uuid": "13.0.0",
         "ws": "8.18.3"
       },
       "devDependencies": {
@@ -45,7 +46,6 @@
         "gulp": "5.0.1",
         "gulp-babel": "8.0.0",
         "gulp-watch": "5.0.1",
-        "idb-keyval": "6.2.2",
         "jasmine": "5.12.0",
         "jasmine-reporters": "2.5.2",
         "jasmine-spec-reporter": "7.0.0",
@@ -15182,9 +15182,7 @@
     "node_modules/crypto-js": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/crypto-js/-/crypto-js-4.2.0.tgz",
-      "integrity": "sha512-KALDyEYgpY+Rlob/iriUtjV6d5Eq+Y191A5g4UqLAi8CyGP9N1+FdVbkc1SxKc2r4YAYqG8JzO2KGL+AizD70Q==",
-      "dev": true,
-      "optional": true
+      "integrity": "sha512-KALDyEYgpY+Rlob/iriUtjV6d5Eq+Y191A5g4UqLAi8CyGP9N1+FdVbkc1SxKc2r4YAYqG8JzO2KGL+AizD70Q=="
     },
     "node_modules/crypto-random-string": {
       "version": "4.0.0",
@@ -20313,7 +20311,6 @@
       "version": "6.2.2",
       "resolved": "https://registry.npmjs.org/idb-keyval/-/idb-keyval-6.2.2.tgz",
       "integrity": "sha512-yjD9nARJ/jb1g+CvD0tlhUHOrJ9Sy0P8T9MF3YaLlHnSRpwPfpTX0XIvpmw3gAJUmEu3FiICLBDPXVwyEvrleg==",
-      "dev": true,
       "license": "Apache-2.0"
     },
     "node_modules/ieee754": {
@@ -34813,18 +34810,6 @@
         "node": ">= 0.4.0"
       }
     },
-    "node_modules/uuid": {
-      "version": "13.0.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-13.0.0.tgz",
-      "integrity": "sha512-XQegIaBTVUjSHliKqcnFqYypAd4S+WCYt5NIeRs6w/UAry7z8Y9j5ZwRRL4kzq9U3sD6v+85er9FvkEaBpji2w==",
-      "funding": [
-        "https://github.com/sponsors/broofa",
-        "https://github.com/sponsors/ctavan"
-      ],
-      "bin": {
-        "uuid": "dist-node/bin/uuid"
-      }
-    },
     "node_modules/v8-to-istanbul": {
       "version": "9.2.0",
       "resolved": "https://registry.npmjs.org/v8-to-istanbul/-/v8-to-istanbul-9.2.0.tgz",
@@ -46637,9 +46622,7 @@
     "crypto-js": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/crypto-js/-/crypto-js-4.2.0.tgz",
-      "integrity": "sha512-KALDyEYgpY+Rlob/iriUtjV6d5Eq+Y191A5g4UqLAi8CyGP9N1+FdVbkc1SxKc2r4YAYqG8JzO2KGL+AizD70Q==",
-      "dev": true,
-      "optional": true
+      "integrity": "sha512-KALDyEYgpY+Rlob/iriUtjV6d5Eq+Y191A5g4UqLAi8CyGP9N1+FdVbkc1SxKc2r4YAYqG8JzO2KGL+AizD70Q=="
     },
     "crypto-random-string": {
       "version": "4.0.0",
@@ -50454,8 +50437,7 @@
     "idb-keyval": {
       "version": "6.2.2",
       "resolved": "https://registry.npmjs.org/idb-keyval/-/idb-keyval-6.2.2.tgz",
-      "integrity": "sha512-yjD9nARJ/jb1g+CvD0tlhUHOrJ9Sy0P8T9MF3YaLlHnSRpwPfpTX0XIvpmw3gAJUmEu3FiICLBDPXVwyEvrleg==",
-      "dev": true
+      "integrity": "sha512-yjD9nARJ/jb1g+CvD0tlhUHOrJ9Sy0P8T9MF3YaLlHnSRpwPfpTX0XIvpmw3gAJUmEu3FiICLBDPXVwyEvrleg=="
     },
     "ieee754": {
       "version": "1.2.1",
@@ -61021,11 +61003,6 @@
       "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
       "integrity": "sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA==",
       "dev": true
-    },
-    "uuid": {
-      "version": "13.0.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-13.0.0.tgz",
-      "integrity": "sha512-XQegIaBTVUjSHliKqcnFqYypAd4S+WCYt5NIeRs6w/UAry7z8Y9j5ZwRRL4kzq9U3sD6v+85er9FvkEaBpji2w=="
     },
     "v8-to-istanbul": {
       "version": "9.2.0",

--- a/package.json
+++ b/package.json
@@ -32,11 +32,12 @@
   },
   "dependencies": {
     "@babel/runtime-corejs3": "7.28.4",
+    "crypto-js": "4.2.0",
+    "idb-keyval": "6.2.2",
     "react-native-crypto-js": "1.0.0",
     "ws": "8.18.3"
   },
   "devDependencies": {
-    "idb-keyval": "6.2.2",
     "@babel/core": "7.28.5",
     "@babel/plugin-proposal-class-properties": "7.18.6",
     "@babel/plugin-transform-runtime": "7.28.5",


### PR DESCRIPTION
## Pull Request

- Report security issues [confidentially](https://github.com/parse-community/Parse-SDK-JS/security/policy).
- Any contribution is under this [license](https://github.com/parse-community/Parse-SDK-JS/blob/alpha/LICENSE).
- Link this pull request to an [issue](https://github.com/parse-community/Parse-SDK-JS/issues?q=is%3Aissue).

## Issue

In #2803, two packages were incorrectly identified as unused:
- crypto-js - Was removed from optionalDependencies
- idb-keyval - Was moved from dependencies to devDependencies

However, both packages are still being imported in the transpiled browser code:
- lib/browser/CryptoController.js:12-13 requires crypto-js/aes and crypto-js/enc-utf8
- lib/browser/IndexedDBStorageController.js:9 requires idb-keyval

When Parse Dashboard installs the Parse SDK as a dependency, these packages are missing, causing webpack to fail with "Module not found" errors.

## Approach

Add both packages as regular dependencies:

- Added "crypto-js": "4.2.0" to dependencies
- Moved "idb-keyval": "6.2.2" back to dependencies (removed from devDependencies)

For `idb-keyval` `optionalDependencies` is not the right solution because:
- Optional dependencies can fail to install - they're meant for truly optional features that the package can work without
- Browser builds DO require crypto-js - it's not optional for them, causing Parse Dashboard to fail

The correct fix is to make `crypto-js` a regular dependency because:
- Modern build tools (webpack, vite) and bundlers properly tree-shake unused code
- The React Native build specifically imports react-native-crypto-js, not crypto-js
- Browser builds need crypto-js to be available, not optional

This is evidenced by the fact that the build process creates separate bundles for each environment, and each environment only bundles what it actually imports.

