### PR TITLE
fix: Fix the serialization issue of nested attribute cache

### DIFF
--- a/src/ObjectStateMutations.ts
+++ b/src/ObjectStateMutations.ts
@@ -226,16 +226,34 @@ export function commitServerChanges(
       continue;
     }
     const val = changes[attr];
+    // Set the change value to server data using nested path
     nestedSet(serverData, attr, val);
+    
+    // Initialize cache value and cache key
+    let cacheVal = val,
+        cacheKey = attr
+    
+    // Handle nested attributes (dot notation)
+    if (attr.indexOf('.') >= 0) {
+      // Split attribute path and use first key for caching
+      const [firstKey, ..._rest] = attr.split('.')
+      cacheKey = firstKey
+      // Get the actual value from server data using first key
+      cacheVal = serverData[firstKey]
+    }
+    
+    // Check if cache value should be serialized and stored
+    // Only serialize plain objects, not Parse instances
     if (
-      val &&
-      typeof val === 'object' &&
-      !(val instanceof ParseObject) &&
-      !(val instanceof ParseFile) &&
-      !(val instanceof ParseRelation)
+      cacheVal && // Value exists
+      typeof cacheVal === 'object' && // Is an object
+      !(cacheVal instanceof ParseObject) &&
+      !(cacheVal instanceof ParseFile) &&
+      !(cacheVal instanceof ParseRelation)
     ) {
-      const json = encode(val, false, true);
-      objectCache[attr] = JSON.stringify(json);
+      const json = encode(cacheVal, false, true)
+      // Store serialized JSON string in object cache
+      objectCache[cacheKey] = JSON.stringify(json)
     }
   }
 }


### PR DESCRIPTION
Pull Request
Report security issues [confidentially](https://github.com/parse-community/Parse-SDK-JS/security/policy).
Any contribution is under this [license](https://github.com/parse-community/Parse-SDK-JS/blob/alpha/LICENSE).
Link this pull request to an [issue](https://github.com/parse-community/Parse-SDK-JS/issues?q=is%3Aissue).

Approach
This PR fixes a serialization issue in the nested attribute cache handling within the commitServerChanges function in ObjectStateMutations.ts. The issue was that when dealing with nested attributes (using dot notation like "address.street"), the caching mechanism was not properly handling the serialization and storage of these nested values.

Key Changes:
Fixed nested attribute cache key handling: When processing nested attributes (e.g., "address.street"), the code now correctly extracts the root key ("address") for caching purposes instead of using the full nested path.

Improved cache value retrieval: For nested attributes, the code now retrieves the entire parent object from server data rather than just the leaf value, ensuring proper serialization of the complete nested structure.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed caching behavior for nested attributes using dot notation paths. Cache keys and values are now properly derived from the nested structure itself, improving data storage efficiency and retrieval performance during server-client synchronization operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->