### PR TITLE
fix: Type error in `Parse.Query.equalTo` when matching optional array

### DIFF
--- a/src/ParseQuery.ts
+++ b/src/ParseQuery.ts
@@ -1152,9 +1152,9 @@ class ParseQuery<T extends ParseObject = ParseObject> {
     key: K,
     value:
       | T['attributes'][K]
-      | (T['attributes'][K] extends ParseObject
+      | (NonNullable<T['attributes'][K]> extends ParseObject
           ? Pointer
-          : T['attributes'][K] extends (infer E)[]
+          : NonNullable<T['attributes'][K]> extends (infer E)[]
             ? E
             : never)
   ): this {
@@ -1181,9 +1181,9 @@ class ParseQuery<T extends ParseObject = ParseObject> {
     key: K,
     value:
       | T['attributes'][K]
-      | (T['attributes'][K] extends ParseObject
+      | (NonNullable<T['attributes'][K]> extends ParseObject
           ? Pointer
-          : T['attributes'][K] extends (infer E)[]
+          : NonNullable<T['attributes'][K]> extends (infer E)[]
             ? E
             : never)
   ): this {

--- a/types/ParseQuery.d.ts
+++ b/types/ParseQuery.d.ts
@@ -427,7 +427,7 @@ declare class ParseQuery<T extends ParseObject = ParseObject> {
      * @param value The value that the Parse.Object must contain.
      * @returns {Parse.Query} Returns the query, so you can chain this call.
      */
-    equalTo<K extends keyof T['attributes'] | keyof BaseAttributes>(key: K, value: T['attributes'][K] | (T['attributes'][K] extends ParseObject ? Pointer : T['attributes'][K] extends (infer E)[] ? E : never)): this;
+    equalTo<K extends keyof T['attributes'] | keyof BaseAttributes>(key: K, value: T['attributes'][K] | (NonNullable<T['attributes'][K]> extends ParseObject ? Pointer : NonNullable<T['attributes'][K]> extends (infer E)[] ? E : never)): this;
     /**
      * Adds a constraint to the query that requires a particular key's value to
      * be not equal to the provided value.
@@ -436,7 +436,7 @@ declare class ParseQuery<T extends ParseObject = ParseObject> {
      * @param value The value that must not be equalled.
      * @returns {Parse.Query} Returns the query, so you can chain this call.
      */
-    notEqualTo<K extends keyof T['attributes'] | keyof BaseAttributes>(key: K, value: T['attributes'][K] | (T['attributes'][K] extends ParseObject ? Pointer : T['attributes'][K] extends (infer E)[] ? E : never)): this;
+    notEqualTo<K extends keyof T['attributes'] | keyof BaseAttributes>(key: K, value: T['attributes'][K] | (NonNullable<T['attributes'][K]> extends ParseObject ? Pointer : NonNullable<T['attributes'][K]> extends (infer E)[] ? E : never)): this;
     /**
      * Adds a constraint to the query that requires a particular key's value to
      * be less than the provided value.

--- a/types/ParseQuery.d.ts
+++ b/types/ParseQuery.d.ts
@@ -427,7 +427,7 @@ declare class ParseQuery<T extends ParseObject = ParseObject> {
      * @param value The value that the Parse.Object must contain.
      * @returns {Parse.Query} Returns the query, so you can chain this call.
      */
-    equalTo<K extends keyof T['attributes'] | keyof BaseAttributes>(key: K, value: T['attributes'][K] | (NonNullable<T['attributes'][K]> extends ParseObject ? Pointer : NonNullable<T['attributes'][K]> extends (infer E)[] ? E : never)): this;
+    equalTo<K extends keyof T['attributes'] | keyof BaseAttributes>(key: K, value: T['attributes'][K] | (T['attributes'][K] extends ParseObject ? Pointer : T['attributes'][K] extends (infer E)[] ? E : never)): this;
     /**
      * Adds a constraint to the query that requires a particular key's value to
      * be not equal to the provided value.
@@ -436,7 +436,7 @@ declare class ParseQuery<T extends ParseObject = ParseObject> {
      * @param value The value that must not be equalled.
      * @returns {Parse.Query} Returns the query, so you can chain this call.
      */
-    notEqualTo<K extends keyof T['attributes'] | keyof BaseAttributes>(key: K, value: T['attributes'][K] | (NonNullable<T['attributes'][K]> extends ParseObject ? Pointer : NonNullable<T['attributes'][K]> extends (infer E)[] ? E : never)): this;
+    notEqualTo<K extends keyof T['attributes'] | keyof BaseAttributes>(key: K, value: T['attributes'][K] | (T['attributes'][K] extends ParseObject ? Pointer : T['attributes'][K] extends (infer E)[] ? E : never)): this;
     /**
      * Adds a constraint to the query that requires a particular key's value to
      * be less than the provided value.

--- a/types/tests.ts
+++ b/types/tests.ts
@@ -1853,6 +1853,8 @@ function testQuery() {
       attribute2: number;
       attribute3: AnotherSubClass;
       attribute4: string[];
+      attribute5?: AnotherSubClass[];
+      attribute6?: string[];
     }> {}
     const query = new Parse.Query(MySubClass);
 
@@ -1962,6 +1964,19 @@ function testQuery() {
     // $ExpectType ParseQuery<MySubClass>
     query.equalTo('attribute4', ['a_string_value']);
 
+    
+    // Optional object[] (e.g. prop?: ClassName[] ): allow matching a single element (array contains object), and allow matching the full array
+    // $ExpectType ParseQuery<MySubClass>
+    query.equalTo('attribute5', new AnotherSubClass());
+    // $ExpectType ParseQuery<MySubClass>
+    query.equalTo('attribute5', [new AnotherSubClass()]);
+
+    // Optional string[] (e.g. prop?: string[] ): allow matching a single element (array contains string), and allow matching the full array
+    // $ExpectType ParseQuery<MySubClass>
+    query.equalTo('attribute6', 'a_string_value');
+    // $ExpectType ParseQuery<MySubClass>
+    query.equalTo('attribute6', ['a_string_value']);
+
     // $ExpectType ParseQuery<MySubClass>
     query.notEqualTo('attribute4', 'a_string_value');
     // $ExpectType ParseQuery<MySubClass>
@@ -1975,6 +1990,12 @@ function testQuery() {
     query.equalTo('attribute4', [5]);
     // $ExpectError
     query.notEqualTo('attribute4', [5]);
+
+    // Optional string[]: reject invalid element types
+    // $ExpectError
+    query.equalTo('attribute6', 5);
+    // $ExpectError
+    query.notEqualTo('attribute6', 5);
 
     // $ExpectType ParseQuery<MySubClass>
     query.exists('attribute1');
@@ -2363,4 +2384,3 @@ function testInitialize() {
   // Node - 1 param (should also work since javaScriptKey is optional in node)
   ParseNode.initialize('appId');
 }
-

--- a/types/tests.ts
+++ b/types/tests.ts
@@ -1970,6 +1970,9 @@ function testQuery() {
     query.equalTo('attribute5', new AnotherSubClass());
     // $ExpectType ParseQuery<MySubClass>
     query.equalTo('attribute5', [new AnotherSubClass()]);
+    // Since there is no `$ExpectNotError` thing, this line is instead used to at least prove that there is no regression for type safety for `Array of object` fields
+    // $ExpectError
+    query.equalTo('attribute5', new MySubClass());
 
     // Optional string[] (e.g. prop?: string[] ): allow matching a single element (array contains string), and allow matching the full array
     // $ExpectType ParseQuery<MySubClass>


### PR DESCRIPTION
## Pull Request

- Report security issues [confidentially](https://github.com/parse-community/Parse-SDK-JS/security/policy).
- Any contribution is under this [license](https://github.com/parse-community/Parse-SDK-JS/blob/alpha/LICENSE).
- Link this pull request to an [issue](https://github.com/parse-community/Parse-SDK-JS/issues?q=is%3Aissue).

## Issue
<!-- Add the link to the issue that this PR closes. -->
For optional arrays (e.g. field?: ClassName[] ), the equalTo function has always shown a type error when we try to match, when the underlying runtime has always worked (Parse supports matching of "array contains element" natively). This only happens when the array is optional; required arrays types already allow element matching

Example
```ts
class MyClass extends Parse.Object<{ myArrayField?: Parse.User[]  }> {}

const u = new Parse.User();
/*
this will error out with this error :
Argument of type 'User<Attributes>' is not assignable to parameter of type 'User<Attributes>[]'.
  Type 'User<Attributes>' is missing the following properties from type 'User<Attributes>[]': length, pop, push, concat, and 29 more.ts(2345)
*/
const q = new Parse.Query(MyClass).equalTo('myArrayField', u);
```

Closes: FILL_THIS_OUT

## Approach
<!-- Describe the changes in this PR. -->
`NonNullable` assertion in `equalTo`/`notEqualTo` allows for type-level check to ignore `undefined` when deciding whether the field is a ParseObject or an array, allowing for normal "array contains element" type inference same as for required arrays, things like `{ fieldName: MyClass[] }`.

## Tasks
<!-- Delete tasks that don't apply. -->

- [x] Add tests

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Improved type resolution for equalTo / notEqualTo to ignore undefined when inferring pointer vs. array-element values, tightening type safety for queries on nullable/optional attributes.

* **Tests**
  * Added tests exercising queries against newly declared optional array attributes (object and string arrays), validating accepted element matches and rejecting invalid element types.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->