### PR TITLE
fix: Missing Node.js type signature for `Parse.initialize` with `masterKey`, `maintenanceKey`

### DIFF
--- a/src/Parse.ts
+++ b/src/Parse.ts
@@ -38,7 +38,97 @@ import StorageController from './StorageController';
 import WebSocketController from './WebSocketController';
 import type { EventuallyQueue } from './CoreManager';
 
-const Parse = {
+/**
+ * The interface for the Parse SDK.
+ * This interface can be augmented in build-specific type definitions (e.g., node.d.ts)
+ * to provide environment-specific type signatures.
+ */
+export interface Parse {
+  ACL: typeof ACL;
+  Analytics: typeof Analytics;
+  AnonymousUtils: typeof AnonymousUtils;
+  Cloud: typeof Cloud;
+  CLP: typeof CLP;
+  CoreManager: typeof CoreManager;
+  Config: typeof Config;
+  Error: typeof ParseError;
+  FacebookUtils: typeof FacebookUtils;
+  File: typeof File;
+  GeoPoint: typeof GeoPoint;
+  Polygon: typeof Polygon;
+  Installation: typeof Installation;
+  LocalDatastore: typeof LocalDatastore;
+  Object: typeof ParseObject;
+  Op: {
+    Set: typeof ParseOp.SetOp;
+    Unset: typeof ParseOp.UnsetOp;
+    Increment: typeof ParseOp.IncrementOp;
+    Add: typeof ParseOp.AddOp;
+    Remove: typeof ParseOp.RemoveOp;
+    AddUnique: typeof ParseOp.AddUniqueOp;
+    Relation: typeof ParseOp.RelationOp;
+  };
+  Push: typeof Push;
+  Query: typeof Query;
+  Relation: typeof Relation;
+  Role: typeof Role;
+  Schema: typeof Schema;
+  Session: typeof Session;
+  Storage: typeof Storage;
+  User: typeof User;
+  LiveQueryClient: typeof LiveQueryClient;
+  IndexedDB: any;
+  Hooks: any;
+  Parse: any;
+
+  EventuallyQueue: EventuallyQueue;
+
+  /**
+   * Call this method first to set up your authentication tokens for Parse.
+   *
+   * @param applicationId Your Parse Application ID.
+   * @param javaScriptKey Your Parse JavaScript Key (Not needed for parse-server)
+   */
+  initialize(applicationId: string, javaScriptKey: string): void;
+
+  _initialize(
+    applicationId: string,
+    javaScriptKey: string,
+    masterKey?: string,
+    maintenanceKey?: string
+  ): void;
+
+  setAsyncStorage(storage: any): void;
+  setLocalDatastoreController(controller: any): void;
+  getServerHealth(): Promise<any>;
+
+  applicationId: string | undefined;
+  javaScriptKey: string | undefined;
+  masterKey: string | undefined;
+  maintenanceKey: string | undefined;
+  serverURL: string | undefined;
+  LiveQuery: ParseLiveQuery;
+  liveQueryServerURL: string | undefined;
+  encryptedUser: boolean;
+  secret: string | undefined;
+  idempotency: boolean | undefined;
+  allowCustomObjectId: boolean | undefined;
+  nodeLogging: boolean | undefined;
+
+  _request(...args: any[]): Promise<any>;
+  _ajax(...args: any[]): Promise<any>;
+  _decode(_: any, value: any): any;
+  _encode(value: any, _: any, disallowObjects?: boolean): any;
+  _getInstallationId(): Promise<string>;
+
+  enableLocalDatastore(polling?: boolean, ms?: number): void;
+  isLocalDatastoreEnabled(): boolean;
+  dumpLocalDatastore(): Promise<any>;
+  enableEncryptedUser(): void;
+  isEncryptedUserEnabled(): boolean;
+}
+
+const Parse: Parse = {
   ACL,
   Analytics,
   AnonymousUtils,

--- a/src/Parse.ts
+++ b/src/Parse.ts
@@ -81,13 +81,19 @@ export interface Parse {
   Hooks: any;
   Parse: any;
 
+  /**
+   * @property {EventuallyQueue} Parse.EventuallyQueue
+   * @static
+   */
   EventuallyQueue: EventuallyQueue;
 
   /**
    * Call this method first to set up your authentication tokens for Parse.
    *
-   * @param applicationId Your Parse Application ID.
-   * @param javaScriptKey Your Parse JavaScript Key (Not needed for parse-server)
+   * @param {string} applicationId Your Parse Application ID.
+   * @param {string} [javaScriptKey] Your Parse JavaScript Key (Not needed for parse-server)
+   * @param {string} [masterKey] Your Parse Master Key. (Node.js only!)
+   * @static
    */
   initialize(applicationId: string, javaScriptKey: string): void;
 
@@ -98,21 +104,101 @@ export interface Parse {
     maintenanceKey?: string
   ): void;
 
+  /**
+   * Call this method to set your AsyncStorage engine
+   * Starting Parse@1.11, the ParseSDK do not provide a React AsyncStorage as the ReactNative module
+   * is not provided at a stable path and changes over versions.
+   *
+   * @param {AsyncStorage} storage a react native async storage.
+   * @static
+   */
   setAsyncStorage(storage: any): void;
+  /**
+   * Call this method to set your LocalDatastoreStorage engine
+   * If using React-Native use {@link Parse.setAsyncStorage Parse.setAsyncStorage()}
+   *
+   * @param {LocalDatastoreController} controller a data storage.
+   * @static
+   */
   setLocalDatastoreController(controller: any): void;
+  /**
+   * Returns information regarding the current server's health
+   *
+   * @returns {Promise}
+   * @static
+   */
   getServerHealth(): Promise<any>;
 
+  /**
+   * @property {string} Parse.applicationId
+   * @static
+   */
   applicationId: string | undefined;
+  /**
+   * @property {string} Parse.javaScriptKey
+   * @static
+   */
   javaScriptKey: string | undefined;
+  /**
+   * @property {string} Parse.masterKey
+   * @static
+   */
   masterKey: string | undefined;
+  /**
+   * @property {string} Parse.maintenanceKey
+   * @static
+   */
   maintenanceKey: string | undefined;
+  /**
+   * @property {string} Parse.serverURL
+   * @static
+   */
   serverURL: string | undefined;
+  /**
+   * @property {ParseLiveQuery} Parse.LiveQuery
+   * @static
+   */
   LiveQuery: ParseLiveQuery;
+  /**
+   * @property {string} Parse.liveQueryServerURL
+   * @static
+   */
   liveQueryServerURL: string | undefined;
+  /**
+   * @property {boolean} Parse.encryptedUser
+   * @static
+   */
   encryptedUser: boolean;
+  /**
+   * @property {string} Parse.secret
+   * @static
+   */
   secret: string | undefined;
+  /**
+   * @property {boolean} Parse.idempotency
+   * @static
+   */
   idempotency: boolean | undefined;
+  /**
+   * @property {boolean} Parse.allowCustomObjectId
+   * @static
+   */
   allowCustomObjectId: boolean | undefined;
+  /**
+   * Setting this property to `true` enables enhanced logging for `Parse.Object`
+   * in Node.js environments. Specifically, it will log:
+   *
+   * ```
+   * ParseObject: className: <CLASS_NAME>, id: <OBJECT_ID>
+   * Attributes: <OBJECT_ATTRIBUTES>
+   * ```
+   *
+   * @warning This should not be enabled in production environments as this may
+   * expose sensitive information in server logs.
+   *
+   * @property {boolean} Parse.nodeLogging
+   * @static
+   */
   nodeLogging: boolean | undefined;
 
   _request(...args: any[]): Promise<any>;
@@ -121,10 +207,46 @@ export interface Parse {
   _encode(value: any, _: any, disallowObjects?: boolean): any;
   _getInstallationId(): Promise<string>;
 
+  /**
+   * Enable pinning in your application.
+   * This must be called after `Parse.initialize` in your application.
+   *
+   * @param [polling] Allow pinging the server /health endpoint. Default true
+   * @param [ms] Milliseconds to ping the server. Default 2000ms
+   * @static
+   */
   enableLocalDatastore(polling?: boolean, ms?: number): void;
+  /**
+   * Flag that indicates whether Local Datastore is enabled.
+   *
+   * @static
+   * @returns {boolean}
+   */
   isLocalDatastoreEnabled(): boolean;
+  /**
+   * Gets all contents from Local Datastore
+   *
+   * <pre>
+   * await Parse.dumpLocalDatastore();
+   * </pre>
+   *
+   * @static
+   * @returns {object}
+   */
   dumpLocalDatastore(): Promise<any>;
+  /**
+   * Enable the current user encryption.
+   * This must be called before login any user.
+   *
+   * @static
+   */
   enableEncryptedUser(): void;
+  /**
+   * Flag that indicates whether Encrypted User is enabled.
+   *
+   * @static
+   * @returns {boolean}
+   */
   isEncryptedUserEnabled(): boolean;
 }
 

--- a/src/Parse.ts
+++ b/src/Parse.ts
@@ -456,7 +456,7 @@ const Parse: Parse = {
   },
   enableLocalDatastore(polling?: boolean, ms?: number) {
     if (!this.applicationId) {
-      console.log("'enableLocalDataStore' must be called after 'initialize'");
+      console.log("'enableLocalDatastore' must be called after 'initialize'");
       return;
     }
     if (!this.LocalDatastore.isEnabled) {

--- a/src/Parse.ts
+++ b/src/Parse.ts
@@ -288,10 +288,6 @@ const Parse: Parse = {
   Hooks: undefined,
   Parse: undefined,
 
-  /**
-   * @property {EventuallyQueue} Parse.EventuallyQueue
-   * @static
-   */
   set EventuallyQueue(queue: EventuallyQueue) {
     CoreManager.setEventuallyQueue(queue);
   },
@@ -300,14 +296,6 @@ const Parse: Parse = {
     return CoreManager.getEventuallyQueue();
   },
 
-  /**
-   * Call this method first to set up your authentication tokens for Parse.
-   *
-   * @param {string} applicationId Your Parse Application ID.
-   * @param {string} [javaScriptKey] Your Parse JavaScript Key (Not needed for parse-server)
-   * @param {string} [masterKey] Your Parse Master Key. (Node.js only!)
-   * @static
-   */
   initialize(applicationId: string, javaScriptKey: string) {
     if (
       process.env.PARSE_BUILD === 'browser' &&
@@ -350,43 +338,18 @@ const Parse: Parse = {
     }
   },
 
-  /**
-   * Call this method to set your AsyncStorage engine
-   * Starting Parse@1.11, the ParseSDK do not provide a React AsyncStorage as the ReactNative module
-   * is not provided at a stable path and changes over versions.
-   *
-   * @param {AsyncStorage} storage a react native async storage.
-   * @static
-   */
   setAsyncStorage(storage: any) {
     CoreManager.setAsyncStorage(storage);
   },
 
-  /**
-   * Call this method to set your LocalDatastoreStorage engine
-   * If using React-Native use {@link Parse.setAsyncStorage Parse.setAsyncStorage()}
-   *
-   * @param {LocalDatastoreController} controller a data storage.
-   * @static
-   */
   setLocalDatastoreController(controller: any) {
     CoreManager.setLocalDatastoreController(controller);
   },
 
-  /**
-   * Returns information regarding the current server's health
-   *
-   * @returns {Promise}
-   * @static
-   */
   getServerHealth() {
     return CoreManager.getRESTController().request('GET', 'health');
   },
 
-  /**
-   * @property {string} Parse.applicationId
-   * @static
-   */
   set applicationId(value) {
     CoreManager.set('APPLICATION_ID', value);
   },
@@ -394,10 +357,6 @@ const Parse: Parse = {
     return CoreManager.get('APPLICATION_ID');
   },
 
-  /**
-   * @property {string} Parse.javaScriptKey
-   * @static
-   */
   set javaScriptKey(value) {
     CoreManager.set('JAVASCRIPT_KEY', value);
   },
@@ -405,10 +364,6 @@ const Parse: Parse = {
     return CoreManager.get('JAVASCRIPT_KEY');
   },
 
-  /**
-   * @property {string} Parse.masterKey
-   * @static
-   */
   set masterKey(value) {
     CoreManager.set('MASTER_KEY', value);
   },
@@ -416,10 +371,6 @@ const Parse: Parse = {
     return CoreManager.get('MASTER_KEY');
   },
 
-  /**
-   * @property {string} Parse.maintenanceKey
-   * @static
-   */
   set maintenanceKey(value) {
     CoreManager.set('MAINTENANCE_KEY', value);
   },
@@ -427,10 +378,6 @@ const Parse: Parse = {
     return CoreManager.get('MAINTENANCE_KEY');
   },
 
-  /**
-   * @property {string} Parse.serverURL
-   * @static
-   */
   set serverURL(value) {
     CoreManager.set('SERVER_URL', value);
   },
@@ -438,10 +385,6 @@ const Parse: Parse = {
     return CoreManager.get('SERVER_URL');
   },
 
-  /**
-   * @property {ParseLiveQuery} Parse.LiveQuery
-   * @static
-   */
   set LiveQuery(liveQuery: ParseLiveQuery) {
     CoreManager.setLiveQuery(liveQuery);
   },
@@ -449,10 +392,6 @@ const Parse: Parse = {
     return CoreManager.getLiveQuery();
   },
 
-  /**
-   * @property {string} Parse.liveQueryServerURL
-   * @static
-   */
   set liveQueryServerURL(value) {
     CoreManager.set('LIVEQUERY_SERVER_URL', value);
   },
@@ -460,10 +399,6 @@ const Parse: Parse = {
     return CoreManager.get('LIVEQUERY_SERVER_URL');
   },
 
-  /**
-   * @property {boolean} Parse.encryptedUser
-   * @static
-   */
   set encryptedUser(value: boolean) {
     CoreManager.set('ENCRYPTED_USER', value);
   },
@@ -471,10 +406,6 @@ const Parse: Parse = {
     return CoreManager.get('ENCRYPTED_USER');
   },
 
-  /**
-   * @property {string} Parse.secret
-   * @static
-   */
   set secret(value) {
     CoreManager.set('ENCRYPTED_KEY', value);
   },
@@ -482,10 +413,6 @@ const Parse: Parse = {
     return CoreManager.get('ENCRYPTED_KEY');
   },
 
-  /**
-   * @property {boolean} Parse.idempotency
-   * @static
-   */
   set idempotency(value) {
     CoreManager.set('IDEMPOTENCY', value);
   },
@@ -493,10 +420,6 @@ const Parse: Parse = {
     return CoreManager.get('IDEMPOTENCY');
   },
 
-  /**
-   * @property {boolean} Parse.allowCustomObjectId
-   * @static
-   */
   set allowCustomObjectId(value) {
     CoreManager.set('ALLOW_CUSTOM_OBJECT_ID', value);
   },
@@ -504,21 +427,6 @@ const Parse: Parse = {
     return CoreManager.get('ALLOW_CUSTOM_OBJECT_ID');
   },
 
-  /**
-   * Setting this property to `true` enables enhanced logging for `Parse.Object`
-   * in Node.js environments. Specifically, it will log:
-   *
-   * ```
-   * ParseObject: className: <CLASS_NAME>, id: <OBJECT_ID>
-   * Attributes: <OBJECT_ATTRIBUTES>
-   * ```
-   *
-   * @warning This should not be enabled in production environments as this may
-   * expose sensitive information in server logs.
-   *
-   * @property {boolean} Parse.nodeLogging
-   * @static
-   */
   set nodeLogging(value) {
     CoreManager.set('NODE_LOGGING', value);
   },
@@ -546,14 +454,6 @@ const Parse: Parse = {
   _getInstallationId() {
     return CoreManager.getInstallationController().currentInstallationId();
   },
-  /**
-   * Enable pinning in your application.
-   * This must be called after `Parse.initialize` in your application.
-   *
-   * @param [polling] Allow pinging the server /health endpoint. Default true
-   * @param [ms] Milliseconds to ping the server. Default 2000ms
-   * @static
-   */
   enableLocalDatastore(polling?: boolean, ms?: number) {
     if (!this.applicationId) {
       console.log("'enableLocalDataStore' must be called after 'initialize'");
@@ -566,25 +466,9 @@ const Parse: Parse = {
       }
     }
   },
-  /**
-   * Flag that indicates whether Local Datastore is enabled.
-   *
-   * @static
-   * @returns {boolean}
-   */
   isLocalDatastoreEnabled(): boolean {
     return this.LocalDatastore.isEnabled;
   },
-  /**
-   * Gets all contents from Local Datastore
-   *
-   * <pre>
-   * await Parse.dumpLocalDatastore();
-   * </pre>
-   *
-   * @static
-   * @returns {object}
-   */
   dumpLocalDatastore() {
     if (!this.LocalDatastore.isEnabled) {
       console.log('Parse.enableLocalDatastore() must be called first');
@@ -594,22 +478,10 @@ const Parse: Parse = {
     }
   },
 
-  /**
-   * Enable the current user encryption.
-   * This must be called before login any user.
-   *
-   * @static
-   */
   enableEncryptedUser() {
     this.encryptedUser = true;
   },
 
-  /**
-   * Flag that indicates whether Encrypted User is enabled.
-   *
-   * @static
-   * @returns {boolean}
-   */
   isEncryptedUserEnabled() {
     return this.encryptedUser;
   },

--- a/src/Parse.ts
+++ b/src/Parse.ts
@@ -91,8 +91,8 @@ export interface Parse {
    * Call this method first to set up your authentication tokens for Parse.
    *
    * @param {string} applicationId Your Parse Application ID.
-   * @param {string} [javaScriptKey] Your Parse JavaScript Key (Not needed for parse-server)
-   * @param {string} [masterKey] Your Parse Master Key. (Node.js only!)
+   * @param {string} javaScriptKey Your Parse JavaScript Key (Not needed for parse-server)
+   * @note Node.js builds (parse/node) support additional parameters: masterKey and maintenanceKey.
    * @static
    */
   initialize(applicationId: string, javaScriptKey: string): void;

--- a/src/__tests__/Parse-test.js
+++ b/src/__tests__/Parse-test.js
@@ -119,7 +119,7 @@ describe('Parse module', () => {
     Parse.initialize(null, null);
     Parse.enableLocalDatastore();
     expect(console.log).toHaveBeenCalledWith(
-      "'enableLocalDataStore' must be called after 'initialize'"
+      "'enableLocalDatastore' must be called after 'initialize'"
     );
 
     Parse.initialize('A', 'B');

--- a/types/Parse.d.ts
+++ b/types/Parse.d.ts
@@ -1,14 +1,18 @@
 import * as ParseOp from './ParseOp';
 import ACL from './ParseACL';
 import * as Analytics from './Analytics';
+import AnonymousUtils from './AnonymousUtils';
 import * as Cloud from './Cloud';
 import CLP from './ParseCLP';
+import CoreManager from './CoreManager';
 import Config from './ParseConfig';
 import ParseError from './ParseError';
+import FacebookUtils from './FacebookUtils';
 import File from './ParseFile';
 import GeoPoint from './ParseGeoPoint';
 import Polygon from './ParsePolygon';
 import Installation from './ParseInstallation';
+import LocalDatastore from './LocalDatastore';
 import ParseObject from './ParseObject';
 import * as Push from './Push';
 import Query from './ParseQuery';
@@ -16,174 +20,31 @@ import Relation from './ParseRelation';
 import Role from './ParseRole';
 import Schema from './ParseSchema';
 import Session from './ParseSession';
+import Storage from './Storage';
 import User from './ParseUser';
 import ParseLiveQuery from './ParseLiveQuery';
 import LiveQueryClient from './LiveQueryClient';
 import type { EventuallyQueue } from './CoreManager';
-declare const Parse: {
+/**
+ * The interface for the Parse SDK.
+ * This interface can be augmented in build-specific type definitions (e.g., node.d.ts)
+ * to provide environment-specific type signatures.
+ */
+export interface Parse {
     ACL: typeof ACL;
     Analytics: typeof Analytics;
-    AnonymousUtils: {
-        isLinked(user: User): boolean;
-        logIn(options?: import("./RESTController").RequestOptions): Promise<User>;
-        link(user: User, options?: import("./RESTController").RequestOptions): Promise<User>;
-        isRegistered(): boolean;
-        _getAuthProvider(): {
-            restoreAuthentication(): boolean;
-            getAuthType(): string;
-            getAuthData(): {
-                authData: {
-                    id: string;
-                };
-            };
-        };
-    };
+    AnonymousUtils: typeof AnonymousUtils;
     Cloud: typeof Cloud;
     CLP: typeof CLP;
-    CoreManager: {
-        get: (key: string) => any;
-        set: (key: string, value: any) => void;
-        setIfNeeded: (key: string, value: any) => any;
-        setAnalyticsController(controller: import("./CoreManager").AnalyticsController): void;
-        getAnalyticsController(): import("./CoreManager").AnalyticsController;
-        setCloudController(controller: import("./CoreManager").CloudController): void;
-        getCloudController(): import("./CoreManager").CloudController;
-        setConfigController(controller: import("./CoreManager").ConfigController): void;
-        getConfigController(): import("./CoreManager").ConfigController;
-        setCryptoController(controller: import("./CoreManager").CryptoController): void;
-        getCryptoController(): import("./CoreManager").CryptoController;
-        setEventEmitter(eventEmitter: any): void;
-        getEventEmitter(): any;
-        setFileController(controller: import("./CoreManager").FileController): void;
-        setEventuallyQueue(controller: EventuallyQueue): void;
-        getEventuallyQueue(): EventuallyQueue;
-        getFileController(): import("./CoreManager").FileController;
-        setInstallationController(controller: import("./CoreManager").InstallationController): void;
-        getInstallationController(): import("./CoreManager").InstallationController;
-        setLiveQuery(liveQuery: any): void;
-        getLiveQuery(): any;
-        setObjectController(controller: import("./CoreManager").ObjectController): void;
-        getObjectController(): import("./CoreManager").ObjectController;
-        setObjectStateController(controller: import("./CoreManager").ObjectStateController): void;
-        getObjectStateController(): import("./CoreManager").ObjectStateController;
-        setPushController(controller: import("./CoreManager").PushController): void;
-        getPushController(): import("./CoreManager").PushController;
-        setQueryController(controller: import("./CoreManager").QueryController): void;
-        getQueryController(): import("./CoreManager").QueryController;
-        setRESTController(controller: import("./CoreManager").RESTController): void;
-        getRESTController(): import("./CoreManager").RESTController;
-        setSchemaController(controller: import("./CoreManager").SchemaController): void;
-        getSchemaController(): import("./CoreManager").SchemaController;
-        setSessionController(controller: import("./CoreManager").SessionController): void;
-        getSessionController(): import("./CoreManager").SessionController;
-        setStorageController(controller: {
-            async: 0;
-            getItem: (path: string) => string | null;
-            setItem: (path: string, value: string) => void;
-            removeItem: (path: string) => void;
-            getItemAsync?: (path: string) => Promise<string | null>;
-            setItemAsync?: (path: string, value: string) => Promise<void>;
-            removeItemAsync?: (path: string) => Promise<void>;
-            clear: () => void;
-            getAllKeys?: () => string[];
-            getAllKeysAsync?: () => Promise<string[]>;
-        } | {
-            async: 1;
-            getItem?: (path: string) => string | null;
-            setItem?: (path: string, value: string) => void;
-            removeItem?: (path: string) => void;
-            getItemAsync: (path: string) => Promise<string | null>;
-            setItemAsync: (path: string, value: string) => Promise<void>;
-            removeItemAsync: (path: string) => Promise<void>;
-            clear: () => void;
-            getAllKeys?: () => string[];
-            getAllKeysAsync?: () => Promise<string[]>;
-        }): void;
-        setLocalDatastoreController(controller: import("./CoreManager").LocalDatastoreController): void;
-        getLocalDatastoreController(): import("./CoreManager").LocalDatastoreController;
-        setLocalDatastore(store: any): void;
-        getLocalDatastore(): any;
-        getStorageController(): {
-            async: 0;
-            getItem: (path: string) => string | null;
-            setItem: (path: string, value: string) => void;
-            removeItem: (path: string) => void;
-            getItemAsync?: (path: string) => Promise<string | null>;
-            setItemAsync?: (path: string, value: string) => Promise<void>;
-            removeItemAsync?: (path: string) => Promise<void>;
-            clear: () => void;
-            getAllKeys?: () => string[];
-            getAllKeysAsync?: () => Promise<string[]>;
-        } | {
-            async: 1;
-            getItem?: (path: string) => string | null;
-            setItem?: (path: string, value: string) => void;
-            removeItem?: (path: string) => void;
-            getItemAsync: (path: string) => Promise<string | null>;
-            setItemAsync: (path: string, value: string) => Promise<void>;
-            removeItemAsync: (path: string) => Promise<void>;
-            clear: () => void;
-            getAllKeys?: () => string[];
-            getAllKeysAsync?: () => Promise<string[]>;
-        };
-        setAsyncStorage(storage: import("./CoreManager").AsyncStorageType): void;
-        getAsyncStorage(): import("./CoreManager").AsyncStorageType;
-        setWebSocketController(controller: new (url: string | URL, protocols?: string | string[] | undefined) => import("./CoreManager").WebSocketController): void;
-        getWebSocketController(): new (url: string | URL, protocols?: string | string[] | undefined) => import("./CoreManager").WebSocketController;
-        setUserController(controller: import("./CoreManager").UserController): void;
-        getUserController(): import("./CoreManager").UserController;
-        setLiveQueryController(controller: import("./CoreManager").LiveQueryControllerType): void;
-        getLiveQueryController(): import("./CoreManager").LiveQueryControllerType;
-        setHooksController(controller: import("./CoreManager").HooksController): void;
-        getHooksController(): import("./CoreManager").HooksController;
-        setParseOp(op: any): void;
-        getParseOp(): any;
-        setParseObject(object: any): void;
-        getParseObject(): any;
-        setParseQuery(query: any): void;
-        getParseQuery(): any;
-        setParseRole(role: any): void;
-        getParseRole(): any;
-        setParseUser(user: any): void;
-        getParseUser(): any;
-    };
+    CoreManager: typeof CoreManager;
     Config: typeof Config;
     Error: typeof ParseError;
-    FacebookUtils: {
-        init(options: any): void;
-        isLinked(user: any): any;
-        logIn(permissions: any, options: any): Promise<User<import("./ParseObject").Attributes>>;
-        link(user: any, permissions: any, options: any): any;
-        unlink: (user: any, options: any) => any;
-        _getAuthProvider(): import("./ParseUser").AuthProvider;
-    };
+    FacebookUtils: typeof FacebookUtils;
     File: typeof File;
     GeoPoint: typeof GeoPoint;
     Polygon: typeof Polygon;
     Installation: typeof Installation;
-    LocalDatastore: {
-        isEnabled: boolean;
-        isSyncing: boolean;
-        fromPinWithName(name: string): Promise<any[]>;
-        pinWithName(name: string, value: any): Promise<void>;
-        unPinWithName(name: string): Promise<void>;
-        _getAllContents(): Promise<any>;
-        _getRawStorage(): Promise<any>;
-        _clear(): Promise<void>;
-        _handlePinAllWithName(name: string, objects: ParseObject[]): Promise<void>;
-        _handleUnPinAllWithName(name: string, objects: ParseObject[]): Promise<any[]>;
-        _getChildren(object: ParseObject): any;
-        _traverse(object: any, encountered: any): void;
-        _serializeObjectsFromPinName(name: string): Promise<any[]>;
-        _serializeObject(objectKey: string, localDatastore: any): Promise<any>;
-        _updateObjectIfPinned(object: ParseObject): Promise<void>;
-        _destroyObjectIfPinned(object: ParseObject): Promise<any[]>;
-        _updateLocalIdForObject(localId: string, object: ParseObject): Promise<any[]>;
-        updateFromServer(): Promise<void>;
-        getKeyForObject(object: any): string;
-        getPinName(pinName?: string): string;
-        checkIfEnabled(): any;
-    };
+    LocalDatastore: typeof LocalDatastore;
     Object: typeof ParseObject;
     Op: {
         Set: typeof ParseOp.SetOp;
@@ -200,179 +61,46 @@ declare const Parse: {
     Role: typeof Role;
     Schema: typeof Schema;
     Session: typeof Session;
-    Storage: {
-        async(): boolean;
-        getItem(path: string): string | null;
-        getItemAsync(path: string): Promise<string | null>;
-        setItem(path: string, value: string): void;
-        setItemAsync(path: string, value: string): Promise<void>;
-        removeItem(path: string): void;
-        removeItemAsync(path: string): Promise<void>;
-        getAllKeys(): string[];
-        getAllKeysAsync(): Promise<string[]>;
-        generatePath(path: string): string;
-        _clear(): void;
-    };
+    Storage: typeof Storage;
     User: typeof User;
     LiveQueryClient: typeof LiveQueryClient;
     IndexedDB: any;
     Hooks: any;
     Parse: any;
-    /**
-     * @property {EventuallyQueue} Parse.EventuallyQueue
-     * @static
-     */
     EventuallyQueue: EventuallyQueue;
     /**
      * Call this method first to set up your authentication tokens for Parse.
      *
-     * @param {string} applicationId Your Parse Application ID.
-     * @param {string} [javaScriptKey] Your Parse JavaScript Key (Not needed for parse-server)
-     * @param {string} [masterKey] Your Parse Master Key. (Node.js only!)
-     * @static
+     * @param applicationId Your Parse Application ID.
+     * @param javaScriptKey Your Parse JavaScript Key (Not needed for parse-server)
      */
     initialize(applicationId: string, javaScriptKey: string): void;
     _initialize(applicationId: string, javaScriptKey: string, masterKey?: string, maintenanceKey?: string): void;
-    /**
-     * Call this method to set your AsyncStorage engine
-     * Starting Parse@1.11, the ParseSDK do not provide a React AsyncStorage as the ReactNative module
-     * is not provided at a stable path and changes over versions.
-     *
-     * @param {AsyncStorage} storage a react native async storage.
-     * @static
-     */
     setAsyncStorage(storage: any): void;
-    /**
-     * Call this method to set your LocalDatastoreStorage engine
-     * If using React-Native use {@link Parse.setAsyncStorage Parse.setAsyncStorage()}
-     *
-     * @param {LocalDatastoreController} controller a data storage.
-     * @static
-     */
     setLocalDatastoreController(controller: any): void;
-    /**
-     * Returns information regarding the current server's health
-     *
-     * @returns {Promise}
-     * @static
-     */
     getServerHealth(): Promise<any>;
-    /**
-     * @property {string} Parse.applicationId
-     * @static
-     */
-    applicationId: any;
-    /**
-     * @property {string} Parse.javaScriptKey
-     * @static
-     */
-    javaScriptKey: any;
-    /**
-     * @property {string} Parse.masterKey
-     * @static
-     */
-    masterKey: any;
-    /**
-     * @property {string} Parse.maintenanceKey
-     * @static
-     */
-    maintenanceKey: any;
-    /**
-     * @property {string} Parse.serverURL
-     * @static
-     */
-    serverURL: any;
-    /**
-     * @property {ParseLiveQuery} Parse.LiveQuery
-     * @static
-     */
+    applicationId: string | undefined;
+    javaScriptKey: string | undefined;
+    masterKey: string | undefined;
+    maintenanceKey: string | undefined;
+    serverURL: string | undefined;
     LiveQuery: ParseLiveQuery;
-    /**
-     * @property {string} Parse.liveQueryServerURL
-     * @static
-     */
-    liveQueryServerURL: any;
-    /**
-     * @property {boolean} Parse.encryptedUser
-     * @static
-     */
+    liveQueryServerURL: string | undefined;
     encryptedUser: boolean;
-    /**
-     * @property {string} Parse.secret
-     * @static
-     */
-    secret: any;
-    /**
-     * @property {boolean} Parse.idempotency
-     * @static
-     */
-    idempotency: any;
-    /**
-     * @property {boolean} Parse.allowCustomObjectId
-     * @static
-     */
-    allowCustomObjectId: any;
-    /**
-     * Setting this property to `true` enables enhanced logging for `Parse.Object`
-     * in Node.js environments. Specifically, it will log:
-     *
-     * ```
-     * ParseObject: className: <CLASS_NAME>, id: <OBJECT_ID>
-     * Attributes: <OBJECT_ATTRIBUTES>
-     * ```
-     *
-     * @warning This should not be enabled in production environments as this may
-     * expose sensitive information in server logs.
-     *
-     * @property {boolean} Parse.nodeLogging
-     * @static
-     */
-    nodeLogging: any;
-    _request(...args: any[]): any;
-    _ajax(...args: any[]): any;
+    secret: string | undefined;
+    idempotency: boolean | undefined;
+    allowCustomObjectId: boolean | undefined;
+    nodeLogging: boolean | undefined;
+    _request(...args: any[]): Promise<any>;
+    _ajax(...args: any[]): Promise<any>;
     _decode(_: any, value: any): any;
-    _encode(value: any, _: any, disallowObjects: any): any;
+    _encode(value: any, _: any, disallowObjects?: boolean): any;
     _getInstallationId(): Promise<string>;
-    /**
-     * Enable pinning in your application.
-     * This must be called after `Parse.initialize` in your application.
-     *
-     * @param [polling] Allow pinging the server /health endpoint. Default true
-     * @param [ms] Milliseconds to ping the server. Default 2000ms
-     * @static
-     */
     enableLocalDatastore(polling?: boolean, ms?: number): void;
-    /**
-     * Flag that indicates whether Local Datastore is enabled.
-     *
-     * @static
-     * @returns {boolean}
-     */
     isLocalDatastoreEnabled(): boolean;
-    /**
-     * Gets all contents from Local Datastore
-     *
-     * <pre>
-     * await Parse.dumpLocalDatastore();
-     * </pre>
-     *
-     * @static
-     * @returns {object}
-     */
     dumpLocalDatastore(): Promise<any>;
-    /**
-     * Enable the current user encryption.
-     * This must be called before login any user.
-     *
-     * @static
-     */
     enableEncryptedUser(): void;
-    /**
-     * Flag that indicates whether Encrypted User is enabled.
-     *
-     * @static
-     * @returns {boolean}
-     */
-    isEncryptedUserEnabled(): any;
-};
+    isEncryptedUserEnabled(): boolean;
+}
+declare const Parse: Parse;
 export default Parse;

--- a/types/Parse.d.ts
+++ b/types/Parse.d.ts
@@ -76,8 +76,8 @@ export interface Parse {
      * Call this method first to set up your authentication tokens for Parse.
      *
      * @param {string} applicationId Your Parse Application ID.
-     * @param {string} [javaScriptKey] Your Parse JavaScript Key (Not needed for parse-server)
-     * @param {string} [masterKey] Your Parse Master Key. (Node.js only!)
+     * @param {string} javaScriptKey Your Parse JavaScript Key (Not needed for parse-server)
+     * @note Node.js builds (parse/node) support additional parameters: masterKey and maintenanceKey.
      * @static
      */
     initialize(applicationId: string, javaScriptKey: string): void;

--- a/types/Parse.d.ts
+++ b/types/Parse.d.ts
@@ -67,39 +67,161 @@ export interface Parse {
     IndexedDB: any;
     Hooks: any;
     Parse: any;
+    /**
+     * @property {EventuallyQueue} Parse.EventuallyQueue
+     * @static
+     */
     EventuallyQueue: EventuallyQueue;
     /**
      * Call this method first to set up your authentication tokens for Parse.
      *
-     * @param applicationId Your Parse Application ID.
-     * @param javaScriptKey Your Parse JavaScript Key (Not needed for parse-server)
+     * @param {string} applicationId Your Parse Application ID.
+     * @param {string} [javaScriptKey] Your Parse JavaScript Key (Not needed for parse-server)
+     * @param {string} [masterKey] Your Parse Master Key. (Node.js only!)
+     * @static
      */
     initialize(applicationId: string, javaScriptKey: string): void;
     _initialize(applicationId: string, javaScriptKey: string, masterKey?: string, maintenanceKey?: string): void;
+    /**
+     * Call this method to set your AsyncStorage engine
+     * Starting Parse@1.11, the ParseSDK do not provide a React AsyncStorage as the ReactNative module
+     * is not provided at a stable path and changes over versions.
+     *
+     * @param {AsyncStorage} storage a react native async storage.
+     * @static
+     */
     setAsyncStorage(storage: any): void;
+    /**
+     * Call this method to set your LocalDatastoreStorage engine
+     * If using React-Native use {@link Parse.setAsyncStorage Parse.setAsyncStorage()}
+     *
+     * @param {LocalDatastoreController} controller a data storage.
+     * @static
+     */
     setLocalDatastoreController(controller: any): void;
+    /**
+     * Returns information regarding the current server's health
+     *
+     * @returns {Promise}
+     * @static
+     */
     getServerHealth(): Promise<any>;
+    /**
+     * @property {string} Parse.applicationId
+     * @static
+     */
     applicationId: string | undefined;
+    /**
+     * @property {string} Parse.javaScriptKey
+     * @static
+     */
     javaScriptKey: string | undefined;
+    /**
+     * @property {string} Parse.masterKey
+     * @static
+     */
     masterKey: string | undefined;
+    /**
+     * @property {string} Parse.maintenanceKey
+     * @static
+     */
     maintenanceKey: string | undefined;
+    /**
+     * @property {string} Parse.serverURL
+     * @static
+     */
     serverURL: string | undefined;
+    /**
+     * @property {ParseLiveQuery} Parse.LiveQuery
+     * @static
+     */
     LiveQuery: ParseLiveQuery;
+    /**
+     * @property {string} Parse.liveQueryServerURL
+     * @static
+     */
     liveQueryServerURL: string | undefined;
+    /**
+     * @property {boolean} Parse.encryptedUser
+     * @static
+     */
     encryptedUser: boolean;
+    /**
+     * @property {string} Parse.secret
+     * @static
+     */
     secret: string | undefined;
+    /**
+     * @property {boolean} Parse.idempotency
+     * @static
+     */
     idempotency: boolean | undefined;
+    /**
+     * @property {boolean} Parse.allowCustomObjectId
+     * @static
+     */
     allowCustomObjectId: boolean | undefined;
+    /**
+     * Setting this property to `true` enables enhanced logging for `Parse.Object`
+     * in Node.js environments. Specifically, it will log:
+     *
+     * ```
+     * ParseObject: className: <CLASS_NAME>, id: <OBJECT_ID>
+     * Attributes: <OBJECT_ATTRIBUTES>
+     * ```
+     *
+     * @warning This should not be enabled in production environments as this may
+     * expose sensitive information in server logs.
+     *
+     * @property {boolean} Parse.nodeLogging
+     * @static
+     */
     nodeLogging: boolean | undefined;
     _request(...args: any[]): Promise<any>;
     _ajax(...args: any[]): Promise<any>;
     _decode(_: any, value: any): any;
     _encode(value: any, _: any, disallowObjects?: boolean): any;
     _getInstallationId(): Promise<string>;
+    /**
+     * Enable pinning in your application.
+     * This must be called after `Parse.initialize` in your application.
+     *
+     * @param [polling] Allow pinging the server /health endpoint. Default true
+     * @param [ms] Milliseconds to ping the server. Default 2000ms
+     * @static
+     */
     enableLocalDatastore(polling?: boolean, ms?: number): void;
+    /**
+     * Flag that indicates whether Local Datastore is enabled.
+     *
+     * @static
+     * @returns {boolean}
+     */
     isLocalDatastoreEnabled(): boolean;
+    /**
+     * Gets all contents from Local Datastore
+     *
+     * <pre>
+     * await Parse.dumpLocalDatastore();
+     * </pre>
+     *
+     * @static
+     * @returns {object}
+     */
     dumpLocalDatastore(): Promise<any>;
+    /**
+     * Enable the current user encryption.
+     * This must be called before login any user.
+     *
+     * @static
+     */
     enableEncryptedUser(): void;
+    /**
+     * Flag that indicates whether Encrypted User is enabled.
+     *
+     * @static
+     * @returns {boolean}
+     */
     isEncryptedUserEnabled(): boolean;
 }
 declare const Parse: Parse;

--- a/types/node.d.ts
+++ b/types/node.d.ts
@@ -1,5 +1,19 @@
 import * as parse from './index';
 
+// Augment Parse interface for Node.js builds
+// In Node.js, Parse.initialize is reassigned to Parse._initialize at runtime,
+// which accepts masterKey and maintenanceKey parameters
+declare module './Parse' {
+  interface Parse {
+    initialize(
+      applicationId: string,
+      javaScriptKey?: string,
+      masterKey?: string,
+      maintenanceKey?: string
+    ): void;
+  }
+}
+
 // Augment Cloud module to include server-side types for parse/node
 declare module './Cloud' {
   // Request types - alias to CloudCode definitions

--- a/types/node.d.ts
+++ b/types/node.d.ts
@@ -5,6 +5,15 @@ import * as parse from './index';
 // which accepts masterKey and maintenanceKey parameters
 declare module './Parse' {
   interface Parse {
+    /**
+     * Call this method first to set up your authentication tokens for Parse.
+     *
+     * @param {string} applicationId Your Parse Application ID.
+     * @param {string} [javaScriptKey] Your Parse JavaScript Key (Not needed for parse-server)
+     * @param {string} [masterKey] Your Parse Master Key.
+     * @param {string} [maintenanceKey] Your Parse Maintenance Key.
+     * @static
+     */
     initialize(
       applicationId: string,
       javaScriptKey?: string,

--- a/types/tests.ts
+++ b/types/tests.ts
@@ -2343,3 +2343,24 @@ function LiveQueryEvents() {
   }
 }
 
+function testInitialize() {
+  // Browser - 2 params (strict)
+  Parse.initialize('appId', 'jsKey');
+
+  // Browser - should error when trying to pass masterKey
+  // @ts-expect-error - Browser build should not accept masterKey
+  Parse.initialize('appId', 'jsKey', 'masterKey');
+
+  // Node - permissive 4 params (should work)
+  ParseNode.initialize('appId', 'jsKey', 'masterKey', 'maintenanceKey');
+
+  // Node - 3 params (should also work)
+  ParseNode.initialize('appId', 'jsKey', 'masterKey');
+
+  // Node - 2 params (should also work)
+  ParseNode.initialize('appId', 'jsKey');
+
+  // Node - 1 param (should also work since javaScriptKey is optional in node)
+  ParseNode.initialize('appId');
+}
+


### PR DESCRIPTION
## Pull Request                                                               
                                                                                
  - Report security issues [confidentially](https://github.com/parse-community/Parse-SDK-JS/security/policy).                                                 
  - Any contribution is under this [license](https://github.com/parse-community/Parse-SDK-JS/blob/alpha/LICENSE).
  - Link this pull request to an [issue](https://github.com/parse-community/Parse-SDK-JS/issues?q=is%3Aissue). 
                                                                                
  ## Issue                                                                      
                                                                                
  Related: https://github.com/parse-community/parse-server/pull/10021           
                                                                                
  ## Approach                                                                   
                                                                                
  In Node.js builds, `Parse.initialize` is reassigned to `Parse._initialize` at 
  runtime (line 409 of `src/Parse.ts`), which accepts 4 parameters:             
  `applicationId`, `javaScriptKey`, `masterKey`, and `maintenanceKey`. However, 
  the TypeScript type definition only exposed the 2-parameter browser signature.
                                                                                
  This became apparent after the type resolution fix in 8.0.1, which correctly  
  resolved `parse/node` types. Before that fix, TypeScript wasn't properly      
  checking the types for `parse/node` imports.                                  
                                                                                
  **Changes:**                                                                  
  1. Added an exported `Parse` interface in `src/Parse.ts` that can be augmented
  2. Added type augmentation in `types/node.d.ts` to override `initialize` with 
  the 4-parameter signature for Node.js builds                                  
  3. Added type tests to verify browser rejects 3+ params and Node accepts 4    
  params                                                                        
                                                                                
  This keeps browser types strict (2 params, no masterKey exposure) while giving
   Node.js the correct 4-parameter signature matching runtime behavior.         
                                                                                
  ## Tasks                                                                      
                                                                                
  - [x] Add tests                                                               
  - [ ] Add changes to documentation (guides, repository pages, code comments)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Public SDK surface reworked into a typed interface with consistent getters/setters and clearer initialization semantics.
* **New Features**
  * Expanded public API: richer lifecycle/configuration controls, storage/health APIs, EventuallyQueue accessors, datastore and encrypted-user controls, and LiveQuery/storage wiring.
* **Tests**
  * Added type-level initialization tests for browser vs Node and corrected a unit test console-message expectation.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->