### PR TITLE
feat: Add support for file upload as binary data via `Buffer`, `Readable`, `ReadableStream`

### DIFF
--- a/integration/test/ParseFileTest.js
+++ b/integration/test/ParseFileTest.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const assert = require('assert');
+const { Readable } = require('stream');
 const Parse = require('../../node');
 
 describe('Parse.File', () => {
@@ -142,6 +143,69 @@ describe('Parse.File', () => {
     } catch (e) {
       assert.equal(e.code, Parse.Error.FILE_DELETE_ERROR);
     }
+  });
+
+  it('can save file from Buffer', async () => {
+    const data = Buffer.from([61, 170, 236, 120]);
+    const file = new Parse.File('buffer-file.bin', data);
+    await file.save();
+
+    assert(file.url());
+    assert(file.name());
+
+    const object = new Parse.Object('TestObject');
+    object.set('file', file);
+    await object.save();
+
+    const query = new Parse.Query('TestObject');
+    const result = await query.get(object.id);
+    assert.equal(result.get('file').name(), file.name());
+    assert.equal(result.get('file').url(), file.url());
+
+    const retrieved = await file.getData();
+    assert.equal(retrieved, data.toString('base64'));
+  });
+
+  it('can save file from Buffer with content type', async () => {
+    const data = Buffer.from('hello world');
+    const file = new Parse.File('hello.txt', data, 'text/plain');
+    await file.save();
+
+    assert(file.url());
+    const retrieved = await file.getData();
+    assert.equal(Buffer.from(retrieved, 'base64').toString(), 'hello world');
+  });
+
+  it('can save file from Readable stream', async () => {
+    const data = Buffer.from([61, 170, 236, 120]);
+    const stream = Readable.from(data);
+    const file = new Parse.File('stream-file.bin', stream);
+    await file.save();
+
+    assert(file.url());
+    assert(file.name());
+
+    const object = new Parse.Object('TestObject');
+    object.set('file', file);
+    await object.save();
+
+    const query = new Parse.Query('TestObject');
+    const result = await query.get(object.id);
+    assert.equal(result.get('file').name(), file.name());
+    assert.equal(result.get('file').url(), file.url());
+
+    const retrieved = await file.getData();
+    assert.equal(retrieved, data.toString('base64'));
+  });
+
+  it('can save file from Readable stream with content type', async () => {
+    const stream = Readable.from(Buffer.from('hello world'));
+    const file = new Parse.File('hello.txt', stream, 'text/plain');
+    await file.save();
+
+    assert(file.url());
+    const retrieved = await file.getData();
+    assert.equal(Buffer.from(retrieved, 'base64').toString(), 'hello world');
   });
 
   it('can save file to localDatastore', async () => {

--- a/src/CoreManager.ts
+++ b/src/CoreManager.ts
@@ -40,6 +40,11 @@ export interface FileController {
     source: FileSource,
     options?: FileSaveOptions
   ) => Promise<{ name: string; url: string }>;
+  saveBinary?: (
+    name: string,
+    source: FileSource,
+    options?: FileSaveOptions
+  ) => Promise<{ name: string; url: string }>;
   download: (uri: string, options?: any) => Promise<{ base64?: string; contentType?: string }>;
   deleteFile: (name: string, options?: { useMasterKey?: boolean }) => Promise<void>;
 }

--- a/src/ParseFile.ts
+++ b/src/ParseFile.ts
@@ -640,7 +640,7 @@ const DefaultController = {
     if (url[url.length - 1] !== '/') {
       url += '/';
     }
-    url += 'files/' + name;
+    url += 'files/' + encodeURIComponent(name);
 
     return CoreManager.getRESTController()
       .ajax('POST', url, body, headers, options)

--- a/src/ParseFile.ts
+++ b/src/ParseFile.ts
@@ -632,14 +632,7 @@ const DefaultController = {
     } else if (source.format === 'stream') {
       const stream = source.stream;
       if (typeof stream.pipe === 'function' && typeof stream.read === 'function') {
-        if (NodeReadable && typeof NodeReadable.toWeb === 'function') {
-          body = NodeReadable.toWeb(stream);
-        } else {
-          throw new Error(
-            'Streaming file uploads require Node.js >= 17.0.0. ' +
-              'Use a Buffer instead, or upgrade your Node.js version.'
-          );
-        }
+        body = NodeReadable.toWeb(stream);
       } else {
         body = stream;
       }

--- a/src/ParseFile.ts
+++ b/src/ParseFile.ts
@@ -138,24 +138,12 @@ class ParseFile {
           type: specifiedType,
         };
       } else if (Array.isArray(data) || data instanceof Uint8Array) {
-        if (typeof Buffer !== 'undefined') {
-          const buffer =
-            data instanceof Uint8Array
-              ? Buffer.from(data.buffer, data.byteOffset, data.byteLength)
-              : Buffer.from(data);
-          this._source = {
-            format: 'buffer',
-            buffer,
-            type: specifiedType,
-          };
-        } else {
-          this._data = ParseFile.encodeBase64(data);
-          this._source = {
-            format: 'base64',
-            base64: this._data,
-            type: specifiedType,
-          };
-        }
+        this._data = ParseFile.encodeBase64(data);
+        this._source = {
+          format: 'base64',
+          base64: this._data,
+          type: specifiedType,
+        };
       } else if (typeof Blob !== 'undefined' && data instanceof Blob) {
         this._source = {
           format: 'file',
@@ -276,8 +264,8 @@ class ParseFile {
   /**
    * Saves the file to the Parse cloud.
    *
-   * In Node.js, files created with Buffer, ReadableStream, or byte arrays are
-   * uploaded as raw binary data, avoiding base64 encoding overhead. If metadata
+   * In Node.js, files created with Buffer or ReadableStream are uploaded as
+   * raw binary data, avoiding base64 encoding overhead. If metadata
    * or tags are set on a Buffer-backed file, the upload falls back to base64
    * JSON encoding (since the binary endpoint does not support metadata).
    * Stream-backed files with metadata or tags will throw an error.

--- a/src/ParseFile.ts
+++ b/src/ParseFile.ts
@@ -3,6 +3,11 @@ import CoreManager from './CoreManager';
 import type { FullOptions } from './RESTController';
 import ParseError from './ParseError';
 
+let NodeReadable: any;
+if (process.env.PARSE_BUILD === 'node') {
+  NodeReadable = require('stream').Readable;
+}
+
 interface Base64 {
   base64: string;
 }
@@ -622,9 +627,8 @@ const DefaultController = {
     } else if (source.format === 'stream') {
       const stream = source.stream;
       if (typeof stream.pipe === 'function' && typeof stream.read === 'function') {
-        const { Readable } = require('stream');
-        if (typeof Readable.toWeb === 'function') {
-          body = Readable.toWeb(stream);
+        if (NodeReadable && typeof NodeReadable.toWeb === 'function') {
+          body = NodeReadable.toWeb(stream);
         } else {
           throw new Error(
             'Streaming file uploads require Node.js >= 17.0.0. ' +

--- a/src/ParseFile.ts
+++ b/src/ParseFile.ts
@@ -29,6 +29,16 @@ export type FileSource =
       format: 'uri';
       uri: string;
       type: string | undefined;
+    }
+  | {
+      format: 'buffer';
+      buffer: any;
+      type: string | undefined;
+    }
+  | {
+      format: 'stream';
+      stream: any;
+      type: string | undefined;
     };
 
 export function b64Digit(number: number): string {
@@ -104,13 +114,48 @@ class ParseFile {
     this._tags = tags || {};
 
     if (data !== undefined) {
-      if (Array.isArray(data) || data instanceof Uint8Array) {
-        this._data = ParseFile.encodeBase64(data);
+      if (typeof Buffer !== 'undefined' && Buffer.isBuffer(data)) {
         this._source = {
-          format: 'base64',
-          base64: this._data,
+          format: 'buffer',
+          buffer: data,
           type: specifiedType,
         };
+      } else if (
+        data !== null &&
+        typeof data === 'object' &&
+        typeof (data as any).pipe === 'function' &&
+        typeof (data as any).read === 'function'
+      ) {
+        this._source = {
+          format: 'stream',
+          stream: data,
+          type: specifiedType,
+        };
+      } else if (typeof ReadableStream !== 'undefined' && data instanceof ReadableStream) {
+        this._source = {
+          format: 'stream',
+          stream: data,
+          type: specifiedType,
+        };
+      } else if (Array.isArray(data) || data instanceof Uint8Array) {
+        if (typeof Buffer !== 'undefined') {
+          const buffer =
+            data instanceof Uint8Array
+              ? Buffer.from(data.buffer, data.byteOffset, data.byteLength)
+              : Buffer.from(data);
+          this._source = {
+            format: 'buffer',
+            buffer,
+            type: specifiedType,
+          };
+        } else {
+          this._data = ParseFile.encodeBase64(data);
+          this._source = {
+            format: 'base64',
+            base64: this._data,
+            type: specifiedType,
+          };
+        }
       } else if (typeof Blob !== 'undefined' && data instanceof Blob) {
         this._source = {
           format: 'file',
@@ -163,6 +208,10 @@ class ParseFile {
   async getData(options?: { progress?: () => void }): Promise<string> {
     options = options || {};
     if (this._data) {
+      return this._data;
+    }
+    if (this._source?.format === 'buffer') {
+      this._data = this._source.buffer.toString('base64');
       return this._data;
     }
     if (!this._url) {
@@ -227,6 +276,12 @@ class ParseFile {
   /**
    * Saves the file to the Parse cloud.
    *
+   * In Node.js, files created with Buffer, ReadableStream, or byte arrays are
+   * uploaded as raw binary data, avoiding base64 encoding overhead. If metadata
+   * or tags are set on a Buffer-backed file, the upload falls back to base64
+   * JSON encoding (since the binary endpoint does not support metadata).
+   * Stream-backed files with metadata or tags will throw an error.
+   *
    * @param {object} options
    * Valid options are:<ul>
    *   <li>useMasterKey: In Cloud Code and Node only, causes the Master Key to
@@ -255,7 +310,50 @@ class ParseFile {
 
     const controller = CoreManager.getFileController();
     if (!this._previousSave) {
-      if (this._source.format === 'file') {
+      if (this._source.format === 'buffer' || this._source.format === 'stream') {
+        const hasMetadataOrTags =
+          (this._metadata && Object.keys(this._metadata).length > 0) ||
+          (this._tags && Object.keys(this._tags).length > 0);
+
+        if (this._source.format === 'stream' && hasMetadataOrTags) {
+          throw new Error(
+            'Cannot save a stream-based file with metadata or tags. Use a Buffer instead.'
+          );
+        }
+        if (this._source.format === 'stream' && !controller.saveBinary) {
+          throw new Error(
+            'Cannot save a stream-based file without saveBinary support on the FileController.'
+          );
+        }
+
+        if (!hasMetadataOrTags && controller.saveBinary) {
+          // Binary upload via ajax
+          this._previousSave = controller
+            .saveBinary(this._name, this._source, options)
+            .then(res => {
+              this._name = res.name;
+              this._url = res.url;
+              this._data = null;
+              this._requestTask = null;
+              return this;
+            });
+        } else if (this._source.format === 'buffer') {
+          // Buffer: fall back to base64 JSON encoding (metadata/tags or no saveBinary)
+          const base64Source = {
+            format: 'base64' as const,
+            base64: this._source.buffer.toString('base64'),
+            type: this._source.type,
+          };
+          this._previousSave = controller
+            .saveBase64(this._name, base64Source, options)
+            .then(res => {
+              this._name = res.name;
+              this._url = res.url;
+              this._requestTask = null;
+              return this;
+            });
+        }
+      } else if (this._source.format === 'file') {
         this._previousSave = controller.saveFile(this._name, this._source, options).then(res => {
           this._name = res.name;
           this._url = res.url;
@@ -483,6 +581,82 @@ const DefaultController = {
     }
     const path = 'files/' + name;
     return CoreManager.getRESTController().request('POST', path, data, options);
+  },
+
+  saveBinary: async function (
+    name: string,
+    source: FileSource,
+    options: FileSaveOptions = {}
+  ) {
+    if (source.format !== 'buffer' && source.format !== 'stream') {
+      throw new Error('saveBinary can only be used with Buffer or Stream sources.');
+    }
+
+    const headers: Record<string, string> = {
+      'X-Parse-Application-ID': CoreManager.get('APPLICATION_ID'),
+    };
+    headers['Content-Type'] = source.type || 'application/octet-stream';
+    const jsKey = CoreManager.get('JAVASCRIPT_KEY');
+    if (jsKey) {
+      headers['X-Parse-JavaScript-Key'] = jsKey;
+    }
+    let useMasterKey = options.useMasterKey;
+    if (typeof useMasterKey === 'undefined') {
+      useMasterKey = CoreManager.get('USE_MASTER_KEY');
+    }
+    if (useMasterKey) {
+      if (CoreManager.get('MASTER_KEY')) {
+        delete headers['X-Parse-JavaScript-Key'];
+        headers['X-Parse-Master-Key'] = CoreManager.get('MASTER_KEY');
+      } else {
+        throw new Error('Cannot use the Master Key, it has not been provided.');
+      }
+    }
+
+    if (options.sessionToken) {
+      headers['X-Parse-Session-Token'] = options.sessionToken;
+    } else {
+      const userController = CoreManager.getUserController();
+      if (userController) {
+        const user = await userController.currentUserAsync();
+        if (user) {
+          const token = user.getSessionToken();
+          if (token) {
+            headers['X-Parse-Session-Token'] = token;
+          }
+        }
+      }
+    }
+
+    let body: any;
+    if (source.format === 'buffer') {
+      body = source.buffer;
+    } else if (source.format === 'stream') {
+      const stream = source.stream;
+      if (typeof stream.pipe === 'function' && typeof stream.read === 'function') {
+        const { Readable } = require('stream');
+        if (typeof Readable.toWeb === 'function') {
+          body = Readable.toWeb(stream);
+        } else {
+          throw new Error(
+            'Streaming file uploads require Node.js >= 17.0.0. ' +
+              'Use a Buffer instead, or upgrade your Node.js version.'
+          );
+        }
+      } else {
+        body = stream;
+      }
+    }
+
+    let url = CoreManager.get('SERVER_URL');
+    if (url[url.length - 1] !== '/') {
+      url += '/';
+    }
+    url += 'files/' + name;
+
+    return CoreManager.getRESTController()
+      .ajax('POST', url, body, headers, options)
+      .then(({ response }) => response);
   },
 
   download: async function (uri, options) {

--- a/src/ParseFile.ts
+++ b/src/ParseFile.ts
@@ -588,7 +588,7 @@ const DefaultController = {
     const headers: Record<string, string> = {
       'X-Parse-Application-ID': CoreManager.get('APPLICATION_ID'),
     };
-    headers['Content-Type'] = source.type || 'application/octet-stream';
+    headers['Content-Type'] = (source.type || 'application/octet-stream').replace(/[\r\n]/g, '');
     const jsKey = CoreManager.get('JAVASCRIPT_KEY');
     if (jsKey) {
       headers['X-Parse-JavaScript-Key'] = jsKey;

--- a/src/ParseFile.ts
+++ b/src/ParseFile.ts
@@ -90,8 +90,13 @@ class ParseFile {
    *     1. an Array of byte value Numbers or Uint8Array.
    *     2. an Object like { base64: "..." } with a base64-encoded String.
    *     3. an Object like { uri: "..." } with a uri String.
-   *     4. a File object selected with a file upload control. (3) only works
-   *        in Firefox 3.6+, Safari 6.0.2+, Chrome 7+, and IE 10+.
+   *     4. a File object selected with a file upload control.
+   *     5. (Node.js only) a Buffer. Uploaded as raw binary data instead of
+   *        base64-encoding, reducing memory usage. Falls back to base64
+   *        JSON encoding if metadata or tags are set.
+   *     6. (Node.js only) a Readable stream, or a Web ReadableStream.
+   *        Streamed as raw binary data directly into the upload request.
+   *        Throws if metadata or tags are set.
    *        For example:
    * <pre>
    * var fileUploadControl = $("#profilePhotoFileUpload")[0];

--- a/src/RESTController.ts
+++ b/src/RESTController.ts
@@ -218,7 +218,9 @@ const RESTController = {
           });
         } else if (status >= 500 || status === 0) {
           // retry on 5XX or library error
-          if (++attempts < CoreManager.get('REQUEST_ATTEMPT_LIMIT')) {
+          // ReadableStream bodies cannot be retried because they are consumed by the first fetch
+          const isStream = typeof ReadableStream !== 'undefined' && data instanceof ReadableStream;
+          if (!isStream && ++attempts < CoreManager.get('REQUEST_ATTEMPT_LIMIT')) {
             // Exponentially-growing random delay
             const delay = Math.round(Math.random() * 125 * Math.pow(2, attempts));
             setTimeout(dispatch, delay);

--- a/src/RESTController.ts
+++ b/src/RESTController.ts
@@ -159,6 +159,9 @@ const RESTController = {
         };
         if (data) {
           fetchOptions.body = data;
+          if (typeof ReadableStream !== 'undefined' && data instanceof ReadableStream) {
+            fetchOptions.duplex = 'half';
+          }
         }
         const response = await fetch(url, fetchOptions);
         const { status } = response;

--- a/src/__tests__/ParseFile-test.js
+++ b/src/__tests__/ParseFile-test.js
@@ -892,7 +892,7 @@ describe('FileController', () => {
     const ajax = jest.fn().mockResolvedValue({
       response: {
         name: 'parse.txt',
-        url: 'https://files.parsetfss.com/a/parse.txt',
+        url: 'https://files.example.com/a/parse.txt',
       },
     });
     CoreManager.setRESTController({ request: () => {}, ajax });
@@ -905,7 +905,7 @@ describe('FileController', () => {
 
     expect(f).toBe(file);
     expect(f.name()).toBe('parse.txt');
-    expect(f.url()).toBe('https://files.parsetfss.com/a/parse.txt');
+    expect(f.url()).toBe('https://files.example.com/a/parse.txt');
     expect(ajax).toHaveBeenCalledWith(
       'POST',
       expect.stringContaining('/files/parse.txt'),
@@ -922,7 +922,7 @@ describe('FileController', () => {
 
   it('saveBinary defaults Content-Type to application/octet-stream', async () => {
     const ajax = jest.fn().mockResolvedValue({
-      response: { name: 'parse.txt', url: 'https://files.parsetfss.com/a/parse.txt' },
+      response: { name: 'parse.txt', url: 'https://files.example.com/a/parse.txt' },
     });
     CoreManager.setRESTController({ request: () => {}, ajax });
     CoreManager.set('APPLICATION_ID', 'testAppId');
@@ -947,7 +947,7 @@ describe('FileController', () => {
     const ajax = jest.fn().mockResolvedValue({
       response: {
         name: 'parse.txt',
-        url: 'https://files.parsetfss.com/a/parse.txt',
+        url: 'https://files.example.com/a/parse.txt',
       },
     });
     CoreManager.setRESTController({ request: () => {}, ajax });
@@ -958,7 +958,7 @@ describe('FileController', () => {
 
     expect(f).toBe(file);
     expect(f.name()).toBe('parse.txt');
-    expect(f.url()).toBe('https://files.parsetfss.com/a/parse.txt');
+    expect(f.url()).toBe('https://files.example.com/a/parse.txt');
     expect(ajax).toHaveBeenCalledWith(
       'POST',
       expect.stringContaining('/files/parse.txt'),
@@ -973,7 +973,7 @@ describe('FileController', () => {
 
   it('saveBinary includes session token from options', async () => {
     const ajax = jest.fn().mockResolvedValue({
-      response: { name: 'parse.txt', url: 'https://files.parsetfss.com/a/parse.txt' },
+      response: { name: 'parse.txt', url: 'https://files.example.com/a/parse.txt' },
     });
     CoreManager.setRESTController({ request: () => {}, ajax });
     CoreManager.set('APPLICATION_ID', 'testAppId');
@@ -1003,7 +1003,7 @@ describe('FileController', () => {
       },
     });
     const ajax = jest.fn().mockResolvedValue({
-      response: { name: 'parse.txt', url: 'https://files.parsetfss.com/a/parse.txt' },
+      response: { name: 'parse.txt', url: 'https://files.example.com/a/parse.txt' },
     });
     CoreManager.setRESTController({ request: () => {}, ajax });
     CoreManager.set('APPLICATION_ID', 'testAppId');
@@ -1024,7 +1024,7 @@ describe('FileController', () => {
 
   it('saveBinary includes master key when useMasterKey is true', async () => {
     const ajax = jest.fn().mockResolvedValue({
-      response: { name: 'parse.txt', url: 'https://files.parsetfss.com/a/parse.txt' },
+      response: { name: 'parse.txt', url: 'https://files.example.com/a/parse.txt' },
     });
     CoreManager.setRESTController({ request: () => {}, ajax });
     CoreManager.set('APPLICATION_ID', 'testAppId');
@@ -1078,7 +1078,7 @@ describe('FileController', () => {
   it('buffer with metadata falls back to saveBase64', async () => {
     const request = jest.fn().mockResolvedValue({
       name: 'parse.txt',
-      url: 'https://files.parsetfss.com/a/parse.txt',
+      url: 'https://files.example.com/a/parse.txt',
     });
     const ajax = jest.fn();
     CoreManager.setRESTController({ request, ajax });
@@ -1120,7 +1120,7 @@ describe('FileController', () => {
 
   it('buffer without metadata uses saveBinary', async () => {
     const ajax = jest.fn().mockResolvedValue({
-      response: { name: 'parse.txt', url: 'https://files.parsetfss.com/a/parse.txt' },
+      response: { name: 'parse.txt', url: 'https://files.example.com/a/parse.txt' },
     });
     const request = jest.fn();
     CoreManager.setRESTController({ request, ajax });
@@ -1139,7 +1139,7 @@ describe('FileController', () => {
       saveFile: jest.fn(),
       saveBase64: jest.fn().mockResolvedValue({
         name: 'parse.txt',
-        url: 'https://files.parsetfss.com/a/parse.txt',
+        url: 'https://files.example.com/a/parse.txt',
       }),
     });
 
@@ -1174,7 +1174,7 @@ describe('FileController', () => {
   it('buffer with tags falls back to saveBase64', async () => {
     const request = jest.fn().mockResolvedValue({
       name: 'parse.txt',
-      url: 'https://files.parsetfss.com/a/parse.txt',
+      url: 'https://files.example.com/a/parse.txt',
     });
     const ajax = jest.fn();
     CoreManager.setRESTController({ request, ajax });

--- a/src/__tests__/ParseFile-test.js
+++ b/src/__tests__/ParseFile-test.js
@@ -1199,6 +1199,35 @@ describe('FileController', () => {
     expect(ajax).not.toHaveBeenCalled();
   });
 
+  it('saveBinary passes Web ReadableStream body directly', async () => {
+    const { ReadableStream: WebReadableStream } = require('stream/web');
+    const origReadableStream = globalThis.ReadableStream;
+    globalThis.ReadableStream = WebReadableStream;
+    try {
+      const stream = new WebReadableStream({
+        start(controller) {
+          controller.enqueue(new Uint8Array([1, 2, 3]));
+          controller.close();
+        },
+      });
+
+      const ajax = jest.fn().mockResolvedValue({
+        response: { name: 'parse.txt', url: 'https://files.example.com/a/parse.txt' },
+      });
+      CoreManager.setRESTController({ request: () => {}, ajax });
+      CoreManager.set('APPLICATION_ID', 'testAppId');
+
+      const file = new ParseFile('parse.txt', stream, 'application/octet-stream');
+      await file.save();
+
+      // Web ReadableStream (no .pipe/.read) should be passed directly as body
+      const body = ajax.mock.calls[0][2];
+      expect(body).toBe(stream);
+    } finally {
+      globalThis.ReadableStream = origReadableStream;
+    }
+  });
+
   it('can save unsaved Parse.File property when localDataStore is enabled.', async () => {
     mockLocalDatastore.isEnabled = true;
     const obj = new ParseObject('Item');

--- a/src/__tests__/ParseFile-test.js
+++ b/src/__tests__/ParseFile-test.js
@@ -150,18 +150,21 @@ describe('ParseFile', () => {
     const file = new ParseFile('parse.txt', [61, 170, 236, 120]);
     expect(file._source.base64).toBe('ParseA==');
     expect(file._source.type).toBe('');
+    expect(file._data).toBe('ParseA==');
   });
 
   it('can create files with  Uint8Arrays', () => {
     const file = new ParseFile('parse.txt', new Uint8Array([61, 170, 236, 120]));
     expect(file._source.base64).toBe('ParseA==');
     expect(file._source.type).toBe('');
+    expect(file._data).toBe('ParseA==');
   });
 
   it('can create files with all types of characters', () => {
     const file = new ParseFile('parse.txt', [11, 239, 191, 215, 80, 52]);
     expect(file._source.base64).toBe('C++/11A0');
     expect(file._source.type).toBe('');
+    expect(file._data).toBe('C++/11A0');
   });
 
   it('can create an empty file', () => {
@@ -359,6 +362,7 @@ describe('ParseFile', () => {
     const file = new ParseFile('parse.txt', [61, 170, 236, 120], '', metadata, tags);
     expect(file._source.base64).toBe('ParseA==');
     expect(file._source.type).toBe('');
+    expect(file._data).toBe('ParseA==');
     expect(file.metadata()).toBe(metadata);
     expect(file.tags()).toBe(tags);
   });

--- a/src/__tests__/ParseFile-test.js
+++ b/src/__tests__/ParseFile-test.js
@@ -442,6 +442,7 @@ describe('ParseFile', () => {
       expect(file._source.format).toBe('stream');
       expect(file._source.stream).toBe(stream);
       expect(file._source.type).toBe('application/octet-stream');
+      expect(file._data).toBeUndefined();
     } finally {
       globalThis.ReadableStream = origReadableStream;
     }

--- a/src/__tests__/ParseFile-test.js
+++ b/src/__tests__/ParseFile-test.js
@@ -1027,6 +1027,7 @@ describe('FileController', () => {
     });
     CoreManager.setRESTController({ request: () => {}, ajax });
     CoreManager.set('APPLICATION_ID', 'testAppId');
+    CoreManager.set('JAVASCRIPT_KEY', 'testJsKey');
     CoreManager.set('MASTER_KEY', 'testMasterKey');
 
     const file = new ParseFile('parse.txt', Buffer.from([1, 2, 3]), 'text/plain');
@@ -1045,6 +1046,7 @@ describe('FileController', () => {
     const headers = ajax.mock.calls[0][3];
     expect(headers).not.toHaveProperty('X-Parse-JavaScript-Key');
     CoreManager.set('MASTER_KEY', null);
+    CoreManager.set('JAVASCRIPT_KEY', null);
   });
 
   it('saveBinary format error', async () => {

--- a/src/__tests__/ParseFile-test.js
+++ b/src/__tests__/ParseFile-test.js
@@ -917,6 +917,7 @@ describe('FileController', () => {
       }),
       expect.any(Object)
     );
+    CoreManager.set('JAVASCRIPT_KEY', null);
   });
 
   it('saveBinary defaults Content-Type to application/octet-stream', async () => {

--- a/src/__tests__/ParseFile-test.js
+++ b/src/__tests__/ParseFile-test.js
@@ -993,6 +993,7 @@ describe('FileController', () => {
   });
 
   it('saveBinary includes session token from currentUserAsync', async () => {
+    const originalUserController = CoreManager.get('UserController');
     CoreManager.set('UserController', {
       currentUserAsync() {
         return Promise.resolve({
@@ -1020,6 +1021,7 @@ describe('FileController', () => {
       }),
       expect.any(Object)
     );
+    CoreManager.set('UserController', originalUserController);
   });
 
   it('saveBinary includes master key when useMasterKey is true', async () => {

--- a/src/__tests__/ParseFile-test.js
+++ b/src/__tests__/ParseFile-test.js
@@ -148,26 +148,20 @@ describe('ParseFile', () => {
 
   it('can create files with byte arrays', () => {
     const file = new ParseFile('parse.txt', [61, 170, 236, 120]);
-    expect(file._source.format).toBe('buffer');
-    expect(Buffer.isBuffer(file._source.buffer)).toBe(true);
+    expect(file._source.base64).toBe('ParseA==');
     expect(file._source.type).toBe('');
-    expect(file._data).toBeUndefined();
   });
 
   it('can create files with  Uint8Arrays', () => {
     const file = new ParseFile('parse.txt', new Uint8Array([61, 170, 236, 120]));
-    expect(file._source.format).toBe('buffer');
-    expect(Buffer.isBuffer(file._source.buffer)).toBe(true);
+    expect(file._source.base64).toBe('ParseA==');
     expect(file._source.type).toBe('');
-    expect(file._data).toBeUndefined();
   });
 
   it('can create files with all types of characters', () => {
     const file = new ParseFile('parse.txt', [11, 239, 191, 215, 80, 52]);
-    expect(file._source.format).toBe('buffer');
-    expect(Buffer.isBuffer(file._source.buffer)).toBe(true);
+    expect(file._source.base64).toBe('C++/11A0');
     expect(file._source.type).toBe('');
-    expect(file._data).toBeUndefined();
   });
 
   it('can create an empty file', () => {
@@ -363,10 +357,8 @@ describe('ParseFile', () => {
     const metadata = { foo: 'bar' };
     const tags = { bar: 'foo' };
     const file = new ParseFile('parse.txt', [61, 170, 236, 120], '', metadata, tags);
-    expect(file._source.format).toBe('buffer');
-    expect(Buffer.isBuffer(file._source.buffer)).toBe(true);
+    expect(file._source.base64).toBe('ParseA==');
     expect(file._source.type).toBe('');
-    expect(file._data).toBeUndefined();
     expect(file.metadata()).toBe(metadata);
     expect(file.tags()).toBe(tags);
   });
@@ -413,22 +405,6 @@ describe('ParseFile', () => {
     expect(file._source.format).toBe('buffer');
     expect(file._source.buffer).toBe(buffer);
     expect(file._source.type).toBe('application/octet-stream');
-    expect(file._data).toBeUndefined();
-  });
-
-  it('can create files with a Uint8Array as buffer format in Node.js', () => {
-    const data = new Uint8Array([61, 170, 236, 120]);
-    const file = new ParseFile('parse.txt', data);
-    expect(file._source.format).toBe('buffer');
-    expect(Buffer.isBuffer(file._source.buffer)).toBe(true);
-    expect(file._data).toBeUndefined();
-  });
-
-  it('can create files with a number array as buffer format in Node.js', () => {
-    const data = [61, 170, 236, 120];
-    const file = new ParseFile('parse.txt', data);
-    expect(file._source.format).toBe('buffer');
-    expect(Buffer.isBuffer(file._source.buffer)).toBe(true);
     expect(file._data).toBeUndefined();
   });
 

--- a/src/__tests__/ParseFile-test.js
+++ b/src/__tests__/ParseFile-test.js
@@ -148,23 +148,26 @@ describe('ParseFile', () => {
 
   it('can create files with byte arrays', () => {
     const file = new ParseFile('parse.txt', [61, 170, 236, 120]);
-    expect(file._source.base64).toBe('ParseA==');
+    expect(file._source.format).toBe('buffer');
+    expect(Buffer.isBuffer(file._source.buffer)).toBe(true);
     expect(file._source.type).toBe('');
-    expect(file._data).toBe('ParseA==');
+    expect(file._data).toBeUndefined();
   });
 
   it('can create files with  Uint8Arrays', () => {
     const file = new ParseFile('parse.txt', new Uint8Array([61, 170, 236, 120]));
-    expect(file._source.base64).toBe('ParseA==');
+    expect(file._source.format).toBe('buffer');
+    expect(Buffer.isBuffer(file._source.buffer)).toBe(true);
     expect(file._source.type).toBe('');
-    expect(file._data).toBe('ParseA==');
+    expect(file._data).toBeUndefined();
   });
 
   it('can create files with all types of characters', () => {
     const file = new ParseFile('parse.txt', [11, 239, 191, 215, 80, 52]);
-    expect(file._source.base64).toBe('C++/11A0');
+    expect(file._source.format).toBe('buffer');
+    expect(Buffer.isBuffer(file._source.buffer)).toBe(true);
     expect(file._source.type).toBe('');
-    expect(file._data).toBe('C++/11A0');
+    expect(file._data).toBeUndefined();
   });
 
   it('can create an empty file', () => {
@@ -360,9 +363,10 @@ describe('ParseFile', () => {
     const metadata = { foo: 'bar' };
     const tags = { bar: 'foo' };
     const file = new ParseFile('parse.txt', [61, 170, 236, 120], '', metadata, tags);
-    expect(file._source.base64).toBe('ParseA==');
+    expect(file._source.format).toBe('buffer');
+    expect(Buffer.isBuffer(file._source.buffer)).toBe(true);
     expect(file._source.type).toBe('');
-    expect(file._data).toBe('ParseA==');
+    expect(file._data).toBeUndefined();
     expect(file.metadata()).toBe(metadata);
     expect(file.tags()).toBe(tags);
   });
@@ -402,6 +406,66 @@ describe('ParseFile', () => {
     file.addTag(10, 'bar');
     expect(file.tags()).toEqual({});
   });
+
+  it('can create files with a Buffer', () => {
+    const buffer = Buffer.from([61, 170, 236, 120]);
+    const file = new ParseFile('parse.txt', buffer, 'application/octet-stream');
+    expect(file._source.format).toBe('buffer');
+    expect(file._source.buffer).toBe(buffer);
+    expect(file._source.type).toBe('application/octet-stream');
+    expect(file._data).toBeUndefined();
+  });
+
+  it('can create files with a Uint8Array as buffer format in Node.js', () => {
+    const data = new Uint8Array([61, 170, 236, 120]);
+    const file = new ParseFile('parse.txt', data);
+    expect(file._source.format).toBe('buffer');
+    expect(Buffer.isBuffer(file._source.buffer)).toBe(true);
+    expect(file._data).toBeUndefined();
+  });
+
+  it('can create files with a number array as buffer format in Node.js', () => {
+    const data = [61, 170, 236, 120];
+    const file = new ParseFile('parse.txt', data);
+    expect(file._source.format).toBe('buffer');
+    expect(Buffer.isBuffer(file._source.buffer)).toBe(true);
+    expect(file._data).toBeUndefined();
+  });
+
+  it('can create files with a Node.js Readable stream', () => {
+    const { Readable } = require('stream');
+    const stream = new Readable({
+      read() {
+        this.push(Buffer.from([61, 170, 236, 120]));
+        this.push(null);
+      },
+    });
+    const file = new ParseFile('parse.txt', stream, 'application/octet-stream');
+    expect(file._source.format).toBe('stream');
+    expect(file._source.stream).toBe(stream);
+    expect(file._source.type).toBe('application/octet-stream');
+    expect(file._data).toBeUndefined();
+  });
+
+  it('can create files with a Web ReadableStream', () => {
+    const { ReadableStream: WebReadableStream } = require('stream/web');
+    const origReadableStream = globalThis.ReadableStream;
+    globalThis.ReadableStream = WebReadableStream;
+    try {
+      const stream = new WebReadableStream({
+        start(controller) {
+          controller.enqueue(new Uint8Array([61, 170, 236, 120]));
+          controller.close();
+        },
+      });
+      const file = new ParseFile('parse.txt', stream, 'application/octet-stream');
+      expect(file._source.format).toBe('stream');
+      expect(file._source.stream).toBe(stream);
+      expect(file._source.type).toBe('application/octet-stream');
+    } finally {
+      globalThis.ReadableStream = origReadableStream;
+    }
+  });
 });
 
 describe('FileController', () => {
@@ -415,7 +479,7 @@ describe('FileController', () => {
       });
     };
     const ajax = function (method, path) {
-      const name = path.substr(path.indexOf('/') + 1);
+      const name = path.substr(path.lastIndexOf('/') + 1);
       return Promise.resolve({
         response: {
           name: name,
@@ -547,6 +611,24 @@ describe('FileController', () => {
     const file = new ParseFile('parse.png');
     try {
       await file.getData();
+    } catch (e) {
+      expect(e.message).toBe('Cannot retrieve data for unsaved ParseFile.');
+    }
+  });
+
+  it('getData from buffer-backed file', async () => {
+    const file = new ParseFile('parse.txt', Buffer.from([61, 170, 236, 120]));
+    const data = await file.getData();
+    expect(data).toBe('ParseA==');
+  });
+
+  it('getData from stream-backed unsaved file throws', async () => {
+    const { Readable } = require('stream');
+    const stream = new Readable({ read() { this.push(null); } });
+    const file = new ParseFile('parse.txt', stream, 'text/plain');
+    try {
+      await file.getData();
+      expect(true).toBe(false);
     } catch (e) {
       expect(e.message).toBe('Cannot retrieve data for unsaved ParseFile.');
     }
@@ -823,6 +905,314 @@ describe('FileController', () => {
       expect(e).toBe('Could not load file.');
     }
     global.FileReader = fileReader;
+  });
+
+  it('saves buffer-backed files via saveBinary', async () => {
+    const ajax = jest.fn().mockResolvedValue({
+      response: {
+        name: 'parse.txt',
+        url: 'https://files.parsetfss.com/a/parse.txt',
+      },
+    });
+    CoreManager.setRESTController({ request: () => {}, ajax });
+    CoreManager.set('APPLICATION_ID', 'testAppId');
+    CoreManager.set('JAVASCRIPT_KEY', 'testJsKey');
+
+    const buffer = Buffer.from([61, 170, 236, 120]);
+    const file = new ParseFile('parse.txt', buffer, 'application/octet-stream');
+    const f = await file.save();
+
+    expect(f).toBe(file);
+    expect(f.name()).toBe('parse.txt');
+    expect(f.url()).toBe('https://files.parsetfss.com/a/parse.txt');
+    expect(ajax).toHaveBeenCalledWith(
+      'POST',
+      expect.stringContaining('/files/parse.txt'),
+      buffer,
+      expect.objectContaining({
+        'Content-Type': 'application/octet-stream',
+        'X-Parse-Application-ID': 'testAppId',
+        'X-Parse-JavaScript-Key': 'testJsKey',
+      }),
+      expect.any(Object)
+    );
+  });
+
+  it('saveBinary defaults Content-Type to application/octet-stream', async () => {
+    const ajax = jest.fn().mockResolvedValue({
+      response: { name: 'parse.txt', url: 'https://files.parsetfss.com/a/parse.txt' },
+    });
+    CoreManager.setRESTController({ request: () => {}, ajax });
+    CoreManager.set('APPLICATION_ID', 'testAppId');
+
+    // No content type specified — should default to application/octet-stream
+    const file = new ParseFile('parse.txt', Buffer.from([61, 170, 236, 120]));
+    await file.save();
+
+    const headers = ajax.mock.calls[0][3];
+    expect(headers['Content-Type']).toBe('application/octet-stream');
+  });
+
+  it('saves stream-backed files via saveBinary', async () => {
+    const { Readable } = require('stream');
+    const stream = new Readable({
+      read() {
+        this.push(Buffer.from([61, 170, 236, 120]));
+        this.push(null);
+      },
+    });
+
+    const ajax = jest.fn().mockResolvedValue({
+      response: {
+        name: 'parse.txt',
+        url: 'https://files.parsetfss.com/a/parse.txt',
+      },
+    });
+    CoreManager.setRESTController({ request: () => {}, ajax });
+    CoreManager.set('APPLICATION_ID', 'testAppId');
+
+    const file = new ParseFile('parse.txt', stream, 'text/plain');
+    const f = await file.save();
+
+    expect(f).toBe(file);
+    expect(f.name()).toBe('parse.txt');
+    expect(f.url()).toBe('https://files.parsetfss.com/a/parse.txt');
+    expect(ajax).toHaveBeenCalledWith(
+      'POST',
+      expect.stringContaining('/files/parse.txt'),
+      expect.anything(),
+      expect.objectContaining({
+        'Content-Type': 'text/plain',
+        'X-Parse-Application-ID': 'testAppId',
+      }),
+      expect.any(Object)
+    );
+  });
+
+  it('saveBinary includes session token from options', async () => {
+    const ajax = jest.fn().mockResolvedValue({
+      response: { name: 'parse.txt', url: 'https://files.parsetfss.com/a/parse.txt' },
+    });
+    CoreManager.setRESTController({ request: () => {}, ajax });
+    CoreManager.set('APPLICATION_ID', 'testAppId');
+
+    const file = new ParseFile('parse.txt', Buffer.from([1, 2, 3]), 'text/plain');
+    await file.save({ sessionToken: 'mySessionToken' });
+
+    expect(ajax).toHaveBeenCalledWith(
+      'POST',
+      expect.any(String),
+      expect.anything(),
+      expect.objectContaining({
+        'X-Parse-Session-Token': 'mySessionToken',
+      }),
+      expect.any(Object)
+    );
+  });
+
+  it('saveBinary includes session token from currentUserAsync', async () => {
+    CoreManager.set('UserController', {
+      currentUserAsync() {
+        return Promise.resolve({
+          getSessionToken() {
+            return 'currentUserToken';
+          },
+        });
+      },
+    });
+    const ajax = jest.fn().mockResolvedValue({
+      response: { name: 'parse.txt', url: 'https://files.parsetfss.com/a/parse.txt' },
+    });
+    CoreManager.setRESTController({ request: () => {}, ajax });
+    CoreManager.set('APPLICATION_ID', 'testAppId');
+
+    const file = new ParseFile('parse.txt', Buffer.from([1, 2, 3]), 'text/plain');
+    await file.save();
+
+    expect(ajax).toHaveBeenCalledWith(
+      'POST',
+      expect.any(String),
+      expect.anything(),
+      expect.objectContaining({
+        'X-Parse-Session-Token': 'currentUserToken',
+      }),
+      expect.any(Object)
+    );
+  });
+
+  it('saveBinary includes master key when useMasterKey is true', async () => {
+    const ajax = jest.fn().mockResolvedValue({
+      response: { name: 'parse.txt', url: 'https://files.parsetfss.com/a/parse.txt' },
+    });
+    CoreManager.setRESTController({ request: () => {}, ajax });
+    CoreManager.set('APPLICATION_ID', 'testAppId');
+    CoreManager.set('MASTER_KEY', 'testMasterKey');
+
+    const file = new ParseFile('parse.txt', Buffer.from([1, 2, 3]), 'text/plain');
+    await file.save({ useMasterKey: true });
+
+    expect(ajax).toHaveBeenCalledWith(
+      'POST',
+      expect.any(String),
+      expect.anything(),
+      expect.objectContaining({
+        'X-Parse-Master-Key': 'testMasterKey',
+      }),
+      expect.any(Object)
+    );
+    // Verify JS_KEY was deleted when master key is used
+    const headers = ajax.mock.calls[0][3];
+    expect(headers).not.toHaveProperty('X-Parse-JavaScript-Key');
+    CoreManager.set('MASTER_KEY', null);
+  });
+
+  it('saveBinary format error', async () => {
+    try {
+      await defaultController.saveBinary('parse.txt', { format: 'base64', base64: 'abc' });
+      expect(true).toBe(false);
+    } catch (e) {
+      expect(e.message).toBe('saveBinary can only be used with Buffer or Stream sources.');
+    }
+  });
+
+  it('saveBinary throws when useMasterKey is true but MASTER_KEY is not set', async () => {
+    const ajax = jest.fn();
+    CoreManager.setRESTController({ request: () => {}, ajax });
+    CoreManager.set('APPLICATION_ID', 'testAppId');
+    CoreManager.set('MASTER_KEY', null);
+
+    const file = new ParseFile('parse.txt', Buffer.from([1, 2, 3]), 'text/plain');
+    try {
+      await file.save({ useMasterKey: true });
+      expect(true).toBe(false);
+    } catch (e) {
+      expect(e.message).toBe('Cannot use the Master Key, it has not been provided.');
+    }
+    expect(ajax).not.toHaveBeenCalled();
+  });
+
+  it('buffer with metadata falls back to saveBase64', async () => {
+    const request = jest.fn().mockResolvedValue({
+      name: 'parse.txt',
+      url: 'https://files.parsetfss.com/a/parse.txt',
+    });
+    const ajax = jest.fn();
+    CoreManager.setRESTController({ request, ajax });
+
+    const file = new ParseFile('parse.txt', Buffer.from([61, 170, 236, 120]), 'text/plain');
+    file.addMetadata('foo', 'bar');
+    const f = await file.save();
+
+    expect(f).toBe(file);
+    expect(f.name()).toBe('parse.txt');
+    expect(request).toHaveBeenCalledWith(
+      'POST',
+      'files/parse.txt',
+      expect.objectContaining({
+        base64: expect.any(String),
+        fileData: expect.objectContaining({
+          metadata: { foo: 'bar' },
+        }),
+      }),
+      expect.any(Object)
+    );
+    expect(ajax).not.toHaveBeenCalled();
+  });
+
+  it('stream with metadata throws error', async () => {
+    const { Readable } = require('stream');
+    const stream = new Readable({ read() { this.push(null); } });
+    const file = new ParseFile('parse.txt', stream, 'text/plain');
+    file.addMetadata('foo', 'bar');
+    try {
+      await file.save();
+      expect(true).toBe(false);
+    } catch (e) {
+      expect(e.message).toBe(
+        'Cannot save a stream-based file with metadata or tags. Use a Buffer instead.'
+      );
+    }
+  });
+
+  it('buffer without metadata uses saveBinary', async () => {
+    const ajax = jest.fn().mockResolvedValue({
+      response: { name: 'parse.txt', url: 'https://files.parsetfss.com/a/parse.txt' },
+    });
+    const request = jest.fn();
+    CoreManager.setRESTController({ request, ajax });
+    CoreManager.set('APPLICATION_ID', 'testAppId');
+
+    const file = new ParseFile('parse.txt', Buffer.from([61, 170, 236, 120]), 'text/plain');
+    const f = await file.save();
+
+    expect(f).toBe(file);
+    expect(ajax).toHaveBeenCalled();
+    expect(request).not.toHaveBeenCalled();
+  });
+
+  it('falls back to saveBase64 when controller lacks saveBinary', async () => {
+    CoreManager.setFileController({
+      saveFile: jest.fn(),
+      saveBase64: jest.fn().mockResolvedValue({
+        name: 'parse.txt',
+        url: 'https://files.parsetfss.com/a/parse.txt',
+      }),
+    });
+
+    const file = new ParseFile('parse.txt', Buffer.from([61, 170, 236, 120]), 'text/plain');
+    const f = await file.save();
+
+    expect(f).toBe(file);
+    expect(f.name()).toBe('parse.txt');
+    const controller = CoreManager.getFileController();
+    expect(controller.saveBase64).toHaveBeenCalled();
+  });
+
+  it('stream throws when controller lacks saveBinary', async () => {
+    const { Readable } = require('stream');
+    CoreManager.setFileController({
+      saveFile: jest.fn(),
+      saveBase64: jest.fn(),
+    });
+
+    const stream = new Readable({ read() { this.push(null); } });
+    const file = new ParseFile('parse.txt', stream, 'text/plain');
+    try {
+      await file.save();
+      expect(true).toBe(false);
+    } catch (e) {
+      expect(e.message).toBe(
+        'Cannot save a stream-based file without saveBinary support on the FileController.'
+      );
+    }
+  });
+
+  it('buffer with tags falls back to saveBase64', async () => {
+    const request = jest.fn().mockResolvedValue({
+      name: 'parse.txt',
+      url: 'https://files.parsetfss.com/a/parse.txt',
+    });
+    const ajax = jest.fn();
+    CoreManager.setRESTController({ request, ajax });
+
+    const file = new ParseFile('parse.txt', Buffer.from([61, 170, 236, 120]), 'text/plain');
+    file.addTag('tagKey', 'tagValue');
+    const f = await file.save();
+
+    expect(f).toBe(file);
+    expect(f.name()).toBe('parse.txt');
+    expect(request).toHaveBeenCalledWith(
+      'POST',
+      'files/parse.txt',
+      expect.objectContaining({
+        base64: expect.any(String),
+        fileData: expect.objectContaining({
+          tags: { tagKey: 'tagValue' },
+        }),
+      }),
+      expect.any(Object)
+    );
+    expect(ajax).not.toHaveBeenCalled();
   });
 
   it('can save unsaved Parse.File property when localDataStore is enabled.', async () => {

--- a/src/__tests__/RESTController-test.js
+++ b/src/__tests__/RESTController-test.js
@@ -554,6 +554,32 @@ describe('RESTController', () => {
     }
   });
 
+  it('does not retry on 5XX when body is a ReadableStream', async () => {
+    mockFetch([
+      { status: 500, response: { code: 1, error: 'Internal server error.' } },
+      { status: 200, response: { success: true } },
+    ]);
+    const { ReadableStream: WebReadableStream } = require('stream/web');
+    const origReadableStream = globalThis.ReadableStream;
+    globalThis.ReadableStream = WebReadableStream;
+    try {
+      const stream = new WebReadableStream({
+        start(controller) {
+          controller.enqueue(new Uint8Array([1, 2, 3]));
+          controller.close();
+        },
+      });
+      await expect(
+        RESTController.ajax('POST', 'https://example.com/files/file.txt', stream, {
+          'Content-Type': 'application/octet-stream',
+        })
+      ).rejects.toEqual({ code: 1, error: 'Internal server error.' });
+      expect(fetch.mock.calls.length).toBe(1);
+    } finally {
+      globalThis.ReadableStream = origReadableStream;
+    }
+  });
+
   it('does not set duplex when body is not a ReadableStream', async () => {
     mockFetch([{ status: 200, response: { success: true } }]);
     await RESTController.ajax('POST', 'users', { key: 'value' });

--- a/src/__tests__/RESTController-test.js
+++ b/src/__tests__/RESTController-test.js
@@ -532,4 +532,31 @@ describe('RESTController', () => {
     // Clean up the custom SERVER_URL
     CoreManager.set('SERVER_URL', 'https://api.parse.com/1');
   });
+
+  it('sets duplex half when body is a ReadableStream', async () => {
+    mockFetch([{ status: 200, response: { name: 'file.txt', url: 'https://example.com/file.txt' } }]);
+    const { ReadableStream: WebReadableStream } = require('stream/web');
+    const origReadableStream = globalThis.ReadableStream;
+    globalThis.ReadableStream = WebReadableStream;
+    try {
+      const stream = new WebReadableStream({
+        start(controller) {
+          controller.enqueue(new Uint8Array([1, 2, 3]));
+          controller.close();
+        },
+      });
+      await RESTController.ajax('POST', 'https://example.com/files/file.txt', stream, {
+        'Content-Type': 'application/octet-stream',
+      });
+      expect(fetch.mock.calls[0][1].duplex).toBe('half');
+    } finally {
+      globalThis.ReadableStream = origReadableStream;
+    }
+  });
+
+  it('does not set duplex when body is not a ReadableStream', async () => {
+    mockFetch([{ status: 200, response: { success: true } }]);
+    await RESTController.ajax('POST', 'users', { key: 'value' });
+    expect(fetch.mock.calls[0][1].duplex).toBeUndefined();
+  });
 });

--- a/types/CoreManager.d.ts
+++ b/types/CoreManager.d.ts
@@ -38,6 +38,10 @@ export interface FileController {
         name: string;
         url: string;
     }>;
+    saveBinary?: (name: string, source: FileSource, options?: FileSaveOptions) => Promise<{
+        name: string;
+        url: string;
+    }>;
     download: (uri: string, options?: any) => Promise<{
         base64?: string;
         contentType?: string;

--- a/types/ParseFile.d.ts
+++ b/types/ParseFile.d.ts
@@ -57,12 +57,12 @@ declare class ParseFile {
      *     2. an Object like { base64: "..." } with a base64-encoded String.
      *     3. an Object like { uri: "..." } with a uri String.
      *     4. a File object selected with a file upload control.
-     *     5. a Node.js Buffer (binary upload, no base64 overhead).
-     *     6. a Node.js Readable stream or Web ReadableStream (streaming binary upload).
-     *
-     *     In Node.js, formats 5 and 6 use binary upload by default, sending
-     *     the raw data directly instead of base64-encoding it. This significantly
-     *     reduces memory usage for large files.
+     *     5. (Node.js only) a Buffer. Uploaded as raw binary data instead of
+     *        base64-encoding, reducing memory usage. Falls back to base64
+     *        JSON encoding if metadata or tags are set.
+     *     6. (Node.js only) a Readable stream, or a Web ReadableStream.
+     *        Streamed as raw binary data directly into the upload request.
+     *        Throws if metadata or tags are set.
      *        For example:
      * <pre>
      * var fileUploadControl = $("#profilePhotoFileUpload")[0];

--- a/types/ParseFile.d.ts
+++ b/types/ParseFile.d.ts
@@ -60,7 +60,7 @@ declare class ParseFile {
      *     5. a Node.js Buffer (binary upload, no base64 overhead).
      *     6. a Node.js Readable stream or Web ReadableStream (streaming binary upload).
      *
-     *     In Node.js, formats 1, 5, and 6 use binary upload by default, sending
+     *     In Node.js, formats 5 and 6 use binary upload by default, sending
      *     the raw data directly instead of base64-encoding it. This significantly
      *     reduces memory usage for large files.
      *        For example:
@@ -139,8 +139,8 @@ declare class ParseFile {
     /**
      * Saves the file to the Parse cloud.
      *
-     * In Node.js, files created with Buffer, ReadableStream, or byte arrays are
-     * uploaded as raw binary data, avoiding base64 encoding overhead. If metadata
+     * In Node.js, files created with Buffer or ReadableStream are uploaded as
+     * raw binary data, avoiding base64 encoding overhead. If metadata
      * or tags are set on a Buffer-backed file, the upload falls back to base64
      * JSON encoding (since the binary endpoint does not support metadata).
      * Stream-backed files with metadata or tags will throw an error.

--- a/types/ParseFile.d.ts
+++ b/types/ParseFile.d.ts
@@ -22,6 +22,14 @@ export type FileSource = {
     format: 'uri';
     uri: string;
     type: string | undefined;
+} | {
+    format: 'buffer';
+    buffer: any;
+    type: string | undefined;
+} | {
+    format: 'stream';
+    stream: any;
+    type: string | undefined;
 };
 export declare function b64Digit(number: number): string;
 /**
@@ -48,8 +56,13 @@ declare class ParseFile {
      *     1. an Array of byte value Numbers or Uint8Array.
      *     2. an Object like { base64: "..." } with a base64-encoded String.
      *     3. an Object like { uri: "..." } with a uri String.
-     *     4. a File object selected with a file upload control. (3) only works
-     *        in Firefox 3.6+, Safari 6.0.2+, Chrome 7+, and IE 10+.
+     *     4. a File object selected with a file upload control.
+     *     5. a Node.js Buffer (binary upload, no base64 overhead).
+     *     6. a Node.js Readable stream or Web ReadableStream (streaming binary upload).
+     *
+     *     In Node.js, formats 1, 5, and 6 use binary upload by default, sending
+     *     the raw data directly instead of base64-encoding it. This significantly
+     *     reduces memory usage for large files.
      *        For example:
      * <pre>
      * var fileUploadControl = $("#profilePhotoFileUpload")[0];
@@ -125,6 +138,12 @@ declare class ParseFile {
     tags(): Record<string, any>;
     /**
      * Saves the file to the Parse cloud.
+     *
+     * In Node.js, files created with Buffer, ReadableStream, or byte arrays are
+     * uploaded as raw binary data, avoiding base64 encoding overhead. If metadata
+     * or tags are set on a Buffer-backed file, the upload falls back to base64
+     * JSON encoding (since the binary endpoint does not support metadata).
+     * Stream-backed files with metadata or tags will throw an error.
      *
      * @param {object} options
      * Valid options are:<ul>


### PR DESCRIPTION
## Pull Request

- Report security issues [confidentially](https://github.com/parse-community/Parse-SDK-JS/security/policy).
- Any contribution is under this [license](https://github.com/parse-community/Parse-SDK-JS/blob/alpha/LICENSE).
- Link this pull request to an [issue](https://github.com/parse-community/Parse-SDK-JS/issues?q=is%3Aissue).

## Issue

Add support for file upload via `Buffer`, `Readable`, `ReadableStream`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Optional controller API to upload raw binary data; direct binary upload support for Buffer and ReadableStream inputs with automatic routing in save flows.

* **Behavior Changes**
  * Streams with metadata/tags are disallowed; buffers with metadata/tags fall back to base64 uploads; fallback to base64 if binary upload not supported.
  * Streaming request bodies use half‑duplex where applicable and are excluded from retry logic.

* **Documentation / Types**
  * Public types updated to include buffer and stream input formats.

* **Tests**
  * Extensive tests covering buffer/stream uploads, headers, auth, fallbacks, and error cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->