### PR TITLE
feat: Add request header `X-Parse-Upload-Mode` to identify file upload as binary data via `Buffer`, `Readable`, `ReadableStream`

### DIFF
--- a/src/ParseFile.ts
+++ b/src/ParseFile.ts
@@ -592,6 +592,7 @@ const DefaultController = {
 
     const headers: Record<string, string> = {
       'X-Parse-Application-ID': CoreManager.get('APPLICATION_ID'),
+      'X-Parse-Upload-Mode': 'stream',
     };
     headers['Content-Type'] = (source.type || 'application/octet-stream').replace(/[\r\n]/g, '');
     const jsKey = CoreManager.get('JAVASCRIPT_KEY');

--- a/src/__tests__/ParseFile-test.js
+++ b/src/__tests__/ParseFile-test.js
@@ -914,6 +914,7 @@ describe('FileController', () => {
         'Content-Type': 'application/octet-stream',
         'X-Parse-Application-ID': 'testAppId',
         'X-Parse-JavaScript-Key': 'testJsKey',
+        'X-Parse-Upload-Mode': 'stream',
       }),
       expect.any(Object)
     );
@@ -966,9 +967,32 @@ describe('FileController', () => {
       expect.objectContaining({
         'Content-Type': 'text/plain',
         'X-Parse-Application-ID': 'testAppId',
+        'X-Parse-Upload-Mode': 'stream',
       }),
       expect.any(Object)
     );
+  });
+
+  it('base64 uploads do not include X-Parse-Upload-Mode header', async () => {
+    const request = jest.fn().mockResolvedValue({
+      name: 'parse.txt',
+      url: 'https://files.example.com/a/parse.txt',
+    });
+    CoreManager.setRESTController({ request, ajax: () => {} });
+    CoreManager.set('APPLICATION_ID', 'testAppId');
+
+    const file = new ParseFile('parse.txt', [61, 170, 236, 120]);
+    await file.save();
+
+    expect(request).toHaveBeenCalledWith(
+      'POST',
+      'files/parse.txt',
+      expect.objectContaining({ base64: expect.any(String) }),
+      expect.any(Object)
+    );
+    // Verify request() was called — not ajax() with binary headers
+    const payload = request.mock.calls[0][2];
+    expect(payload['X-Parse-Upload-Mode']).toBeUndefined();
   });
 
   it('saveBinary includes session token from options', async () => {
@@ -1225,6 +1249,8 @@ describe('FileController', () => {
       // Web ReadableStream (no .pipe/.read) should be passed directly as body
       const body = ajax.mock.calls[0][2];
       expect(body).toBe(stream);
+      const headers = ajax.mock.calls[0][3];
+      expect(headers['X-Parse-Upload-Mode']).toBe('stream');
     } finally {
       globalThis.ReadableStream = origReadableStream;
     }

--- a/src/__tests__/ParseFile-test.js
+++ b/src/__tests__/ParseFile-test.js
@@ -978,7 +978,8 @@ describe('FileController', () => {
       name: 'parse.txt',
       url: 'https://files.example.com/a/parse.txt',
     });
-    CoreManager.setRESTController({ request, ajax: () => {} });
+    const ajax = jest.fn();
+    CoreManager.setRESTController({ request, ajax });
     CoreManager.set('APPLICATION_ID', 'testAppId');
 
     const file = new ParseFile('parse.txt', [61, 170, 236, 120]);
@@ -990,9 +991,8 @@ describe('FileController', () => {
       expect.objectContaining({ base64: expect.any(String) }),
       expect.any(Object)
     );
-    // Verify request() was called — not ajax() with binary headers
-    const payload = request.mock.calls[0][2];
-    expect(payload['X-Parse-Upload-Mode']).toBeUndefined();
+    // Binary path (which sets X-Parse-Upload-Mode) should not be taken
+    expect(ajax).not.toHaveBeenCalled();
   });
 
   it('saveBinary includes session token from options', async () => {


### PR DESCRIPTION
## Pull Request

- Report security issues [confidentially](https://github.com/parse-community/Parse-SDK-JS/security/policy).
- Any contribution is under this [license](https://github.com/parse-community/Parse-SDK-JS/blob/alpha/LICENSE).
- Link this pull request to an [issue](https://github.com/parse-community/Parse-SDK-JS/issues?q=is%3Aissue).

## Issue

Add request header `X-Parse-Upload-Mode` to identify file upload as binary data via `Buffer`, `Readable`, `ReadableStream`.

This new header is needed to distinguish between the new [streaming](https://github.com/parse-community/Parse-SDK-JS/pull/2925) and traditional non-streaming file upload on the Parse Server side. Other ways to distinguish have drawbacks and introduce breaking changes in edge cases. For example, using `Content-Type: application/octet-stream` to infer streaming would be a misuse as it should describe the data, not delivery mode.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced stream-based file upload handling with explicit upload mode indication.

* **Tests**
  * Added comprehensive test coverage for stream and base64 upload modes to ensure proper header configuration across upload scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->