### PR TITLE
feat: Add support for `Parse.File.setDirectory()` with master key to save file in directory

### DIFF
--- a/src/ParseFile.ts
+++ b/src/ParseFile.ts
@@ -18,6 +18,7 @@ type FileData = number[] | Base64 | Blob | Uri;
 export type FileSaveOptions = FullOptions & {
   metadata?: Record<string, any>;
   tags?: Record<string, any>;
+  directory?: string;
 };
 export type FileSource =
   | {
@@ -80,6 +81,7 @@ class ParseFile {
   _requestTask?: any;
   _metadata?: Record<string, any>;
   _tags?: Record<string, any>;
+  _directory?: string;
 
   /**
    * @param name {String} The file's name. This will be prefixed by a unique
@@ -272,6 +274,15 @@ class ParseFile {
   }
 
   /**
+   * Gets the directory of the file.
+   *
+   * @returns {string | undefined}
+   */
+  directory(): string | undefined {
+    return this._directory;
+  }
+
+  /**
    * Saves the file to the Parse cloud.
    *
    * In Node.js, files created with Buffer or ReadableStream are uploaded as
@@ -305,6 +316,7 @@ class ParseFile {
     options.requestTask = task => (this._requestTask = task);
     options.metadata = this._metadata;
     options.tags = this._tags;
+    options.directory = this._directory;
 
     const controller = CoreManager.getFileController();
     if (!this._previousSave) {
@@ -504,6 +516,18 @@ class ParseFile {
     }
   }
 
+  /**
+   * Sets the directory where the file will be stored.
+   * Requires the Master Key when saving.
+   *
+   * @param {string} directory the directory path
+   */
+  setDirectory(directory: string) {
+    if (typeof directory === 'string') {
+      this._directory = directory;
+    }
+  }
+
   static fromJSON(obj): ParseFile {
     if (obj.__type !== 'File') {
       throw new TypeError('JSON object does not represent a ParseFile');
@@ -570,10 +594,12 @@ const DefaultController = {
       fileData: {
         metadata: { ...options.metadata },
         tags: { ...options.tags },
+        ...(options.directory ? { directory: options.directory } : {}),
       },
     };
     delete options.metadata;
     delete options.tags;
+    delete options.directory;
     if (source.type) {
       data._ContentType = source.type;
     }

--- a/src/ParseFile.ts
+++ b/src/ParseFile.ts
@@ -321,13 +321,14 @@ class ParseFile {
     const controller = CoreManager.getFileController();
     if (!this._previousSave) {
       if (this._source.format === 'buffer' || this._source.format === 'stream') {
-        const hasMetadataOrTags =
+        const hasFileData =
           (this._metadata && Object.keys(this._metadata).length > 0) ||
-          (this._tags && Object.keys(this._tags).length > 0);
+          (this._tags && Object.keys(this._tags).length > 0) ||
+          !!this._directory;
 
-        if (this._source.format === 'stream' && hasMetadataOrTags) {
+        if (this._source.format === 'stream' && hasFileData) {
           throw new Error(
-            'Cannot save a stream-based file with metadata or tags. Use a Buffer instead.'
+            'Cannot save a stream-based file with metadata, tags, or directory. Use a Buffer instead.'
           );
         }
         if (this._source.format === 'stream' && !controller.saveBinary) {
@@ -336,7 +337,7 @@ class ParseFile {
           );
         }
 
-        if (!hasMetadataOrTags && controller.saveBinary) {
+        if (!hasFileData && controller.saveBinary) {
           // Binary upload via ajax
           this._previousSave = controller
             .saveBinary(this._name, this._source, options)
@@ -523,7 +524,7 @@ class ParseFile {
    * @param {string} directory the directory path
    */
   setDirectory(directory: string) {
-    if (typeof directory === 'string') {
+    if (typeof directory === 'string' && directory.length > 0) {
       this._directory = directory;
     }
   }

--- a/src/__tests__/ParseFile-test.js
+++ b/src/__tests__/ParseFile-test.js
@@ -351,6 +351,33 @@ describe('ParseFile', () => {
       {
         metadata: { foo: 'bar' },
         tags: { bar: 'foo' },
+        directory: undefined,
+        requestTask: expect.any(Function),
+      }
+    );
+  });
+
+  it('should save file with directory option', async () => {
+    const fileController = {
+      saveFile: jest.fn().mockResolvedValue({}),
+      saveBase64: () => {},
+      download: () => {},
+    };
+    CoreManager.setFileController(fileController);
+    const file = new ParseFile('donald_duck.txt', new File(['Parse'], 'donald_duck.txt'));
+    file.setDirectory('user-uploads/avatars');
+    await file.save();
+    expect(fileController.saveFile).toHaveBeenCalledWith(
+      'donald_duck.txt',
+      {
+        file: expect.any(File),
+        format: 'file',
+        type: '',
+      },
+      {
+        metadata: {},
+        tags: {},
+        directory: 'user-uploads/avatars',
         requestTask: expect.any(Function),
       }
     );
@@ -401,6 +428,23 @@ describe('ParseFile', () => {
     const file = new ParseFile('parse.txt', [61, 170, 236, 120]);
     file.addTag(10, 'bar');
     expect(file.tags()).toEqual({});
+  });
+
+  it('should set directory', () => {
+    const file = new ParseFile('parse.txt', [61, 170, 236, 120]);
+    file.setDirectory('user-uploads/avatars');
+    expect(file.directory()).toBe('user-uploads/avatars');
+  });
+
+  it('should not set directory if value is not a string', () => {
+    const file = new ParseFile('parse.txt', [61, 170, 236, 120]);
+    file.setDirectory(123);
+    expect(file.directory()).toBeUndefined();
+  });
+
+  it('should return undefined directory by default', () => {
+    const file = new ParseFile('parse.txt', [61, 170, 236, 120]);
+    expect(file.directory()).toBeUndefined();
   });
 
   it('can create files with a Buffer', () => {
@@ -755,6 +799,68 @@ describe('FileController', () => {
           tags: {
             bar: 'foo',
           },
+        },
+      },
+      { requestTask: expect.any(Function) }
+    );
+  });
+
+  it('should include directory in fileData payload when saving', async () => {
+    const request = jest.fn((method, path) => {
+      const name = path.substr(path.indexOf('/') + 1);
+      return Promise.resolve({
+        name: name,
+        url: 'https://files.example.com/a/' + name,
+      });
+    });
+    const ajax = function () {
+      return Promise.resolve({ response: {} });
+    };
+    CoreManager.setRESTController({ request, ajax });
+
+    const file = new ParseFile('parse.txt', { base64: 'ParseA==' });
+    file.setDirectory('user-uploads/avatars');
+    await file.save();
+    expect(request).toHaveBeenCalledWith(
+      'POST',
+      'files/parse.txt',
+      {
+        base64: 'ParseA==',
+        _ContentType: 'text/plain',
+        fileData: {
+          metadata: {},
+          tags: {},
+          directory: 'user-uploads/avatars',
+        },
+      },
+      { requestTask: expect.any(Function) }
+    );
+  });
+
+  it('should not include directory in fileData payload when not set', async () => {
+    const request = jest.fn((method, path) => {
+      const name = path.substr(path.indexOf('/') + 1);
+      return Promise.resolve({
+        name: name,
+        url: 'https://files.example.com/a/' + name,
+      });
+    });
+    const ajax = function () {
+      return Promise.resolve({ response: {} });
+    };
+    CoreManager.setRESTController({ request, ajax });
+
+    const file = new ParseFile('parse.txt', { base64: 'ParseA==' });
+    await file.save();
+    expect(request).toHaveBeenCalledWith(
+      'POST',
+      'files/parse.txt',
+      {
+        base64: 'ParseA==',
+        _ContentType: 'text/plain',
+        fileData: {
+          metadata: {},
+          tags: {},
         },
       },
       { requestTask: expect.any(Function) }

--- a/src/__tests__/ParseFile-test.js
+++ b/src/__tests__/ParseFile-test.js
@@ -442,6 +442,12 @@ describe('ParseFile', () => {
     expect(file.directory()).toBeUndefined();
   });
 
+  it('should not set directory if value is an empty string', () => {
+    const file = new ParseFile('parse.txt', [61, 170, 236, 120]);
+    file.setDirectory('');
+    expect(file.directory()).toBeUndefined();
+  });
+
   it('should return undefined directory by default', () => {
     const file = new ParseFile('parse.txt', [61, 170, 236, 120]);
     expect(file.directory()).toBeUndefined();
@@ -1245,7 +1251,7 @@ describe('FileController', () => {
       expect(true).toBe(false);
     } catch (e) {
       expect(e.message).toBe(
-        'Cannot save a stream-based file with metadata or tags. Use a Buffer instead.'
+        'Cannot save a stream-based file with metadata, tags, or directory. Use a Buffer instead.'
       );
     }
   });
@@ -1264,6 +1270,29 @@ describe('FileController', () => {
     expect(f).toBe(file);
     expect(ajax).toHaveBeenCalled();
     expect(request).not.toHaveBeenCalled();
+  });
+
+  it('buffer with directory falls back to saveBase64', async () => {
+    const request = jest.fn().mockResolvedValue({
+      name: 'parse.txt',
+      url: 'https://files.example.com/a/parse.txt',
+    });
+    const ajax = jest.fn();
+    CoreManager.setRESTController({ request, ajax });
+
+    const file = new ParseFile('parse.txt', Buffer.from([61, 170, 236, 120]), 'text/plain');
+    file.setDirectory('user-uploads/avatars');
+    await file.save();
+
+    expect(ajax).not.toHaveBeenCalled();
+    expect(request).toHaveBeenCalledWith(
+      'POST',
+      'files/parse.txt',
+      expect.objectContaining({
+        fileData: expect.objectContaining({ directory: 'user-uploads/avatars' }),
+      }),
+      expect.any(Object)
+    );
   });
 
   it('falls back to saveBase64 when controller lacks saveBinary', async () => {

--- a/types/ParseFile.d.ts
+++ b/types/ParseFile.d.ts
@@ -9,6 +9,7 @@ type FileData = number[] | Base64 | Blob | Uri;
 export type FileSaveOptions = FullOptions & {
     metadata?: Record<string, any>;
     tags?: Record<string, any>;
+    directory?: string;
 };
 export type FileSource = {
     format: 'file';
@@ -47,6 +48,7 @@ declare class ParseFile {
     _requestTask?: any;
     _metadata?: Record<string, any>;
     _tags?: Record<string, any>;
+    _directory?: string;
     /**
      * @param name {String} The file's name. This will be prefixed by a unique
      *     value once the file has finished saving. The file name must begin with
@@ -137,6 +139,12 @@ declare class ParseFile {
      */
     tags(): Record<string, any>;
     /**
+     * Gets the directory of the file.
+     *
+     * @returns {string | undefined}
+     */
+    directory(): string | undefined;
+    /**
      * Saves the file to the Parse cloud.
      *
      * In Node.js, files created with Buffer or ReadableStream are uploaded as
@@ -216,6 +224,13 @@ declare class ParseFile {
      * @param {*} value tag
      */
     addTag(key: string, value: string): void;
+    /**
+     * Sets the directory where the file will be stored.
+     * Requires the Master Key when saving.
+     *
+     * @param {string} directory the directory path
+     */
+    setDirectory(directory: string): void;
     static fromJSON(obj: any): ParseFile;
     static encodeBase64(bytes: number[] | Uint8Array): string;
 }


### PR DESCRIPTION
## Pull Request

- Report security issues [confidentially](https://github.com/parse-community/Parse-SDK-JS/security/policy).
- Any contribution is under this [license](https://github.com/parse-community/Parse-SDK-JS/blob/alpha/LICENSE).
- Link this pull request to an [issue](https://github.com/parse-community/Parse-SDK-JS/issues?q=is%3Aissue).

## Issue

Setting a directory in which to store a `Parse.File` is currently not possible, as the filename validation in Parse Server  as part of the file name. The Parse Server S3 storage adapter allows to set a bucket prefix for all files, but not on a per-file level.

## Approach

Add support for directory using master key when saving a `Parse.File`. Adds a directory property to `Parse.File` that allows specifying a storage directory path when saving files. The directory is prepended to the filename before passing it to the storage adapter.

The `beforeSaveFile` trigger can also set the directory server-side. No S3 adapter changes are needed as it already handles `/` in filenames.

Requires additional PR for parse-server, where integration tests will be added.

## Tasks
<!-- Delete tasks that don't apply. -->

- [x] Add tests
- [x] Add changes to documentation (guides, repository pages, code comments)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * File directory support: set and retrieve a storage directory for files; directory is included in save operations to help organize saved files.

* **Bug Fixes / Improvements**
  * Validation for directory input (rejects empty/invalid values) and clearer error messaging when saving unsupported stream-based files with directory, metadata, or tags.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->