### PR TITLE
fix: `Parse.Object.createWithoutData` doesn't preserve object subclass

### DIFF
--- a/src/ParseObject.ts
+++ b/src/ParseObject.ts
@@ -1877,7 +1877,7 @@ class ParseObject<T extends Attributes = Attributes> {
    * @static
    * @returns {Parse.Object} A Parse.Object reference.
    */
-  static createWithoutData(id: string): ParseObject {
+  static createWithoutData<T extends ParseObject>(this: new (...args: any[]) => T, id: string): T {
     const obj = new this();
     obj.id = id;
     return obj;

--- a/types/ParseObject.d.ts
+++ b/types/ParseObject.d.ts
@@ -894,7 +894,7 @@ declare class ParseObject<T extends Attributes = Attributes> {
      * @static
      * @returns {Parse.Object} A Parse.Object reference.
      */
-    static createWithoutData(id: string): ParseObject;
+    static createWithoutData<T extends ParseObject>(this: new (...args: any[]) => T, id: string): T;
     /**
      * Creates a new instance of a Parse Object from a JSON representation.
      *

--- a/types/tests.ts
+++ b/types/tests.ts
@@ -42,6 +42,12 @@ async function test_object() {
   // Create a new instance of that class.
   const gameScore = new GameScore();
 
+  // Expect that `createWitoutData` returns the types for the same classes (not generic ParseObjects)
+  // $ExpectType Game
+  Game.createWithoutData('someid');
+  // $ExpectType GameScore
+  GameScore.createWithoutData('scoreid');
+
   gameScore.set('score', 1337);
   gameScore.set('playerName', 'Sean Plott');
   gameScore.set('cheatMode', false);
@@ -2363,4 +2369,3 @@ function testInitialize() {
   // Node - 1 param (should also work since javaScriptKey is optional in node)
   ParseNode.initialize('appId');
 }
-

--- a/types/tests.ts
+++ b/types/tests.ts
@@ -47,6 +47,8 @@ async function test_object() {
   Game.createWithoutData('someid');
   // $ExpectType GameScore
   GameScore.createWithoutData('scoreid');
+  // $ExpectType ParseUser<Attributes>
+  Parse.User.createWithoutData('someuser');
 
   gameScore.set('score', 1337);
   gameScore.set('playerName', 'Sean Plott');

--- a/types/tests.ts
+++ b/types/tests.ts
@@ -42,7 +42,7 @@ async function test_object() {
   // Create a new instance of that class.
   const gameScore = new GameScore();
 
-  // Expect that `createWitoutData` returns the types for the same classes (not generic ParseObjects)
+  // Expect that `createWithoutData` returns the types for the same classes (not generic ParseObjects)
   // $ExpectType Game
   Game.createWithoutData('someid');
   // $ExpectType GameScore


### PR DESCRIPTION
## Pull Request

- Report security issues [confidentially](https://github.com/parse-community/Parse-SDK-JS/security/policy).
- Any contribution is under this [license](https://github.com/parse-community/Parse-SDK-JS/blob/alpha/LICENSE).
- Link this pull request to an [issue](https://github.com/parse-community/Parse-SDK-JS/issues?q=is%3Aissue).

## Issue
<!-- Add the link to the issue that this PR closes. -->
This was originally already an issue with the original DefinitelyTyped typings, but with the new built-in typings the issue has expanded beyond the original scope.
Problem : `createWithoutData` calls on Parse.Object subclasses return object instances of that specific class. However, the current typings lose this connection and instead reverts to a generic Parse.Object type. Originally with the DefinitelyTyped typings this issue affected all user-defined classes, but at least Parse.User wasn't affected since it had its own separate typings. However, with our definition of ParseUser now extending from ParseObject, this version's Parse.User is also affected by this issue.

```ts
const user = Parse.User.createWithoutData('userId') // Originally would have types be Parse.User; right now it is Parse.Object

const myObj = MyClass.createWithoutData('objId') // We would expect that this is a `MyClass` instance, however the typings show as Parse.Object.
```


## Approach
Added generic typing argument to `createWithoutData`. (`this` only affects TS typings, JS and usage wise it is still a single argument method)

## Tasks
<!-- Delete tasks that don't apply. -->

- [x] Add tests


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved TypeScript typings so factory calls on subclass types now return the correct subclass type, enhancing type safety, reducing type errors, and improving IDE autocomplete and developer ergonomics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->