### PR TITLE
feat: Add `Parse.File` option `maxUploadSize` to override the Parse Server option `maxUploadSize` per file upload

### DIFF
--- a/src/ParseFile.ts
+++ b/src/ParseFile.ts
@@ -19,6 +19,7 @@ export type FileSaveOptions = FullOptions & {
   metadata?: Record<string, any>;
   tags?: Record<string, any>;
   directory?: string;
+  maxUploadSize?: string;
 };
 export type FileSource =
   | {
@@ -333,7 +334,7 @@ class ParseFile {
           (this._tags && Object.keys(this._tags).length > 0) ||
           !!this._directory;
 
-        if (controller.saveBinary && (this._source.format === 'stream' || !hasFileData)) {
+        if (controller.saveBinary && (this._source.format === 'stream' || !hasFileData || options.maxUploadSize)) {
           // Binary upload via ajax (file data sent via headers for streams)
           this._previousSave = controller
             .saveBinary(this._name, this._source, options)
@@ -631,6 +632,9 @@ const DefaultController = {
     }
     if (options.tags && Object.keys(options.tags).length > 0) {
       headers['X-Parse-File-Tags'] = JSON.stringify(options.tags);
+    }
+    if (options.maxUploadSize) {
+      headers['X-Parse-File-Max-Upload-Size'] = options.maxUploadSize;
     }
     const jsKey = CoreManager.get('JAVASCRIPT_KEY');
     if (jsKey) {

--- a/src/ParseFile.ts
+++ b/src/ParseFile.ts
@@ -19,6 +19,16 @@ export type FileSaveOptions = FullOptions & {
   metadata?: Record<string, any>;
   tags?: Record<string, any>;
   directory?: string;
+  /**
+   * Overrides the server's `maxUploadSize` for this file upload. Requires the
+   * master key (`useMasterKey: true`). The value uses the same format as the
+   * server option (e.g. `'50mb'`, `'1gb'`).
+   *
+   * Only supported for Buffer and Stream source types. Files created from
+   * base64 strings, number arrays, Blobs, or URIs do not support this option.
+   *
+   * Requires Parse Server >= 9.5.0.
+   */
   maxUploadSize?: string;
 };
 export type FileSource =
@@ -310,6 +320,10 @@ class ParseFile {
    *   }
    * });
    * </pre>
+   *   <li>maxUploadSize: Overrides the server's maxUploadSize for this upload.
+   *     Requires the master key. Only supported for Buffer and Stream source
+   *     types; files created from base64 strings, number arrays, Blobs, or URIs
+   *     do not support this option. Requires Parse Server >= 9.5.0.
    * </ul>
    * @returns {Promise | undefined} Promise that is resolved when the save finishes.
    */

--- a/src/ParseFile.ts
+++ b/src/ParseFile.ts
@@ -648,7 +648,7 @@ const DefaultController = {
       headers['X-Parse-File-Tags'] = JSON.stringify(options.tags);
     }
     if (options.maxUploadSize) {
-      headers['X-Parse-File-Max-Upload-Size'] = options.maxUploadSize;
+      headers['X-Parse-File-Max-Upload-Size'] = options.maxUploadSize.replace(/[\r\n]/g, '');
     }
     const jsKey = CoreManager.get('JAVASCRIPT_KEY');
     if (jsKey) {

--- a/types/ParseFile.d.ts
+++ b/types/ParseFile.d.ts
@@ -10,6 +10,16 @@ export type FileSaveOptions = FullOptions & {
     metadata?: Record<string, any>;
     tags?: Record<string, any>;
     directory?: string;
+    /**
+     * Overrides the server's `maxUploadSize` for this file upload. Requires the
+     * master key (`useMasterKey: true`). The value uses the same format as the
+     * server option (e.g. `'50mb'`, `'1gb'`).
+     *
+     * Only supported for Buffer and Stream source types. Files created from
+     * base64 strings, number arrays, Blobs, or URIs do not support this option.
+     *
+     * Requires Parse Server >= 9.5.0.
+     */
     maxUploadSize?: string;
 };
 export type FileSource = {
@@ -172,6 +182,10 @@ declare class ParseFile {
      *   }
      * });
      * </pre>
+     *   <li>maxUploadSize: Overrides the server's maxUploadSize for this upload.
+     *     Requires the master key. Only supported for Buffer and Stream source
+     *     types; files created from base64 strings, number arrays, Blobs, or URIs
+     *     do not support this option. Requires Parse Server >= 9.5.0.
      * </ul>
      * @returns {Promise | undefined} Promise that is resolved when the save finishes.
      */

--- a/types/ParseFile.d.ts
+++ b/types/ParseFile.d.ts
@@ -10,6 +10,7 @@ export type FileSaveOptions = FullOptions & {
     metadata?: Record<string, any>;
     tags?: Record<string, any>;
     directory?: string;
+    maxUploadSize?: string;
 };
 export type FileSource = {
     format: 'file';


### PR DESCRIPTION
## Pull Request

- Report security issues [confidentially](https://github.com/parse-community/Parse-SDK-JS/security/policy).
- Any contribution is under this [license](https://github.com/parse-community/Parse-SDK-JS/blob/alpha/LICENSE).
- Link this pull request to an [issue](https://github.com/parse-community/Parse-SDK-JS/issues?q=is%3Aissue).

## Issue

Add `Parse.File` option `maxUploadSize` to override the Parse Server option `maxUploadSize` per file upload. Only works for `buffer` and `stream` formats, not for `base64`, `file`, and `uri` formats. Requires master key.

## Tasks
<!-- Delete tasks that don't apply. -->

- [x] Add tests
- [x] Add changes to documentation (guides, repository pages, code comments)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added ability to override server's maximum upload size on a per-file basis through a new optional configuration parameter in file save options. Requires master key authentication and Parse Server version 9.5.0 or later. Applicable to Buffer and Stream upload sources only.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->