### PR TITLE
fix: Cloud trigger type errors for void returns and subclass constructors

### DIFF
--- a/src/CloudCode.ts
+++ b/src/CloudCode.ts
@@ -3,6 +3,8 @@ import type ParseUser from './ParseUser';
 import type ParseFile from './ParseFile';
 import type ParseQuery from './ParseQuery';
 
+type ParseObjectConstructor<T extends ParseObject = ParseObject> = new (...args: any[]) => T;
+
 /**
  * @typedef Parse.Cloud.FunctionRequest
  * @property {string} installationId If set, the installationId triggering the request.
@@ -282,7 +284,7 @@ export declare function job(name: string, handler: (request: JobRequest) => any)
  * @param validator An optional function to validate the request
  */
 export declare function beforeSave<T extends ParseObject = ParseObject>(
-  className: string | (new () => T),
+  className: string | ParseObjectConstructor<T>,
   handler: (request: BeforeSaveRequest<T>) => T | undefined | Promise<T | undefined>,
   validator?: ValidatorObject | ((request: BeforeSaveRequest<T>) => any)
 ): void;
@@ -310,7 +312,7 @@ export declare function beforeSave<T extends ParseObject = ParseObject>(
  * @param validator An optional function to validate the request
  */
 export declare function afterSave<T extends ParseObject = ParseObject>(
-  className: string | (new () => T),
+  className: string | ParseObjectConstructor<T>,
   handler: (request: AfterSaveRequest<T>) => Promise<void> | undefined,
   validator?: ValidatorObject | ((request: AfterSaveRequest<T>) => any)
 ): void;
@@ -338,7 +340,7 @@ export declare function afterSave<T extends ParseObject = ParseObject>(
  * @param validator An optional function to validate the request
  */
 export declare function beforeDelete<T extends ParseObject = ParseObject>(
-  className: string | (new () => T),
+  className: string | ParseObjectConstructor<T>,
   handler: (request: BeforeDeleteRequest<T>) => Promise<void> | undefined,
   validator?: ValidatorObject | ((request: BeforeDeleteRequest<T>) => any)
 ): void;
@@ -366,7 +368,7 @@ export declare function beforeDelete<T extends ParseObject = ParseObject>(
  * @param validator An optional function to validate the request
  */
 export declare function afterDelete<T extends ParseObject = ParseObject>(
-  className: string | (new () => T),
+  className: string | ParseObjectConstructor<T>,
   handler: (request: AfterDeleteRequest<T>) => Promise<void> | undefined,
   validator?: ValidatorObject | ((request: AfterDeleteRequest<T>) => any)
 ): void;
@@ -381,7 +383,7 @@ export declare function afterDelete<T extends ParseObject = ParseObject>(
  * @param validator An optional function to validate the request
  */
 export declare function beforeFind<T extends ParseObject = ParseObject>(
-  className: string | (new () => T),
+  className: string | ParseObjectConstructor<T>,
   handler: (request: BeforeFindRequest<T>) => ParseQuery<T> | undefined | Promise<ParseQuery<T> | undefined>,
   validator?: ValidatorObject | ((request: BeforeFindRequest<T>) => any)
 ): void;
@@ -396,7 +398,7 @@ export declare function beforeFind<T extends ParseObject = ParseObject>(
  * @param validator An optional function to validate the request
  */
 export declare function afterFind<T extends ParseObject = ParseObject>(
-  className: string | (new () => T),
+  className: string | ParseObjectConstructor<T>,
   handler: (request: AfterFindRequest<T>) => T[] | undefined | Promise<T[] | undefined>,
   validator?: ValidatorObject | ((request: AfterFindRequest<T>) => any)
 ): void;
@@ -552,7 +554,7 @@ export declare function beforeConnect(
  * @param validator An optional function to validate the request
  */
 export declare function beforeSubscribe<T extends ParseObject = ParseObject>(
-  className: string | (new () => T),
+  className: string | ParseObjectConstructor<T>,
   handler: (request: TriggerRequest<T>) => Promise<void> | undefined,
   validator?: ValidatorObject | ((request: TriggerRequest<T>) => any)
 ): void;
@@ -567,7 +569,7 @@ export declare function beforeSubscribe<T extends ParseObject = ParseObject>(
  * @param validator An optional function to validate the request
  */
 export declare function afterLiveQueryEvent<T extends ParseObject = ParseObject>(
-  className: string | (new () => T),
+  className: string | ParseObjectConstructor<T>,
   handler: (request: LiveQueryEventTrigger<T>) => Promise<void> | undefined,
   validator?: ValidatorObject | ((request: LiveQueryEventTrigger<T>) => any)
 ): void;

--- a/src/CloudCode.ts
+++ b/src/CloudCode.ts
@@ -285,7 +285,7 @@ export declare function job(name: string, handler: (request: JobRequest) => any)
  */
 export declare function beforeSave<T extends ParseObject = ParseObject>(
   className: string | ParseObjectConstructor<T>,
-  handler: (request: BeforeSaveRequest<T>) => T | undefined | Promise<T | undefined>,
+  handler: (request: BeforeSaveRequest<T>) => void | T | undefined | Promise<void | T | undefined>,
   validator?: ValidatorObject | ((request: BeforeSaveRequest<T>) => any)
 ): void;
 
@@ -313,7 +313,7 @@ export declare function beforeSave<T extends ParseObject = ParseObject>(
  */
 export declare function afterSave<T extends ParseObject = ParseObject>(
   className: string | ParseObjectConstructor<T>,
-  handler: (request: AfterSaveRequest<T>) => Promise<void> | undefined,
+  handler: (request: AfterSaveRequest<T>) => void | Promise<void> | undefined,
   validator?: ValidatorObject | ((request: AfterSaveRequest<T>) => any)
 ): void;
 
@@ -341,7 +341,7 @@ export declare function afterSave<T extends ParseObject = ParseObject>(
  */
 export declare function beforeDelete<T extends ParseObject = ParseObject>(
   className: string | ParseObjectConstructor<T>,
-  handler: (request: BeforeDeleteRequest<T>) => Promise<void> | undefined,
+  handler: (request: BeforeDeleteRequest<T>) => void | Promise<void> | undefined,
   validator?: ValidatorObject | ((request: BeforeDeleteRequest<T>) => any)
 ): void;
 
@@ -369,7 +369,7 @@ export declare function beforeDelete<T extends ParseObject = ParseObject>(
  */
 export declare function afterDelete<T extends ParseObject = ParseObject>(
   className: string | ParseObjectConstructor<T>,
-  handler: (request: AfterDeleteRequest<T>) => Promise<void> | undefined,
+  handler: (request: AfterDeleteRequest<T>) => void | Promise<void> | undefined,
   validator?: ValidatorObject | ((request: AfterDeleteRequest<T>) => any)
 ): void;
 
@@ -384,7 +384,11 @@ export declare function afterDelete<T extends ParseObject = ParseObject>(
  */
 export declare function beforeFind<T extends ParseObject = ParseObject>(
   className: string | ParseObjectConstructor<T>,
-  handler: (request: BeforeFindRequest<T>) => ParseQuery<T> | undefined | Promise<ParseQuery<T> | undefined>,
+  handler: (request: BeforeFindRequest<T>) =>
+    | void
+    | ParseQuery<T>
+    | undefined
+    | Promise<void | ParseQuery<T> | undefined>,
   validator?: ValidatorObject | ((request: BeforeFindRequest<T>) => any)
 ): void;
 
@@ -399,7 +403,7 @@ export declare function beforeFind<T extends ParseObject = ParseObject>(
  */
 export declare function afterFind<T extends ParseObject = ParseObject>(
   className: string | ParseObjectConstructor<T>,
-  handler: (request: AfterFindRequest<T>) => T[] | undefined | Promise<T[] | undefined>,
+  handler: (request: AfterFindRequest<T>) => void | T[] | undefined | Promise<void | T[] | undefined>,
   validator?: ValidatorObject | ((request: AfterFindRequest<T>) => any)
 ): void;
 
@@ -412,7 +416,7 @@ export declare function afterFind<T extends ParseObject = ParseObject>(
  * @param validator An optional function to validate the request
  */
 export declare function beforeLogin(
-  handler: (request: TriggerRequest<ParseUser>) => Promise<void> | undefined,
+  handler: (request: TriggerRequest<ParseUser>) => void | Promise<void> | undefined,
   validator?: ValidatorObject | ((request: TriggerRequest<ParseUser>) => any)
 ): void;
 
@@ -424,7 +428,7 @@ export declare function beforeLogin(
  * @param handler The function to run after a login.
  */
 export declare function afterLogin(
-  handler: (request: TriggerRequest<ParseUser>) => Promise<void> | undefined
+  handler: (request: TriggerRequest<ParseUser>) => void | Promise<void> | undefined
 ): void;
 
 /**
@@ -435,7 +439,7 @@ export declare function afterLogin(
  * @param handler The function to run after a logout.
  */
 export declare function afterLogout(
-  handler: (request: TriggerRequest) => Promise<void> | undefined
+  handler: (request: TriggerRequest) => void | Promise<void> | undefined
 ): void;
 
 /**
@@ -447,7 +451,7 @@ export declare function afterLogout(
  * @param validator An optional function to validate the request
  */
 export declare function beforePasswordResetRequest(
-  handler: (request: TriggerRequest<ParseUser>) => Promise<void> | undefined,
+  handler: (request: TriggerRequest<ParseUser>) => void | Promise<void> | undefined,
   validator?: ValidatorObject | ((request: TriggerRequest<ParseUser>) => any)
 ): void;
 
@@ -468,7 +472,11 @@ export declare function beforePasswordResetRequest(
  * @param handler The function to run before a file saves.
  */
 export declare function beforeSaveFile(
-  handler: (request: FileTriggerRequest) => ParseFile | undefined | Promise<ParseFile | undefined>
+  handler: (request: FileTriggerRequest) =>
+    | void
+    | ParseFile
+    | undefined
+    | Promise<void | ParseFile | undefined>
 ): void;
 
 /**
@@ -488,7 +496,7 @@ export declare function beforeSaveFile(
  * @param handler The function to run after a file saves.
  */
 export declare function afterSaveFile(
-  handler: (request: FileTriggerRequest) => Promise<void> | undefined
+  handler: (request: FileTriggerRequest) => void | Promise<void> | undefined
 ): void;
 
 /**
@@ -499,7 +507,7 @@ export declare function afterSaveFile(
  * @param handler The function to run before a file is deleted.
  */
 export declare function beforeDeleteFile(
-  handler: (request: FileTriggerRequest) => Promise<void> | undefined
+  handler: (request: FileTriggerRequest) => void | Promise<void> | undefined
 ): void;
 
 /**
@@ -510,7 +518,7 @@ export declare function beforeDeleteFile(
  * @param handler The function to run after a file is deleted.
  */
 export declare function afterDeleteFile(
-  handler: (request: FileTriggerRequest) => Promise<void> | undefined
+  handler: (request: FileTriggerRequest) => void | Promise<void> | undefined
 ): void;
 
 /**
@@ -530,7 +538,7 @@ export declare function afterDeleteFile(
  * @param validator An optional function to validate the request
  */
 export declare function beforeConnect(
-  handler: (request: ConnectTriggerRequest) => Promise<void> | undefined,
+  handler: (request: ConnectTriggerRequest) => void | Promise<void> | undefined,
   validator?: ValidatorObject | ((request: ConnectTriggerRequest) => any)
 ): void;
 
@@ -555,7 +563,7 @@ export declare function beforeConnect(
  */
 export declare function beforeSubscribe<T extends ParseObject = ParseObject>(
   className: string | ParseObjectConstructor<T>,
-  handler: (request: TriggerRequest<T>) => Promise<void> | undefined,
+  handler: (request: TriggerRequest<T>) => void | Promise<void> | undefined,
   validator?: ValidatorObject | ((request: TriggerRequest<T>) => any)
 ): void;
 
@@ -570,7 +578,7 @@ export declare function beforeSubscribe<T extends ParseObject = ParseObject>(
  */
 export declare function afterLiveQueryEvent<T extends ParseObject = ParseObject>(
   className: string | ParseObjectConstructor<T>,
-  handler: (request: LiveQueryEventTrigger<T>) => Promise<void> | undefined,
+  handler: (request: LiveQueryEventTrigger<T>) => void | Promise<void> | undefined,
   validator?: ValidatorObject | ((request: LiveQueryEventTrigger<T>) => any)
 ): void;
 

--- a/src/CloudCode.ts
+++ b/src/CloudCode.ts
@@ -1,3 +1,5 @@
+/* eslint-disable @typescript-eslint/no-invalid-void-type -- Cloud trigger handlers legitimately return void | T */
+
 import type ParseObject from './ParseObject';
 import type ParseUser from './ParseUser';
 import type ParseFile from './ParseFile';

--- a/types/CloudCode.d.ts
+++ b/types/CloudCode.d.ts
@@ -260,7 +260,7 @@ export declare function job(name: string, handler: (request: JobRequest) => any)
  * @param handler The function to run before a save.
  * @param validator An optional function to validate the request
  */
-export declare function beforeSave<T extends ParseObject = ParseObject>(className: string | ParseObjectConstructor<T>, handler: (request: BeforeSaveRequest<T>) => T | undefined | Promise<T | undefined>, validator?: ValidatorObject | ((request: BeforeSaveRequest<T>) => any)): void;
+export declare function beforeSave<T extends ParseObject = ParseObject>(className: string | ParseObjectConstructor<T>, handler: (request: BeforeSaveRequest<T>) => void | T | undefined | Promise<void | T | undefined>, validator?: ValidatorObject | ((request: BeforeSaveRequest<T>) => any)): void;
 /**
  * Registers an after save function.
  *
@@ -283,7 +283,7 @@ export declare function beforeSave<T extends ParseObject = ParseObject>(classNam
  * @param handler The function to run after a save.
  * @param validator An optional function to validate the request
  */
-export declare function afterSave<T extends ParseObject = ParseObject>(className: string | ParseObjectConstructor<T>, handler: (request: AfterSaveRequest<T>) => Promise<void> | undefined, validator?: ValidatorObject | ((request: AfterSaveRequest<T>) => any)): void;
+export declare function afterSave<T extends ParseObject = ParseObject>(className: string | ParseObjectConstructor<T>, handler: (request: AfterSaveRequest<T>) => void | Promise<void> | undefined, validator?: ValidatorObject | ((request: AfterSaveRequest<T>) => any)): void;
 /**
  * Registers a before delete function.
  *
@@ -306,7 +306,7 @@ export declare function afterSave<T extends ParseObject = ParseObject>(className
  * @param handler The function to run before a delete.
  * @param validator An optional function to validate the request
  */
-export declare function beforeDelete<T extends ParseObject = ParseObject>(className: string | ParseObjectConstructor<T>, handler: (request: BeforeDeleteRequest<T>) => Promise<void> | undefined, validator?: ValidatorObject | ((request: BeforeDeleteRequest<T>) => any)): void;
+export declare function beforeDelete<T extends ParseObject = ParseObject>(className: string | ParseObjectConstructor<T>, handler: (request: BeforeDeleteRequest<T>) => void | Promise<void> | undefined, validator?: ValidatorObject | ((request: BeforeDeleteRequest<T>) => any)): void;
 /**
  * Registers an after delete function.
  *
@@ -329,7 +329,7 @@ export declare function beforeDelete<T extends ParseObject = ParseObject>(classN
  * @param handler The function to run after a delete.
  * @param validator An optional function to validate the request
  */
-export declare function afterDelete<T extends ParseObject = ParseObject>(className: string | ParseObjectConstructor<T>, handler: (request: AfterDeleteRequest<T>) => Promise<void> | undefined, validator?: ValidatorObject | ((request: AfterDeleteRequest<T>) => any)): void;
+export declare function afterDelete<T extends ParseObject = ParseObject>(className: string | ParseObjectConstructor<T>, handler: (request: AfterDeleteRequest<T>) => void | Promise<void> | undefined, validator?: ValidatorObject | ((request: AfterDeleteRequest<T>) => any)): void;
 /**
  * Registers a before find function.
  *
@@ -339,7 +339,7 @@ export declare function afterDelete<T extends ParseObject = ParseObject>(classNa
  * @param handler The function to run before a find.
  * @param validator An optional function to validate the request
  */
-export declare function beforeFind<T extends ParseObject = ParseObject>(className: string | ParseObjectConstructor<T>, handler: (request: BeforeFindRequest<T>) => ParseQuery<T> | undefined | Promise<ParseQuery<T> | undefined>, validator?: ValidatorObject | ((request: BeforeFindRequest<T>) => any)): void;
+export declare function beforeFind<T extends ParseObject = ParseObject>(className: string | ParseObjectConstructor<T>, handler: (request: BeforeFindRequest<T>) => void | ParseQuery<T> | undefined | Promise<void | ParseQuery<T> | undefined>, validator?: ValidatorObject | ((request: BeforeFindRequest<T>) => any)): void;
 /**
  * Registers an after find function.
  *
@@ -349,7 +349,7 @@ export declare function beforeFind<T extends ParseObject = ParseObject>(classNam
  * @param handler The function to run after a find.
  * @param validator An optional function to validate the request
  */
-export declare function afterFind<T extends ParseObject = ParseObject>(className: string | ParseObjectConstructor<T>, handler: (request: AfterFindRequest<T>) => T[] | undefined | Promise<T[] | undefined>, validator?: ValidatorObject | ((request: AfterFindRequest<T>) => any)): void;
+export declare function afterFind<T extends ParseObject = ParseObject>(className: string | ParseObjectConstructor<T>, handler: (request: AfterFindRequest<T>) => void | T[] | undefined | Promise<void | T[] | undefined>, validator?: ValidatorObject | ((request: AfterFindRequest<T>) => any)): void;
 /**
  * Registers a before login function.
  *
@@ -358,7 +358,7 @@ export declare function afterFind<T extends ParseObject = ParseObject>(className
  * @param handler The function to run before a login.
  * @param validator An optional function to validate the request
  */
-export declare function beforeLogin(handler: (request: TriggerRequest<ParseUser>) => Promise<void> | undefined, validator?: ValidatorObject | ((request: TriggerRequest<ParseUser>) => any)): void;
+export declare function beforeLogin(handler: (request: TriggerRequest<ParseUser>) => void | Promise<void> | undefined, validator?: ValidatorObject | ((request: TriggerRequest<ParseUser>) => any)): void;
 /**
  * Registers an after login function.
  *
@@ -366,7 +366,7 @@ export declare function beforeLogin(handler: (request: TriggerRequest<ParseUser>
  *
  * @param handler The function to run after a login.
  */
-export declare function afterLogin(handler: (request: TriggerRequest<ParseUser>) => Promise<void> | undefined): void;
+export declare function afterLogin(handler: (request: TriggerRequest<ParseUser>) => void | Promise<void> | undefined): void;
 /**
  * Registers an after logout function.
  *
@@ -374,7 +374,7 @@ export declare function afterLogin(handler: (request: TriggerRequest<ParseUser>)
  *
  * @param handler The function to run after a logout.
  */
-export declare function afterLogout(handler: (request: TriggerRequest) => Promise<void> | undefined): void;
+export declare function afterLogout(handler: (request: TriggerRequest) => void | Promise<void> | undefined): void;
 /**
  * Registers a before password reset request function.
  *
@@ -383,7 +383,7 @@ export declare function afterLogout(handler: (request: TriggerRequest) => Promis
  * @param handler The function to run before a password reset request.
  * @param validator An optional function to validate the request
  */
-export declare function beforePasswordResetRequest(handler: (request: TriggerRequest<ParseUser>) => Promise<void> | undefined, validator?: ValidatorObject | ((request: TriggerRequest<ParseUser>) => any)): void;
+export declare function beforePasswordResetRequest(handler: (request: TriggerRequest<ParseUser>) => void | Promise<void> | undefined, validator?: ValidatorObject | ((request: TriggerRequest<ParseUser>) => any)): void;
 /**
  * Registers a before save file function.
  *
@@ -400,7 +400,7 @@ export declare function beforePasswordResetRequest(handler: (request: TriggerReq
  *
  * @param handler The function to run before a file saves.
  */
-export declare function beforeSaveFile(handler: (request: FileTriggerRequest) => ParseFile | undefined | Promise<ParseFile | undefined>): void;
+export declare function beforeSaveFile(handler: (request: FileTriggerRequest) => void | ParseFile | undefined | Promise<void | ParseFile | undefined>): void;
 /**
  * Registers an after save file function.
  *
@@ -417,7 +417,7 @@ export declare function beforeSaveFile(handler: (request: FileTriggerRequest) =>
  *
  * @param handler The function to run after a file saves.
  */
-export declare function afterSaveFile(handler: (request: FileTriggerRequest) => Promise<void> | undefined): void;
+export declare function afterSaveFile(handler: (request: FileTriggerRequest) => void | Promise<void> | undefined): void;
 /**
  * Registers a before delete file function.
  *
@@ -425,7 +425,7 @@ export declare function afterSaveFile(handler: (request: FileTriggerRequest) => 
  *
  * @param handler The function to run before a file is deleted.
  */
-export declare function beforeDeleteFile(handler: (request: FileTriggerRequest) => Promise<void> | undefined): void;
+export declare function beforeDeleteFile(handler: (request: FileTriggerRequest) => void | Promise<void> | undefined): void;
 /**
  * Registers an after delete file function.
  *
@@ -433,7 +433,7 @@ export declare function beforeDeleteFile(handler: (request: FileTriggerRequest) 
  *
  * @param handler The function to run after a file is deleted.
  */
-export declare function afterDeleteFile(handler: (request: FileTriggerRequest) => Promise<void> | undefined): void;
+export declare function afterDeleteFile(handler: (request: FileTriggerRequest) => void | Promise<void> | undefined): void;
 /**
  * Registers a before connect function for LiveQuery.
  *
@@ -450,7 +450,7 @@ export declare function afterDeleteFile(handler: (request: FileTriggerRequest) =
  * @param handler The function to run before a LiveQuery connection is made.
  * @param validator An optional function to validate the request
  */
-export declare function beforeConnect(handler: (request: ConnectTriggerRequest) => Promise<void> | undefined, validator?: ValidatorObject | ((request: ConnectTriggerRequest) => any)): void;
+export declare function beforeConnect(handler: (request: ConnectTriggerRequest) => void | Promise<void> | undefined, validator?: ValidatorObject | ((request: ConnectTriggerRequest) => any)): void;
 /**
  * Registers a before subscribe function for LiveQuery.
  *
@@ -470,7 +470,7 @@ export declare function beforeConnect(handler: (request: ConnectTriggerRequest) 
  * @param handler The function to run before a subscription.
  * @param validator An optional function to validate the request
  */
-export declare function beforeSubscribe<T extends ParseObject = ParseObject>(className: string | ParseObjectConstructor<T>, handler: (request: TriggerRequest<T>) => Promise<void> | undefined, validator?: ValidatorObject | ((request: TriggerRequest<T>) => any)): void;
+export declare function beforeSubscribe<T extends ParseObject = ParseObject>(className: string | ParseObjectConstructor<T>, handler: (request: TriggerRequest<T>) => void | Promise<void> | undefined, validator?: ValidatorObject | ((request: TriggerRequest<T>) => any)): void;
 /**
  * Registers an after live query event function.
  *
@@ -480,7 +480,7 @@ export declare function beforeSubscribe<T extends ParseObject = ParseObject>(cla
  * @param handler The function to run after a live query event.
  * @param validator An optional function to validate the request
  */
-export declare function afterLiveQueryEvent<T extends ParseObject = ParseObject>(className: string | ParseObjectConstructor<T>, handler: (request: LiveQueryEventTrigger<T>) => Promise<void> | undefined, validator?: ValidatorObject | ((request: LiveQueryEventTrigger<T>) => any)): void;
+export declare function afterLiveQueryEvent<T extends ParseObject = ParseObject>(className: string | ParseObjectConstructor<T>, handler: (request: LiveQueryEventTrigger<T>) => void | Promise<void> | undefined, validator?: ValidatorObject | ((request: LiveQueryEventTrigger<T>) => any)): void;
 /**
  * Sends an email.
  *
@@ -522,3 +522,4 @@ export declare function sendEmail(data: {
  * @returns A promise that will be resolved with a {@link HTTPResponse} object when the request completes.
  */
 export declare function httpRequest(options: HTTPOptions): Promise<HTTPResponse>;
+export {};

--- a/types/CloudCode.d.ts
+++ b/types/CloudCode.d.ts
@@ -2,6 +2,7 @@ import type ParseObject from './ParseObject';
 import type ParseUser from './ParseUser';
 import type ParseFile from './ParseFile';
 import type ParseQuery from './ParseQuery';
+type ParseObjectConstructor<T extends ParseObject = ParseObject> = new (...args: any[]) => T;
 /**
  * @typedef Parse.Cloud.FunctionRequest
  * @property {string} installationId If set, the installationId triggering the request.
@@ -259,7 +260,7 @@ export declare function job(name: string, handler: (request: JobRequest) => any)
  * @param handler The function to run before a save.
  * @param validator An optional function to validate the request
  */
-export declare function beforeSave<T extends ParseObject = ParseObject>(className: string | (new () => T), handler: (request: BeforeSaveRequest<T>) => T | undefined | Promise<T | undefined>, validator?: ValidatorObject | ((request: BeforeSaveRequest<T>) => any)): void;
+export declare function beforeSave<T extends ParseObject = ParseObject>(className: string | ParseObjectConstructor<T>, handler: (request: BeforeSaveRequest<T>) => T | undefined | Promise<T | undefined>, validator?: ValidatorObject | ((request: BeforeSaveRequest<T>) => any)): void;
 /**
  * Registers an after save function.
  *
@@ -282,7 +283,7 @@ export declare function beforeSave<T extends ParseObject = ParseObject>(classNam
  * @param handler The function to run after a save.
  * @param validator An optional function to validate the request
  */
-export declare function afterSave<T extends ParseObject = ParseObject>(className: string | (new () => T), handler: (request: AfterSaveRequest<T>) => Promise<void> | undefined, validator?: ValidatorObject | ((request: AfterSaveRequest<T>) => any)): void;
+export declare function afterSave<T extends ParseObject = ParseObject>(className: string | ParseObjectConstructor<T>, handler: (request: AfterSaveRequest<T>) => Promise<void> | undefined, validator?: ValidatorObject | ((request: AfterSaveRequest<T>) => any)): void;
 /**
  * Registers a before delete function.
  *
@@ -305,7 +306,7 @@ export declare function afterSave<T extends ParseObject = ParseObject>(className
  * @param handler The function to run before a delete.
  * @param validator An optional function to validate the request
  */
-export declare function beforeDelete<T extends ParseObject = ParseObject>(className: string | (new () => T), handler: (request: BeforeDeleteRequest<T>) => Promise<void> | undefined, validator?: ValidatorObject | ((request: BeforeDeleteRequest<T>) => any)): void;
+export declare function beforeDelete<T extends ParseObject = ParseObject>(className: string | ParseObjectConstructor<T>, handler: (request: BeforeDeleteRequest<T>) => Promise<void> | undefined, validator?: ValidatorObject | ((request: BeforeDeleteRequest<T>) => any)): void;
 /**
  * Registers an after delete function.
  *
@@ -328,7 +329,7 @@ export declare function beforeDelete<T extends ParseObject = ParseObject>(classN
  * @param handler The function to run after a delete.
  * @param validator An optional function to validate the request
  */
-export declare function afterDelete<T extends ParseObject = ParseObject>(className: string | (new () => T), handler: (request: AfterDeleteRequest<T>) => Promise<void> | undefined, validator?: ValidatorObject | ((request: AfterDeleteRequest<T>) => any)): void;
+export declare function afterDelete<T extends ParseObject = ParseObject>(className: string | ParseObjectConstructor<T>, handler: (request: AfterDeleteRequest<T>) => Promise<void> | undefined, validator?: ValidatorObject | ((request: AfterDeleteRequest<T>) => any)): void;
 /**
  * Registers a before find function.
  *
@@ -338,7 +339,7 @@ export declare function afterDelete<T extends ParseObject = ParseObject>(classNa
  * @param handler The function to run before a find.
  * @param validator An optional function to validate the request
  */
-export declare function beforeFind<T extends ParseObject = ParseObject>(className: string | (new () => T), handler: (request: BeforeFindRequest<T>) => ParseQuery<T> | undefined | Promise<ParseQuery<T> | undefined>, validator?: ValidatorObject | ((request: BeforeFindRequest<T>) => any)): void;
+export declare function beforeFind<T extends ParseObject = ParseObject>(className: string | ParseObjectConstructor<T>, handler: (request: BeforeFindRequest<T>) => ParseQuery<T> | undefined | Promise<ParseQuery<T> | undefined>, validator?: ValidatorObject | ((request: BeforeFindRequest<T>) => any)): void;
 /**
  * Registers an after find function.
  *
@@ -348,7 +349,7 @@ export declare function beforeFind<T extends ParseObject = ParseObject>(classNam
  * @param handler The function to run after a find.
  * @param validator An optional function to validate the request
  */
-export declare function afterFind<T extends ParseObject = ParseObject>(className: string | (new () => T), handler: (request: AfterFindRequest<T>) => T[] | undefined | Promise<T[] | undefined>, validator?: ValidatorObject | ((request: AfterFindRequest<T>) => any)): void;
+export declare function afterFind<T extends ParseObject = ParseObject>(className: string | ParseObjectConstructor<T>, handler: (request: AfterFindRequest<T>) => T[] | undefined | Promise<T[] | undefined>, validator?: ValidatorObject | ((request: AfterFindRequest<T>) => any)): void;
 /**
  * Registers a before login function.
  *
@@ -469,7 +470,7 @@ export declare function beforeConnect(handler: (request: ConnectTriggerRequest) 
  * @param handler The function to run before a subscription.
  * @param validator An optional function to validate the request
  */
-export declare function beforeSubscribe<T extends ParseObject = ParseObject>(className: string | (new () => T), handler: (request: TriggerRequest<T>) => Promise<void> | undefined, validator?: ValidatorObject | ((request: TriggerRequest<T>) => any)): void;
+export declare function beforeSubscribe<T extends ParseObject = ParseObject>(className: string | ParseObjectConstructor<T>, handler: (request: TriggerRequest<T>) => Promise<void> | undefined, validator?: ValidatorObject | ((request: TriggerRequest<T>) => any)): void;
 /**
  * Registers an after live query event function.
  *
@@ -479,7 +480,7 @@ export declare function beforeSubscribe<T extends ParseObject = ParseObject>(cla
  * @param handler The function to run after a live query event.
  * @param validator An optional function to validate the request
  */
-export declare function afterLiveQueryEvent<T extends ParseObject = ParseObject>(className: string | (new () => T), handler: (request: LiveQueryEventTrigger<T>) => Promise<void> | undefined, validator?: ValidatorObject | ((request: LiveQueryEventTrigger<T>) => any)): void;
+export declare function afterLiveQueryEvent<T extends ParseObject = ParseObject>(className: string | ParseObjectConstructor<T>, handler: (request: LiveQueryEventTrigger<T>) => Promise<void> | undefined, validator?: ValidatorObject | ((request: LiveQueryEventTrigger<T>) => any)): void;
 /**
  * Sends an email.
  *

--- a/types/tests.ts
+++ b/types/tests.ts
@@ -613,6 +613,10 @@ async function test_cloud_functions() {
     }
   });
 
+  ParseNode.Cloud.beforeSave('MyCustomClass', (request): void => {
+    request.object;
+  });
+
   // Tests to allow for Parse.Object subclasses with non-optional constructor params.
   class ArgObject extends Parse.Object<{ a: string }> {
     constructor(arg: { a: string }) {

--- a/types/tests.ts
+++ b/types/tests.ts
@@ -613,6 +613,17 @@ async function test_cloud_functions() {
     }
   });
 
+  // Tests to allow for Parse.Object subclasses with non-optional constructor params.
+  class ArgObject extends Parse.Object<{ a: string }> {
+    constructor(arg: { a: string }) {
+      super('ArgObject', arg);
+    }
+  }
+  ParseNode.Cloud.beforeSave(ArgObject, request => {
+    // $ExpectType ArgObject
+    request.object;
+  });
+
   ParseNode.Cloud.beforeFind('MyCustomClass', request => {
     request.query;
     request.user;
@@ -2363,4 +2374,3 @@ function testInitialize() {
   // Node - 1 param (should also work since javaScriptKey is optional in node)
   ParseNode.initialize('appId');
 }
-


### PR DESCRIPTION
## Pull Request

- Report security issues [confidentially](https://github.com/parse-community/Parse-SDK-JS/security/policy).
- Any contribution is under this [license](https://github.com/parse-community/Parse-SDK-JS/blob/alpha/LICENSE).
- Link this pull request to an [issue](https://github.com/parse-community/Parse-SDK-JS/issues?q=is%3Aissue).

## Issue
<!-- Add the link to the issue that this PR closes. -->
This both fixes a regression in cloud trigger return typings & fixes a longstanding issue when defining triggers on subclasses.
The current typings allow only for triggers to return *something* e.g. undefined, or the exact object class (which is generally likely the same request.object).
```
// This previously fine case would fail with the current typings, since it returns "void" instead of the currently required "undefined" return.
Parse.Cloud.beforeSave(MyClass, (req)=>{
  req.object.set('serverTime', Date.now());
})
```

However, the behaviour commonly used, and was accepted in the prior DefinitelyTyped-defined typings, was to simply not return anything and do mutations on the object e.g. `request.object.set(...)`, which would mean a function with a return type of `void`. Since the typings do not allow for `void` returns, upgrading a prior codebase to a newer version of Parse JS SDK with built-in typings will cause errors.
Another thing that this fixes is for subclasses of Parse.Object that have non-optional arguments for types, `Parse.Cloud` triggers (e.g. `Parse.Cloud.beforeSave`) previously was typed using the `new () => T` syntax, which means anything with constructor arguments could not be typed. This now allows for us to do things like.
```
class A extends Parse.Object<{ a: string }> { constructor(arg:{ a: string } ) { super('A', arg); } };
// Previously this would complain that A does not fit the signature
Parse.Cloud.beforeSave(A, (req)=> { /* whatever */ })
```

## Approach
<!-- Describe the changes in this PR. -->
Added `void` return type to Parse.Cloud typings.
Fixed type trigger class generic typings to allow for subclasses with constructors that have arguments.

## Tasks
<!-- Delete tasks that don't apply. -->

- [x] Add tests


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  - Cloud Code hooks now accept class constructors as well as string class names for broader registration options.
  - Hook handlers may return void (synchronously or via Promise) in addition to previous return shapes, simplifying synchronous handlers.
  - Changes apply across triggers (save, delete, find, subscribe, login/logout, password reset, file operations, live query, connect).

* **Tests**
  - Added tests demonstrating constructor-based hook usage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->