### PR TITLE
fix: `ws` package causes React-Native build failure

### DIFF
--- a/src/WebSocketController.ts
+++ b/src/WebSocketController.ts
@@ -1,7 +1,4 @@
 /* global WebSocket */
-import ws from 'ws';
-import SocketWeapp from './Socket.weapp';
-
 let WebSocketController;
 
 try {
@@ -9,9 +6,9 @@ try {
     WebSocketController =
       typeof WebSocket === 'function' || typeof WebSocket === 'object' ? WebSocket : null;
   } else if (process.env.PARSE_BUILD === 'node') {
-    WebSocketController = ws;
+    WebSocketController = require('ws');
   } else if (process.env.PARSE_BUILD === 'weapp') {
-    WebSocketController = SocketWeapp;
+    WebSocketController = require('./Socket.weapp');
   } else if (process.env.PARSE_BUILD === 'react-native') {
     WebSocketController = WebSocket;
   }


### PR DESCRIPTION
## Pull Request

- Report security issues [confidentially](https://github.com/parse-community/Parse-SDK-JS/security/policy).
- Any contribution is under this [license](https://github.com/parse-community/Parse-SDK-JS/blob/alpha/LICENSE).
- Link this pull request to an [issue](https://github.com/parse-community/Parse-SDK-JS/issues?q=is%3Aissue).

## Issue
<!-- Add the link to the issue that this PR closes. -->
Since we don't have tree shaking the ws module gets included in the react-native build when it's not used

Closes: https://github.com/parse-community/Parse-SDK-JS/issues/2633

Before: 
<img width="683" height="256" alt="450291218-be773c1d-e324-4149-a08e-59fbe12c2e01" src="https://github.com/user-attachments/assets/71ae20b9-a24b-46e4-828a-cd30038b6a03" />


After:
<img width="450" height="201" alt="Screenshot 2026-01-08 at 7 16 37 AM" src="https://github.com/user-attachments/assets/ba32929c-bb0a-4e32-9553-e2308915d3cb" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated internal module loading mechanism for improved build compatibility. No changes to functionality or user-facing features.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->