### PR TITLE
docs: Fix incorrect compatibility table

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 [![Snyk Badge](https://snyk.io/test/github/parse-community/Parse-SDK-JS/badge.svg)](https://snyk.io/test/github/parse-community/Parse-SDK-JS)
 [![Coverage](https://codecov.io/gh/parse-community/Parse-SDK-JS/branch/alpha/graph/badge.svg)](https://codecov.io/gh/parse-community/Parse-SDK-JS)
 
-[![Node Version](https://img.shields.io/badge/nodejs-18,_20,_22,_24-green.svg?logo=node.js&style=flat)](https://nodejs.org/)
+[![Node Version](https://img.shields.io/badge/nodejs-20,_22,_24-green.svg?logo=node.js&style=flat)](https://nodejs.org/)
 [![auto-release](https://img.shields.io/badge/%F0%9F%9A%80-auto--release-9e34eb.svg)](https://github.com/parse-community/parse-dashboard/releases)
 
 [![npm latest version](https://img.shields.io/npm/v/parse/latest.svg)](https://www.npmjs.com/package/parse)
@@ -51,10 +51,9 @@ Parse JS SDK is continuously tested with the most recent releases of Node.js to 
 
 | Version    | Latest Version | End-of-Life | Compatible |
 |------------|----------------|-------------|------------|
-| Node.js 18 | 18.20.3        | April 2025  | ✅ Yes      |
-| Node.js 20 | 20.15.0        | April 2026  | ✅ Yes      |
-| Node.js 22 | 22.4.0         | April 2027  | ✅ Yes      |
-| Node.js 24 | 24.0.0         | April 2028  | ✅ Yes      |
+| Node.js 20 | 20.19.0        | April 2026  | ✅ Yes      |
+| Node.js 22 | 22.12.0        | April 2027  | ✅ Yes      |
+| Node.js 24 | 24.1.0         | April 2028  | ✅ Yes      |
 
 ## Getting Started
 


### PR DESCRIPTION
## Pull Request

- Report security issues [confidentially](https://github.com/parse-community/Parse-SDK-JS/security/policy).
- Any contribution is under this [license](https://github.com/parse-community/Parse-SDK-JS/blob/alpha/LICENSE).
- Link this pull request to an [issue](https://github.com/parse-community/Parse-SDK-JS/issues?q=is%3Aissue).

## Issue
<!-- Add the link to the issue that this PR closes. -->
Doesn't match with Version 8 release


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Node.js version compatibility information throughout the project documentation. Removed Node.js 18 from the supported versions list, compatibility table, and version badges. The documentation now reflects support for Node.js 20, 22, and 24. Latest patch version numbers for each of these supported releases have been updated to current versions.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->