### PR TITLE
docs: Add missing Parse Server requirement to JSDoc for `Parse.File.setDirectory()`

### DIFF
--- a/src/ParseFile.ts
+++ b/src/ParseFile.ts
@@ -275,6 +275,7 @@ class ParseFile {
 
   /**
    * Gets the directory of the file.
+   * Requires Parse Server >= 9.4.0.
    *
    * @returns {string | undefined}
    */
@@ -520,6 +521,7 @@ class ParseFile {
   /**
    * Sets the directory where the file will be stored.
    * Requires the Master Key when saving.
+   * Requires Parse Server >= 9.4.0.
    *
    * @param {string} directory the directory path
    */

--- a/types/ParseFile.d.ts
+++ b/types/ParseFile.d.ts
@@ -140,6 +140,7 @@ declare class ParseFile {
     tags(): Record<string, any>;
     /**
      * Gets the directory of the file.
+     * Requires Parse Server >= 9.4.0.
      *
      * @returns {string | undefined}
      */
@@ -227,6 +228,7 @@ declare class ParseFile {
     /**
      * Sets the directory where the file will be stored.
      * Requires the Master Key when saving.
+     * Requires Parse Server >= 9.4.0.
      *
      * @param {string} directory the directory path
      */


### PR DESCRIPTION
## Pull Request

- Report security issues [confidentially](https://github.com/parse-community/Parse-SDK-JS/security/policy).
- Any contribution is under this [license](https://github.com/parse-community/Parse-SDK-JS/blob/alpha/LICENSE).
- Link this pull request to an [issue](https://github.com/parse-community/Parse-SDK-JS/issues?q=is%3Aissue).

## Issue

Add missing Parse Server requirement to JSDoc for `Parse.File.setDirectory()`

## Tasks
<!-- Delete tasks that don't apply. -->

- [ ] Add tests
- [x] Add changes to documentation (guides, repository pages, code comments)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated ParseFile.directory() and ParseFile.setDirectory() method documentation to specify Parse Server >= 9.4.0 requirement.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->