### PR TITLE
fix: `Parse.serverURL` not accessible via global `Parse` scope

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -5,6 +5,7 @@ export default parse;
 
 // All exports beyond this point will be included in the Parse namespace
 export as namespace Parse;
+export let serverURL: import('./Parse').Parse['serverURL'];
 import ACL from './ParseACL';
 import * as Analytics from './Analytics';
 import AnonymousUtils from './AnonymousUtils';


### PR DESCRIPTION
## Pull Request

- Report security issues [confidentially](https://github.com/parse-community/Parse-SDK-JS/security/policy).
- Any contribution is under this [license](https://github.com/parse-community/Parse-SDK-JS/blob/alpha/LICENSE).
- Link this pull request to an [issue](https://github.com/parse-community/Parse-SDK-JS/issues?q=is%3Aissue).

## Issue
<!-- Add the link to the issue that this PR closes. -->
Parse.serverURL is intended to be accessible in the global Parse scope, however, with the current typing changes, `Parse.serverURL` would not be accessible without an explicit (`import Parse from 'parse'`) in the same file, due to `serverURL` not being part of the exported variables in `index.d.ts`

## Approach
<!-- Describe the changes in this PR. -->
Added serverURL to the `index.d.ts` declaration.

## Tasks
<!-- Delete tasks that don't apply. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `serverURL` to the public API, allowing users to access and reference server URL configuration directly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->