### PR TITLE
docs: Add missing docs to `Parse.Query.select`

### DIFF
--- a/src/ParseQuery.ts
+++ b/src/ParseQuery.ts
@@ -1921,6 +1921,11 @@ class ParseQuery<T extends ParseObject = ParseObject> {
    * provided keys.  If this is called multiple times, then all of the keys
    * specified in each of the calls will be included.
    *
+   * When selecting `authData` on `Parse.User`, only auth data of currently
+   * configured auth providers is returned. Auth data of providers that are no
+   * longer configured is not included. To return all auth data regardless of
+   * the provider configuration, do not select `authData`.
+   *
    * @param {...string|Array<string>} keys The name(s) of the key(s) to include.
    * @returns {Parse.Query} Returns the query, so you can chain this call.
    */

--- a/types/ParseQuery.d.ts
+++ b/types/ParseQuery.d.ts
@@ -812,6 +812,11 @@ declare class ParseQuery<T extends ParseObject = ParseObject> {
      * provided keys.  If this is called multiple times, then all of the keys
      * specified in each of the calls will be included.
      *
+     * When selecting `authData` on `Parse.User`, only auth data of currently
+     * configured auth providers is returned. Auth data of providers that are no
+     * longer configured is not included. To return all auth data regardless of
+     * the provider configuration, do not select `authData`.
+     *
      * @param {...string|Array<string>} keys The name(s) of the key(s) to include.
      * @returns {Parse.Query} Returns the query, so you can chain this call.
      */


### PR DESCRIPTION
## Pull Request

- Report security issues [confidentially](https://github.com/parse-community/Parse-SDK-JS/security/policy).
- Any contribution is under this [license](https://github.com/parse-community/Parse-SDK-JS/blob/alpha/LICENSE).
- Link this pull request to an [issue](https://github.com/parse-community/Parse-SDK-JS/issues?q=is%3Aissue).

## Issue

Add missing docs to `Parse.Query.select`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified user account authData behavior: selecting authData returns only data for currently configured auth providers; auth data from unconfigured providers is excluded. Note added that to retrieve all authData regardless of provider configuration, do not select authData. This is a docs-only clarification with no runtime or API signature changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->