### PR TITLE
refactor: Bump parse-server from 9.2.0 to 9.6.0

### DIFF
--- a/integration/test/ParseUserTest.js
+++ b/integration/test/ParseUserTest.js
@@ -1049,7 +1049,6 @@ describe('Parse User', () => {
   it('can link with twitter', async () => {
     const TwitterAdapter = require('../../node_modules/parse-server/lib/Adapters/Auth/twitter').default.constructor;
     spyOn(TwitterAdapter.prototype, 'beforeFind').and.callFake(() => Promise.resolve());
-    spyOn(TwitterAdapter.prototype, 'validateAuthData').and.callThrough();
 
     await reconfigureServer();
 
@@ -1065,13 +1064,11 @@ describe('Parse User', () => {
 
     await user._unlinkFrom('twitter');
     expect(user._isLinked('twitter')).toBe(false);
-    expect(TwitterAdapter.prototype.validateAuthData).toHaveBeenCalled();
   });
 
   it('can link with twitter and facebook', async () => {
     const TwitterAdapter = require('../../node_modules/parse-server/lib/Adapters/Auth/twitter').default.constructor;
     spyOn(TwitterAdapter.prototype, 'beforeFind').and.callFake(() => Promise.resolve());
-    spyOn(TwitterAdapter.prototype, 'validateAuthData').and.callThrough();
 
     await reconfigureServer();
 
@@ -1090,7 +1087,6 @@ describe('Parse User', () => {
 
     expect(user.get('authData').twitter.id).toBe(twitterAuthData.id);
     expect(user.get('authData').facebook.id).toBe('test');
-    expect(TwitterAdapter.prototype.validateAuthData).toHaveBeenCalled();
   });
 
   it('can verify user password via static method', async () => {

--- a/integration/test/ParseUserTest.js
+++ b/integration/test/ParseUserTest.js
@@ -1047,10 +1047,11 @@ describe('Parse User', () => {
   });
 
   it('can link with twitter', async () => {
-    const server = await reconfigureServer();
-    const twitter = server.config.auth.twitter;
-    spyOn(twitter, 'beforeFind').and.callFake(() => Promise.resolve());
-    const spy = spyOn(twitter, 'validateAuthData').and.callThrough();
+    const TwitterAdapter = require('../../node_modules/parse-server/lib/Adapters/Auth/twitter').default.constructor;
+    spyOn(TwitterAdapter.prototype, 'beforeFind').and.callFake(() => Promise.resolve());
+    spyOn(TwitterAdapter.prototype, 'validateAuthData').and.callThrough();
+
+    await reconfigureServer();
 
     Parse.User.enableUnsafeCurrentUser();
     const user = new Parse.User();
@@ -1064,14 +1065,15 @@ describe('Parse User', () => {
 
     await user._unlinkFrom('twitter');
     expect(user._isLinked('twitter')).toBe(false);
-    expect(spy).toHaveBeenCalled();
+    expect(TwitterAdapter.prototype.validateAuthData).toHaveBeenCalled();
   });
 
   it('can link with twitter and facebook', async () => {
-    const server = await reconfigureServer();
-    const twitter = server.config.auth.twitter;
-    spyOn(twitter, 'beforeFind').and.callFake(() => Promise.resolve());
-    const spy = spyOn(twitter, 'validateAuthData').and.callThrough();
+    const TwitterAdapter = require('../../node_modules/parse-server/lib/Adapters/Auth/twitter').default.constructor;
+    spyOn(TwitterAdapter.prototype, 'beforeFind').and.callFake(() => Promise.resolve());
+    spyOn(TwitterAdapter.prototype, 'validateAuthData').and.callThrough();
+
+    await reconfigureServer();
 
     Parse.User.enableUnsafeCurrentUser();
     Parse.FacebookUtils.init();
@@ -1088,7 +1090,7 @@ describe('Parse User', () => {
 
     expect(user.get('authData').twitter.id).toBe(twitterAuthData.id);
     expect(user.get('authData').facebook.id).toBe('test');
-    expect(spy).toHaveBeenCalled();
+    expect(TwitterAdapter.prototype.validateAuthData).toHaveBeenCalled();
   });
 
   it('can verify user password via static method', async () => {

--- a/integration/test/ParseUserTest.js
+++ b/integration/test/ParseUserTest.js
@@ -996,7 +996,7 @@ describe('Parse User', () => {
       getAuthData() {
         return {
           authData: {
-            id: 1234,
+            id: '1234',
           },
         };
       },
@@ -1047,13 +1047,9 @@ describe('Parse User', () => {
   });
 
   it('can link with twitter', async () => {
-    const twitterAdapter = require('../../node_modules/parse-server/lib/Adapters/Auth/twitter').default;
-    spyOn(twitterAdapter, 'beforeFind').and.callFake(() => {
-      return Promise.resolve();
-    });
-
     const server = await reconfigureServer();
     const twitter = server.config.auth.twitter;
+    spyOn(twitter, 'beforeFind').and.callFake(() => Promise.resolve());
     const spy = spyOn(twitter, 'validateAuthData').and.callThrough();
 
     Parse.User.enableUnsafeCurrentUser();
@@ -1072,13 +1068,9 @@ describe('Parse User', () => {
   });
 
   it('can link with twitter and facebook', async () => {
-    const twitterAdapter = require('../../node_modules/parse-server/lib/Adapters/Auth/twitter').default;
-    spyOn(twitterAdapter, 'beforeFind').and.callFake(() => {
-      return Promise.resolve();
-    });
-
     const server = await reconfigureServer();
     const twitter = server.config.auth.twitter;
+    spyOn(twitter, 'beforeFind').and.callFake(() => Promise.resolve());
     const spy = spyOn(twitter, 'validateAuthData').and.callThrough();
 
     Parse.User.enableUnsafeCurrentUser();

--- a/package-lock.json
+++ b/package-lock.json
@@ -58,7 +58,7 @@
         "madge": "8.0.0",
         "metro-react-native-babel-preset": "0.77.0",
         "mongodb-runner": "6.6.1",
-        "parse-server": "9.2.0",
+        "parse-server": "9.6.0",
         "puppeteer": "24.37.2",
         "regenerator-runtime": "0.14.1",
         "semantic-release": "25.0.3",
@@ -3364,13 +3364,13 @@
       "license": "Apache-2.0"
     },
     "node_modules/@firebase/component": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/@firebase/component/-/component-0.7.0.tgz",
-      "integrity": "sha512-wR9En2A+WESUHexjmRHkqtaVH94WLNKt6rmeqZhSLBybg4Wyf0Umk04SZsS6sBq4102ZsDBFwoqMqJYj2IoDSg==",
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/@firebase/component/-/component-0.7.2.tgz",
+      "integrity": "sha512-iyVDGc6Vjx7Rm0cAdccLH/NG6fADsgJak/XW9IA2lPf8AjIlsemOpFGKczYyPHxm4rnKdR8z6sK4+KEC7NwmEg==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@firebase/util": "1.13.0",
+        "@firebase/util": "1.15.0",
         "tslib": "^2.1.0"
       },
       "engines": {
@@ -3378,17 +3378,17 @@
       }
     },
     "node_modules/@firebase/database": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@firebase/database/-/database-1.1.0.tgz",
-      "integrity": "sha512-gM6MJFae3pTyNLoc9VcJNuaUDej0ctdjn3cVtILo3D5lpp0dmUHHLFN/pUKe7ImyeB1KAvRlEYxvIHNF04Filg==",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@firebase/database/-/database-1.1.2.tgz",
+      "integrity": "sha512-lP96CMjMPy/+d1d9qaaHjHHdzdwvEOuyyLq9ehX89e2XMKwS1jHNzYBO+42bdSumuj5ukPbmnFtViZu8YOMT+w==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@firebase/app-check-interop-types": "0.3.3",
         "@firebase/auth-interop-types": "0.2.4",
-        "@firebase/component": "0.7.0",
+        "@firebase/component": "0.7.2",
         "@firebase/logger": "0.5.0",
-        "@firebase/util": "1.13.0",
+        "@firebase/util": "1.15.0",
         "faye-websocket": "0.11.4",
         "tslib": "^2.1.0"
       },
@@ -3397,17 +3397,17 @@
       }
     },
     "node_modules/@firebase/database-compat": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@firebase/database-compat/-/database-compat-2.1.0.tgz",
-      "integrity": "sha512-8nYc43RqxScsePVd1qe1xxvWNf0OBnbwHxmXJ7MHSuuTVYFO3eLyLW3PiCKJ9fHnmIz4p4LbieXwz+qtr9PZDg==",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@firebase/database-compat/-/database-compat-2.1.2.tgz",
+      "integrity": "sha512-j4A6IhVZbgxAzT6gJJC2PfOxYCK9SrDrUO7nTM4EscTYtKkAkzsbKoCnDdjFapQfnsncvPWjqVTr/0PffUwg3g==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@firebase/component": "0.7.0",
-        "@firebase/database": "1.1.0",
-        "@firebase/database-types": "1.0.16",
+        "@firebase/component": "0.7.2",
+        "@firebase/database": "1.1.2",
+        "@firebase/database-types": "1.0.18",
         "@firebase/logger": "0.5.0",
-        "@firebase/util": "1.13.0",
+        "@firebase/util": "1.15.0",
         "tslib": "^2.1.0"
       },
       "engines": {
@@ -3415,14 +3415,14 @@
       }
     },
     "node_modules/@firebase/database-types": {
-      "version": "1.0.16",
-      "resolved": "https://registry.npmjs.org/@firebase/database-types/-/database-types-1.0.16.tgz",
-      "integrity": "sha512-xkQLQfU5De7+SPhEGAXFBnDryUWhhlFXelEg2YeZOQMCdoe7dL64DDAd77SQsR+6uoXIZY5MB4y/inCs4GTfcw==",
+      "version": "1.0.18",
+      "resolved": "https://registry.npmjs.org/@firebase/database-types/-/database-types-1.0.18.tgz",
+      "integrity": "sha512-yOY8IC2go9lfbVDMiy2ATun4EB2AFwocPaQADwMN/RHRUAZSM4rlAV7PGbWPSG/YhkJ2A9xQAiAENgSua9G5Fg==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@firebase/app-types": "0.9.3",
-        "@firebase/util": "1.13.0"
+        "@firebase/util": "1.15.0"
       }
     },
     "node_modules/@firebase/logger": {
@@ -3439,9 +3439,9 @@
       }
     },
     "node_modules/@firebase/util": {
-      "version": "1.13.0",
-      "resolved": "https://registry.npmjs.org/@firebase/util/-/util-1.13.0.tgz",
-      "integrity": "sha512-0AZUyYUfpMNcztR5l09izHwXkZpghLgCUaAGjtMwXnCg3bj4ml5VgiwqOMOxJ+Nw4qN/zJAaOQBcJ7KGkWStqQ==",
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/@firebase/util/-/util-1.15.0.tgz",
+      "integrity": "sha512-AmWf3cHAOMbrCPG4xdPKQaj5iHnyYfyLKZxwz+Xf55bqKbpAmcYifB4jQinT2W9XhDRHISOoPyBOariJpCG6FA==",
       "dev": true,
       "hasInstallScript": true,
       "license": "Apache-2.0",
@@ -5878,9 +5878,9 @@
       }
     },
     "node_modules/@opentelemetry/api": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.0.tgz",
-      "integrity": "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==",
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.1.tgz",
+      "integrity": "sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q==",
       "dev": true,
       "license": "Apache-2.0",
       "optional": true,
@@ -5904,14 +5904,14 @@
       }
     },
     "node_modules/@parse/node-apn": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/@parse/node-apn/-/node-apn-7.0.1.tgz",
-      "integrity": "sha512-2xBiaznvupLOoXFaxWxcWcqCGlRn9rvqeAQnv8ogL8hZPe1Rd0es+F8ppE7g4QIy5DPJv0R4fruB8amGM6K/qA==",
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/@parse/node-apn/-/node-apn-7.1.0.tgz",
+      "integrity": "sha512-a40P5nScLDi9Pf7koKKkbwI73px0q+iLaKYNrr7kyKJebq/4duGOy3mMevZS0zltn171k3jB5BWCC27dPGsMmw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "debug": "4.4.3",
-        "jsonwebtoken": "9.0.2",
+        "jsonwebtoken": "9.0.3",
         "node-forge": "1.3.2",
         "verror": "1.10.1"
       },
@@ -5925,6 +5925,29 @@
       "integrity": "sha512-3lqz5YjWTYnW6dlDa5TLaTCcShfar1e40rmcJVwCBJC6mWlFuj0eCHIElmG1g5kyuJ/GD+8Wn4FFCcz4gJPfaQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@parse/node-apn/node_modules/jsonwebtoken": {
+      "version": "9.0.3",
+      "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-9.0.3.tgz",
+      "integrity": "sha512-MT/xP0CrubFRNLNKvxJ2BYfy53Zkm++5bX9dtuPbqAeQpTVe0MQTFhao8+Cp//EmJp244xt6Drw/GVEGCUj40g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "jws": "^4.0.1",
+        "lodash.includes": "^4.3.0",
+        "lodash.isboolean": "^3.0.3",
+        "lodash.isinteger": "^4.0.4",
+        "lodash.isnumber": "^3.0.3",
+        "lodash.isplainobject": "^4.0.6",
+        "lodash.isstring": "^4.0.1",
+        "lodash.once": "^4.0.0",
+        "ms": "^2.1.1",
+        "semver": "^7.5.4"
+      },
+      "engines": {
+        "node": ">=12",
+        "npm": ">=6"
+      }
     },
     "node_modules/@parse/node-apn/node_modules/verror": {
       "version": "1.10.1",
@@ -5942,21 +5965,39 @@
       }
     },
     "node_modules/@parse/push-adapter": {
-      "version": "8.2.0",
-      "resolved": "https://registry.npmjs.org/@parse/push-adapter/-/push-adapter-8.2.0.tgz",
-      "integrity": "sha512-z5RB1TwNELNSvummTVP1fgncOT424j13HeKxsGHpAftUmjE+hUtSsIeG49chD0gac22Zmrk+7flYjRwQpUs6+w==",
+      "version": "8.3.1",
+      "resolved": "https://registry.npmjs.org/@parse/push-adapter/-/push-adapter-8.3.1.tgz",
+      "integrity": "sha512-UOkL0bTOtUx4R866XtBwGGYvkNLQrQPrPWC4uzpbd9vR8tbfYIQQvBDT7eg58GryLb4EG+NOP8enm/VkhbwMVw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@parse/node-apn": "7.0.1",
-        "expo-server-sdk": "4.0.0",
-        "firebase-admin": "13.6.0",
+        "@parse/node-apn": "7.1.0",
+        "expo-server-sdk": "5.0.0",
+        "firebase-admin": "13.6.1",
         "npmlog": "7.0.1",
-        "parse": "8.0.3",
+        "parse": "8.2.0",
         "web-push": "3.6.7"
       },
       "engines": {
         "node": "20 || 22 || 24"
+      }
+    },
+    "node_modules/@parse/push-adapter/node_modules/parse": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/parse/-/parse-8.2.0.tgz",
+      "integrity": "sha512-jSx4zIqCja6O2HKhkzZ6JTm4fBUQS6sQpvFCAsqzaU4XlEhoRLm9mM1tZeYhvxTVA6zymvj/EJZ4YDOXCTRbmA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@babel/runtime": "7.28.6",
+        "@babel/runtime-corejs3": "7.29.0",
+        "crypto-js": "4.2.0",
+        "idb-keyval": "6.2.2",
+        "react-native-crypto-js": "1.0.0",
+        "ws": "8.19.0"
+      },
+      "engines": {
+        "node": ">=20.19.0 <21 || >=22.12.0 <23 || >=24.1.0 <25"
       }
     },
     "node_modules/@peculiar/asn1-cms": {
@@ -12344,9 +12385,9 @@
       }
     },
     "node_modules/asn1.js/node_modules/bn.js": {
-      "version": "4.12.2",
-      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.2.tgz",
-      "integrity": "sha512-n4DSx829VRTRByMRGdjQ9iqsN0Bh4OolPsFnaZBLcbi8iXcB+kJ9s7EnRt4wILZNV3kPLHkRVfOc/HvhC3ovDw==",
+      "version": "4.12.3",
+      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.3.tgz",
+      "integrity": "sha512-fGTi3gxV/23FTYdAoUtLYp6qySe2KE3teyZitipKNRuVYcBkoP/bB3guXN/XVKUe9mxCHXnc9C4ocyz8OmgN0g==",
       "dev": true,
       "license": "MIT"
     },
@@ -13082,12 +13123,6 @@
       "engines": {
         "node": ">=10.13.0"
       }
-    },
-    "node_modules/backo2": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/backo2/-/backo2-1.0.2.tgz",
-      "integrity": "sha512-zj6Z6M7Eq+PBZ7PQxl5NT665MvJdAkzp0f60nAJ+sLaSCBPMwVak5ZegFbgVCzFcCJTKFoMizvM5Ld7+JrRJHA==",
-      "dev": true
     },
     "node_modules/backoff": {
       "version": "2.5.0",
@@ -15454,15 +15489,6 @@
       "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
       "dev": true
     },
-    "node_modules/deepcopy": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/deepcopy/-/deepcopy-2.1.0.tgz",
-      "integrity": "sha512-8cZeTb1ZKC3bdSCP6XOM1IsTczIO73fdqtwa2B0N15eAz7gmyhQo+mc5gnFuulsgN3vIQYmTgbmQVKalH1dKvQ==",
-      "dev": true,
-      "dependencies": {
-        "type-detect": "^4.0.8"
-      }
-    },
     "node_modules/deepmerge": {
       "version": "4.3.1",
       "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.3.1.tgz",
@@ -17012,12 +17038,6 @@
         "node": ">=6"
       }
     },
-    "node_modules/eventemitter3": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-3.1.2.tgz",
-      "integrity": "sha512-tvtQIeLVHjDkJYnzf2dgVMxfuSGJeM/7UCG17TT4EumTfNtF+0nebF/4zWOIkCreAbtNqhGEboB6BWrwqNaw4Q==",
-      "dev": true
-    },
     "node_modules/events": {
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
@@ -17220,18 +17240,28 @@
       }
     },
     "node_modules/expo-server-sdk": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/expo-server-sdk/-/expo-server-sdk-4.0.0.tgz",
-      "integrity": "sha512-zi83XtG2pqyP3gyn1JIRYkydo2i6HU3CYaWo/VvhZG/F29U+QIDv6LBEUsWf4ddZlVE7c9WN1N8Be49rHgO8OQ==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/expo-server-sdk/-/expo-server-sdk-5.0.0.tgz",
+      "integrity": "sha512-GEp1XYLU80iS/hdRo3c2n092E8TgTXcHSuw6Lw68dSoWaAgiLPI2R+e5hp5+hGF1TtJZOi2nxtJX63+XA3iz9g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "node-fetch": "^2.6.0",
         "promise-limit": "^2.7.0",
-        "promise-retry": "^2.0.1"
+        "promise-retry": "^2.0.1",
+        "undici": "^7.2.0"
       },
       "engines": {
         "node": ">=20"
+      }
+    },
+    "node_modules/expo-server-sdk/node_modules/undici": {
+      "version": "7.24.6",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.24.6.tgz",
+      "integrity": "sha512-Xi4agocCbRzt0yYMZGMA6ApD7gvtUFaxm4ZmeacWI4cZxaF6C+8I8QfofC20NAePiB/IcvZmzkJ7XPa471AEtA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.1"
       }
     },
     "node_modules/express": {
@@ -17278,10 +17308,14 @@
       }
     },
     "node_modules/express-rate-limit": {
-      "version": "7.5.1",
-      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-7.5.1.tgz",
-      "integrity": "sha512-7iN8iPMDzOMHPUYllBEsQdWVB6fPDMPqwjBaFrgr4Jgr/+okjvzAy+UHlYYL/Vs0OsOrMkwS6PJDkFlJwoxUnw==",
+      "version": "8.2.1",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.2.1.tgz",
+      "integrity": "sha512-PCZEIEIxqwhzw4KF0n7QF4QqruVTcF73O5kFKUnGOyjbCCgizBBiFaYpd/fnBLUMPw/BWw9OsiN7GgrNYr7j6g==",
       "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ip-address": "10.0.1"
+      },
       "engines": {
         "node": ">= 16"
       },
@@ -17290,6 +17324,16 @@
       },
       "peerDependencies": {
         "express": ">= 4.11"
+      }
+    },
+    "node_modules/express-rate-limit/node_modules/ip-address": {
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.0.1.tgz",
+      "integrity": "sha512-NWv9YLW4PoW2B7xtzaS3NCot75m6nK7Icdv0o3lfMceJVRfSoQwqD4wEH5rLwoKJwUiZ/rfpiVBhnaF0FK4HoA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
       }
     },
     "node_modules/express/node_modules/accepts": {
@@ -17690,6 +17734,7 @@
           "url": "https://github.com/sponsors/NaturalIntelligence"
         }
       ],
+      "license": "MIT",
       "optional": true,
       "dependencies": {
         "path-expression-matcher": "^1.1.3"
@@ -17706,6 +17751,7 @@
           "url": "https://github.com/sponsors/NaturalIntelligence"
         }
       ],
+      "license": "MIT",
       "optional": true,
       "dependencies": {
         "fast-xml-builder": "^1.1.4",
@@ -18004,9 +18050,9 @@
       }
     },
     "node_modules/firebase-admin": {
-      "version": "13.6.0",
-      "resolved": "https://registry.npmjs.org/firebase-admin/-/firebase-admin-13.6.0.tgz",
-      "integrity": "sha512-GdPA/t0+Cq8p1JnjFRBmxRxAGvF/kl2yfdhALl38PrRp325YxyQ5aNaHui0XmaKcKiGRFIJ/EgBNWFoDP0onjw==",
+      "version": "13.6.1",
+      "resolved": "https://registry.npmjs.org/firebase-admin/-/firebase-admin-13.6.1.tgz",
+      "integrity": "sha512-Zgc6yPtmPxAZo+FoK6LMG6zpSEsoSK8ifIR+IqF4oWuC3uWZU40OjxgfLTSFcsRlj/k/wD66zNv2UiTRreCNSw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -20922,12 +20968,6 @@
       "engines": {
         "node": ">=8"
       }
-    },
-    "node_modules/iterall": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/iterall/-/iterall-1.3.0.tgz",
-      "integrity": "sha512-QZ9qOMdF+QLHxy1QIpUHUU1D5pS2CG2P69LF6L6CPjPYA/XMOmKV3PZpawHoAjHNyB0swdVTRxdYT4tbBbxqwg==",
-      "dev": true
     },
     "node_modules/jackspeak": {
       "version": "2.2.0",
@@ -28718,15 +28758,6 @@
         "node": ">= 14"
       }
     },
-    "node_modules/package-json-from-dist": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
-      "integrity": "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==",
-      "dev": true,
-      "license": "BlueOak-1.0.0",
-      "optional": true,
-      "peer": true
-    },
     "node_modules/pako": {
       "version": "1.0.11",
       "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
@@ -28746,14 +28777,14 @@
       }
     },
     "node_modules/parse": {
-      "version": "8.0.3",
-      "resolved": "https://registry.npmjs.org/parse/-/parse-8.0.3.tgz",
-      "integrity": "sha512-WQPrnfnXy6/p25OFD6qOAVK9hIhhU882Nw1AW5RjAJbO2G7YqChJxBgL94aexsaTnP9ajVzjGISSQ+mESrkMIA==",
+      "version": "8.5.0",
+      "resolved": "https://registry.npmjs.org/parse/-/parse-8.5.0.tgz",
+      "integrity": "sha512-X9gI4Yjbi9LPMPnCtKL4h0Nxe1aSCFMPWcB1zbu11qU/Be3eVSB5I5IMBunTuWlVz6Wchu3dtM5jl/1aBZ9wiQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@babel/runtime": "7.28.6",
-        "@babel/runtime-corejs3": "7.28.6",
+        "@babel/runtime-corejs3": "7.29.0",
         "crypto-js": "4.2.0",
         "idb-keyval": "6.2.2",
         "react-native-crypto-js": "1.0.0",
@@ -28916,9 +28947,9 @@
       }
     },
     "node_modules/parse-server": {
-      "version": "9.2.0",
-      "resolved": "https://registry.npmjs.org/parse-server/-/parse-server-9.2.0.tgz",
-      "integrity": "sha512-YAjVkzDqmTLlkfHdI5Tu+HegheOLSE2uzWQSaTl6KSC9Ksck3cQVCRIarQdijWZoYml5rwwqyHak3v3hgOazsg==",
+      "version": "9.6.0",
+      "resolved": "https://registry.npmjs.org/parse-server/-/parse-server-9.6.0.tgz",
+      "integrity": "sha512-SCdX+LwbSPl/kekQw37V9LvzbwgTL5WPURf5FXbcANhV0Af8prIlAGbMc3aBtwSEWa5qq/T2os88e96tMxvv0w==",
       "dev": true,
       "hasInstallScript": true,
       "license": "Apache-2.0",
@@ -28929,13 +28960,12 @@
         "@graphql-tools/schema": "10.0.23",
         "@graphql-tools/utils": "10.8.6",
         "@parse/fs-files-adapter": "3.0.0",
-        "@parse/push-adapter": "8.2.0",
+        "@parse/push-adapter": "8.3.1",
         "bcryptjs": "3.0.3",
-        "commander": "14.0.2",
+        "commander": "14.0.3",
         "cors": "2.8.6",
-        "deepcopy": "2.1.0",
         "express": "5.2.1",
-        "express-rate-limit": "7.5.1",
+        "express-rate-limit": "8.2.1",
         "follow-redirects": "1.15.9",
         "graphql": "16.11.0",
         "graphql-list-fields": "2.0.4",
@@ -28948,19 +28978,18 @@
         "lodash": "4.17.23",
         "lru-cache": "10.4.0",
         "mime": "4.0.7",
-        "mongodb": "7.0.0",
+        "mongodb": "7.1.0",
         "mustache": "4.2.0",
         "otpauth": "9.4.0",
-        "parse": "8.0.3",
+        "parse": "8.5.0",
         "path-to-regexp": "8.3.0",
-        "pg-monitor": "3.0.0",
+        "pg-monitor": "3.1.0",
         "pg-promise": "12.6.0",
         "pluralize": "8.0.0",
         "punycode": "2.3.1",
         "rate-limit-redis": "4.2.0",
         "redis": "5.10.0",
         "semver": "7.7.2",
-        "subscriptions-transport-ws": "0.11.0",
         "tv4": "1.3.0",
         "uuid": "11.1.0",
         "winston": "3.19.0",
@@ -29014,9 +29043,9 @@
       }
     },
     "node_modules/parse-server/node_modules/commander": {
-      "version": "14.0.2",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-14.0.2.tgz",
-      "integrity": "sha512-TywoWNNRbhoD0BXs1P3ZEScW8W5iKrnbithIl0YH+uCmBd0QpPOA8yc82DS3BIE5Ma6FnBVUsJ7wVUDz4dvOWQ==",
+      "version": "14.0.3",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-14.0.3.tgz",
+      "integrity": "sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -29036,9 +29065,9 @@
       }
     },
     "node_modules/parse-server/node_modules/gaxios": {
-      "version": "7.1.3",
-      "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-7.1.3.tgz",
-      "integrity": "sha512-YGGyuEdVIjqxkxVH1pUTMY/XtmmsApXrCVv5EU25iX6inEPbV+VakJfLealkBtJN69AQmh1eGOdCl9Sm1UP6XQ==",
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-7.1.4.tgz",
+      "integrity": "sha512-bTIgTsM2bWn3XklZISBTQX7ZSddGW+IO3bMdGaemHZ3tbqExMENHLx6kKZ/KlejgrMtj8q7wBItt51yegqalrA==",
       "dev": true,
       "license": "Apache-2.0",
       "optional": true,
@@ -29046,8 +29075,7 @@
       "dependencies": {
         "extend": "^3.0.2",
         "https-proxy-agent": "^7.0.1",
-        "node-fetch": "^3.3.2",
-        "rimraf": "^5.0.1"
+        "node-fetch": "^3.3.2"
       },
       "engines": {
         "node": ">=18"
@@ -29099,14 +29127,14 @@
       }
     },
     "node_modules/parse-server/node_modules/mongodb": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-7.0.0.tgz",
-      "integrity": "sha512-vG/A5cQrvGGvZm2mTnCSz1LUcbOPl83hfB6bxULKQ8oFZauyox/2xbZOoGNl+64m8VBrETkdGCDBdOsCr3F3jg==",
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-7.1.0.tgz",
+      "integrity": "sha512-kMfnKunbolQYwCIyrkxNJFB4Ypy91pYqua5NargS/f8ODNSJxT03ZU3n1JqL4mCzbSih8tvmMEMLpKTT7x5gCg==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@mongodb-js/saslprep": "^1.3.0",
-        "bson": "^7.0.0",
+        "bson": "^7.1.1",
         "mongodb-connection-string-url": "^7.0.0"
       },
       "engines": {
@@ -29185,6 +29213,7 @@
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
       "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=6"
       }
@@ -29253,19 +29282,6 @@
       "integrity": "sha512-HlsyYdMBnbPQ9Jr/VgJ1YF4scnldvJpJxCVx6KgqPL4dxppsWrJHCIIxQXMJrqGnsRkNPATbeMJ8Yxu7JMsYcA==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/parse/node_modules/@babel/runtime-corejs3": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/runtime-corejs3/-/runtime-corejs3-7.28.6.tgz",
-      "integrity": "sha512-kz2fAQ5UzjV7X7D3ySxmj3vRq89dTpqOZWv76Z6pNPztkwb/0Yj1Mtx1xFrYj6mbIHysxtBot8J4o0JLCblcFw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "core-js-pure": "^3.43.0"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
     },
     "node_modules/parse5": {
       "version": "7.3.0",
@@ -29358,6 +29374,7 @@
           "url": "https://github.com/sponsors/NaturalIntelligence"
         }
       ],
+      "license": "MIT",
       "optional": true,
       "engines": {
         "node": ">=14.0.0"
@@ -29611,16 +29628,16 @@
       }
     },
     "node_modules/pg-monitor": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/pg-monitor/-/pg-monitor-3.0.0.tgz",
-      "integrity": "sha512-62jezmq3lR+lKCIsi9BXVg8Fxv+JG5LtaAuUmex5EVnBPlvAU7Ad6dOiQXHtH1xNh/Oy6Hux36k8uIjZWNeWtQ==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/pg-monitor/-/pg-monitor-3.1.0.tgz",
+      "integrity": "sha512-giK0h52AOO/v8iu6hZCdZ/X9W8oAM9Dm1VReQQtki532X8g4z1LVIm4Z/3cGvDcETWW+Ty0FrtU8iTrGFYIZfA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "picocolors": "^1.1.1"
+        "picocolors": "1.1.1"
       },
       "engines": {
-        "node": ">=14"
+        "node": ">=16"
       }
     },
     "node_modules/pg-pool": {
@@ -31321,108 +31338,6 @@
       "resolved": "https://registry.npmjs.org/rfdc/-/rfdc-1.4.1.tgz",
       "integrity": "sha512-q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA==",
       "dev": true
-    },
-    "node_modules/rimraf": {
-      "version": "5.0.10",
-      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-5.0.10.tgz",
-      "integrity": "sha512-l0OE8wL34P4nJH/H2ffoaniAokM2qSmrtXHmlpvYr5AVVX8msAyW0l8NVJFDxlSK4u3Uh/f41cQheDVdnYijwQ==",
-      "dev": true,
-      "license": "ISC",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "glob": "^10.3.7"
-      },
-      "bin": {
-        "rimraf": "dist/esm/bin.mjs"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/rimraf/node_modules/brace-expansion": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
-      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "balanced-match": "^1.0.0"
-      }
-    },
-    "node_modules/rimraf/node_modules/glob": {
-      "version": "10.5.0",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz",
-      "integrity": "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==",
-      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
-      "dev": true,
-      "license": "ISC",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "foreground-child": "^3.1.0",
-        "jackspeak": "^3.1.2",
-        "minimatch": "^9.0.4",
-        "minipass": "^7.1.2",
-        "package-json-from-dist": "^1.0.0",
-        "path-scurry": "^1.11.1"
-      },
-      "bin": {
-        "glob": "dist/esm/bin.mjs"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/rimraf/node_modules/jackspeak": {
-      "version": "3.4.3",
-      "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-3.4.3.tgz",
-      "integrity": "sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==",
-      "dev": true,
-      "license": "BlueOak-1.0.0",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@isaacs/cliui": "^8.0.2"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      },
-      "optionalDependencies": {
-        "@pkgjs/parseargs": "^0.11.0"
-      }
-    },
-    "node_modules/rimraf/node_modules/minimatch": {
-      "version": "9.0.5",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
-      "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
-      "dev": true,
-      "license": "ISC",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "brace-expansion": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=16 || 14 >=14.17"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/rimraf/node_modules/minipass": {
-      "version": "7.1.2",
-      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.2.tgz",
-      "integrity": "sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==",
-      "dev": true,
-      "license": "ISC",
-      "optional": true,
-      "peer": true,
-      "engines": {
-        "node": ">=16 || 14 >=14.17"
-      }
     },
     "node_modules/ripemd160": {
       "version": "2.0.2",
@@ -33282,6 +33197,7 @@
           "url": "https://github.com/sponsors/NaturalIntelligence"
         }
       ],
+      "license": "MIT",
       "optional": true
     },
     "node_modules/stubs": {
@@ -33303,44 +33219,6 @@
       },
       "engines": {
         "node": ">=18"
-      }
-    },
-    "node_modules/subscriptions-transport-ws": {
-      "version": "0.11.0",
-      "resolved": "https://registry.npmjs.org/subscriptions-transport-ws/-/subscriptions-transport-ws-0.11.0.tgz",
-      "integrity": "sha512-8D4C6DIH5tGiAIpp5I0wD/xRlNiZAPGHygzCe7VzyzUoxHtawzjNAY9SUTXU05/EY2NMY9/9GF0ycizkXr1CWQ==",
-      "deprecated": "The `subscriptions-transport-ws` package is no longer maintained. We recommend you use `graphql-ws` instead. For help migrating Apollo software to `graphql-ws`, see https://www.apollographql.com/docs/apollo-server/data/subscriptions/#switching-from-subscriptions-transport-ws    For general help using `graphql-ws`, see https://github.com/enisdenjo/graphql-ws/blob/master/README.md",
-      "dev": true,
-      "dependencies": {
-        "backo2": "^1.0.2",
-        "eventemitter3": "^3.1.0",
-        "iterall": "^1.2.1",
-        "symbol-observable": "^1.0.4",
-        "ws": "^5.2.0 || ^6.0.0 || ^7.0.0"
-      },
-      "peerDependencies": {
-        "graphql": "^15.7.2 || ^16.0.0"
-      }
-    },
-    "node_modules/subscriptions-transport-ws/node_modules/ws": {
-      "version": "7.5.9",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.9.tgz",
-      "integrity": "sha512-F+P9Jil7UiSKSkppIiD94dN07AwvFixvLIj1Og1Rl9GGMuNipJnV9JzjD6XuqmAeiswGvUmNLjr5cFuXwNS77Q==",
-      "dev": true,
-      "engines": {
-        "node": ">=8.3.0"
-      },
-      "peerDependencies": {
-        "bufferutil": "^4.0.1",
-        "utf-8-validate": "^5.0.2"
-      },
-      "peerDependenciesMeta": {
-        "bufferutil": {
-          "optional": true
-        },
-        "utf-8-validate": {
-          "optional": true
-        }
       }
     },
     "node_modules/super-regex": {
@@ -33440,15 +33318,6 @@
       "optional": true,
       "bin": {
         "semver": "bin/semver.js"
-      }
-    },
-    "node_modules/symbol-observable": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-1.2.0.tgz",
-      "integrity": "sha512-e900nM8RRtGhlV36KGEU9k65K3mPb1WV70OdjfxlG2EAuM1noi/E/BaW/uMhL7bPEssK8QV57vN3esixjUvcXQ==",
-      "dev": true,
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
     "node_modules/symbol-tree": {
@@ -37946,52 +37815,52 @@
       "dev": true
     },
     "@firebase/component": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/@firebase/component/-/component-0.7.0.tgz",
-      "integrity": "sha512-wR9En2A+WESUHexjmRHkqtaVH94WLNKt6rmeqZhSLBybg4Wyf0Umk04SZsS6sBq4102ZsDBFwoqMqJYj2IoDSg==",
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/@firebase/component/-/component-0.7.2.tgz",
+      "integrity": "sha512-iyVDGc6Vjx7Rm0cAdccLH/NG6fADsgJak/XW9IA2lPf8AjIlsemOpFGKczYyPHxm4rnKdR8z6sK4+KEC7NwmEg==",
       "dev": true,
       "requires": {
-        "@firebase/util": "1.13.0",
+        "@firebase/util": "1.15.0",
         "tslib": "^2.1.0"
       }
     },
     "@firebase/database": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@firebase/database/-/database-1.1.0.tgz",
-      "integrity": "sha512-gM6MJFae3pTyNLoc9VcJNuaUDej0ctdjn3cVtILo3D5lpp0dmUHHLFN/pUKe7ImyeB1KAvRlEYxvIHNF04Filg==",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@firebase/database/-/database-1.1.2.tgz",
+      "integrity": "sha512-lP96CMjMPy/+d1d9qaaHjHHdzdwvEOuyyLq9ehX89e2XMKwS1jHNzYBO+42bdSumuj5ukPbmnFtViZu8YOMT+w==",
       "dev": true,
       "requires": {
         "@firebase/app-check-interop-types": "0.3.3",
         "@firebase/auth-interop-types": "0.2.4",
-        "@firebase/component": "0.7.0",
+        "@firebase/component": "0.7.2",
         "@firebase/logger": "0.5.0",
-        "@firebase/util": "1.13.0",
+        "@firebase/util": "1.15.0",
         "faye-websocket": "0.11.4",
         "tslib": "^2.1.0"
       }
     },
     "@firebase/database-compat": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@firebase/database-compat/-/database-compat-2.1.0.tgz",
-      "integrity": "sha512-8nYc43RqxScsePVd1qe1xxvWNf0OBnbwHxmXJ7MHSuuTVYFO3eLyLW3PiCKJ9fHnmIz4p4LbieXwz+qtr9PZDg==",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@firebase/database-compat/-/database-compat-2.1.2.tgz",
+      "integrity": "sha512-j4A6IhVZbgxAzT6gJJC2PfOxYCK9SrDrUO7nTM4EscTYtKkAkzsbKoCnDdjFapQfnsncvPWjqVTr/0PffUwg3g==",
       "dev": true,
       "requires": {
-        "@firebase/component": "0.7.0",
-        "@firebase/database": "1.1.0",
-        "@firebase/database-types": "1.0.16",
+        "@firebase/component": "0.7.2",
+        "@firebase/database": "1.1.2",
+        "@firebase/database-types": "1.0.18",
         "@firebase/logger": "0.5.0",
-        "@firebase/util": "1.13.0",
+        "@firebase/util": "1.15.0",
         "tslib": "^2.1.0"
       }
     },
     "@firebase/database-types": {
-      "version": "1.0.16",
-      "resolved": "https://registry.npmjs.org/@firebase/database-types/-/database-types-1.0.16.tgz",
-      "integrity": "sha512-xkQLQfU5De7+SPhEGAXFBnDryUWhhlFXelEg2YeZOQMCdoe7dL64DDAd77SQsR+6uoXIZY5MB4y/inCs4GTfcw==",
+      "version": "1.0.18",
+      "resolved": "https://registry.npmjs.org/@firebase/database-types/-/database-types-1.0.18.tgz",
+      "integrity": "sha512-yOY8IC2go9lfbVDMiy2ATun4EB2AFwocPaQADwMN/RHRUAZSM4rlAV7PGbWPSG/YhkJ2A9xQAiAENgSua9G5Fg==",
       "dev": true,
       "requires": {
         "@firebase/app-types": "0.9.3",
-        "@firebase/util": "1.13.0"
+        "@firebase/util": "1.15.0"
       }
     },
     "@firebase/logger": {
@@ -38004,9 +37873,9 @@
       }
     },
     "@firebase/util": {
-      "version": "1.13.0",
-      "resolved": "https://registry.npmjs.org/@firebase/util/-/util-1.13.0.tgz",
-      "integrity": "sha512-0AZUyYUfpMNcztR5l09izHwXkZpghLgCUaAGjtMwXnCg3bj4ml5VgiwqOMOxJ+Nw4qN/zJAaOQBcJ7KGkWStqQ==",
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/@firebase/util/-/util-1.15.0.tgz",
+      "integrity": "sha512-AmWf3cHAOMbrCPG4xdPKQaj5iHnyYfyLKZxwz+Xf55bqKbpAmcYifB4jQinT2W9XhDRHISOoPyBOariJpCG6FA==",
       "dev": true,
       "requires": {
         "tslib": "^2.1.0"
@@ -39807,9 +39676,9 @@
       }
     },
     "@opentelemetry/api": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.0.tgz",
-      "integrity": "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==",
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.1.tgz",
+      "integrity": "sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q==",
       "dev": true,
       "optional": true
     },
@@ -39828,13 +39697,13 @@
       }
     },
     "@parse/node-apn": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/@parse/node-apn/-/node-apn-7.0.1.tgz",
-      "integrity": "sha512-2xBiaznvupLOoXFaxWxcWcqCGlRn9rvqeAQnv8ogL8hZPe1Rd0es+F8ppE7g4QIy5DPJv0R4fruB8amGM6K/qA==",
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/@parse/node-apn/-/node-apn-7.1.0.tgz",
+      "integrity": "sha512-a40P5nScLDi9Pf7koKKkbwI73px0q+iLaKYNrr7kyKJebq/4duGOy3mMevZS0zltn171k3jB5BWCC27dPGsMmw==",
       "dev": true,
       "requires": {
         "debug": "4.4.3",
-        "jsonwebtoken": "9.0.2",
+        "jsonwebtoken": "9.0.3",
         "node-forge": "1.3.2",
         "verror": "1.10.1"
       },
@@ -39844,6 +39713,24 @@
           "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
           "integrity": "sha512-3lqz5YjWTYnW6dlDa5TLaTCcShfar1e40rmcJVwCBJC6mWlFuj0eCHIElmG1g5kyuJ/GD+8Wn4FFCcz4gJPfaQ==",
           "dev": true
+        },
+        "jsonwebtoken": {
+          "version": "9.0.3",
+          "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-9.0.3.tgz",
+          "integrity": "sha512-MT/xP0CrubFRNLNKvxJ2BYfy53Zkm++5bX9dtuPbqAeQpTVe0MQTFhao8+Cp//EmJp244xt6Drw/GVEGCUj40g==",
+          "dev": true,
+          "requires": {
+            "jws": "^4.0.1",
+            "lodash.includes": "^4.3.0",
+            "lodash.isboolean": "^3.0.3",
+            "lodash.isinteger": "^4.0.4",
+            "lodash.isnumber": "^3.0.3",
+            "lodash.isplainobject": "^4.0.6",
+            "lodash.isstring": "^4.0.1",
+            "lodash.once": "^4.0.0",
+            "ms": "^2.1.1",
+            "semver": "^7.5.4"
+          }
         },
         "verror": {
           "version": "1.10.1",
@@ -39859,17 +39746,33 @@
       }
     },
     "@parse/push-adapter": {
-      "version": "8.2.0",
-      "resolved": "https://registry.npmjs.org/@parse/push-adapter/-/push-adapter-8.2.0.tgz",
-      "integrity": "sha512-z5RB1TwNELNSvummTVP1fgncOT424j13HeKxsGHpAftUmjE+hUtSsIeG49chD0gac22Zmrk+7flYjRwQpUs6+w==",
+      "version": "8.3.1",
+      "resolved": "https://registry.npmjs.org/@parse/push-adapter/-/push-adapter-8.3.1.tgz",
+      "integrity": "sha512-UOkL0bTOtUx4R866XtBwGGYvkNLQrQPrPWC4uzpbd9vR8tbfYIQQvBDT7eg58GryLb4EG+NOP8enm/VkhbwMVw==",
       "dev": true,
       "requires": {
-        "@parse/node-apn": "7.0.1",
-        "expo-server-sdk": "4.0.0",
-        "firebase-admin": "13.6.0",
+        "@parse/node-apn": "7.1.0",
+        "expo-server-sdk": "5.0.0",
+        "firebase-admin": "13.6.1",
         "npmlog": "7.0.1",
-        "parse": "8.0.3",
+        "parse": "8.2.0",
         "web-push": "3.6.7"
+      },
+      "dependencies": {
+        "parse": {
+          "version": "8.2.0",
+          "resolved": "https://registry.npmjs.org/parse/-/parse-8.2.0.tgz",
+          "integrity": "sha512-jSx4zIqCja6O2HKhkzZ6JTm4fBUQS6sQpvFCAsqzaU4XlEhoRLm9mM1tZeYhvxTVA6zymvj/EJZ4YDOXCTRbmA==",
+          "dev": true,
+          "requires": {
+            "@babel/runtime": "7.28.6",
+            "@babel/runtime-corejs3": "7.29.0",
+            "crypto-js": "4.2.0",
+            "idb-keyval": "6.2.2",
+            "react-native-crypto-js": "1.0.0",
+            "ws": "8.19.0"
+          }
+        }
       }
     },
     "@peculiar/asn1-cms": {
@@ -44321,9 +44224,9 @@
       },
       "dependencies": {
         "bn.js": {
-          "version": "4.12.2",
-          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.2.tgz",
-          "integrity": "sha512-n4DSx829VRTRByMRGdjQ9iqsN0Bh4OolPsFnaZBLcbi8iXcB+kJ9s7EnRt4wILZNV3kPLHkRVfOc/HvhC3ovDw==",
+          "version": "4.12.3",
+          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.3.tgz",
+          "integrity": "sha512-fGTi3gxV/23FTYdAoUtLYp6qySe2KE3teyZitipKNRuVYcBkoP/bB3guXN/XVKUe9mxCHXnc9C4ocyz8OmgN0g==",
           "dev": true
         }
       }
@@ -44891,12 +44794,6 @@
         "async-settle": "^2.0.0",
         "now-and-later": "^3.0.0"
       }
-    },
-    "backo2": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/backo2/-/backo2-1.0.2.tgz",
-      "integrity": "sha512-zj6Z6M7Eq+PBZ7PQxl5NT665MvJdAkzp0f60nAJ+sLaSCBPMwVak5ZegFbgVCzFcCJTKFoMizvM5Ld7+JrRJHA==",
-      "dev": true
     },
     "backoff": {
       "version": "2.5.0",
@@ -46667,15 +46564,6 @@
       "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
       "dev": true
     },
-    "deepcopy": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/deepcopy/-/deepcopy-2.1.0.tgz",
-      "integrity": "sha512-8cZeTb1ZKC3bdSCP6XOM1IsTczIO73fdqtwa2B0N15eAz7gmyhQo+mc5gnFuulsgN3vIQYmTgbmQVKalH1dKvQ==",
-      "dev": true,
-      "requires": {
-        "type-detect": "^4.0.8"
-      }
-    },
     "deepmerge": {
       "version": "4.3.1",
       "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.3.1.tgz",
@@ -47785,12 +47673,6 @@
       "dev": true,
       "optional": true
     },
-    "eventemitter3": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-3.1.2.tgz",
-      "integrity": "sha512-tvtQIeLVHjDkJYnzf2dgVMxfuSGJeM/7UCG17TT4EumTfNtF+0nebF/4zWOIkCreAbtNqhGEboB6BWrwqNaw4Q==",
-      "dev": true
-    },
     "events": {
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
@@ -47954,14 +47836,22 @@
       }
     },
     "expo-server-sdk": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/expo-server-sdk/-/expo-server-sdk-4.0.0.tgz",
-      "integrity": "sha512-zi83XtG2pqyP3gyn1JIRYkydo2i6HU3CYaWo/VvhZG/F29U+QIDv6LBEUsWf4ddZlVE7c9WN1N8Be49rHgO8OQ==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/expo-server-sdk/-/expo-server-sdk-5.0.0.tgz",
+      "integrity": "sha512-GEp1XYLU80iS/hdRo3c2n092E8TgTXcHSuw6Lw68dSoWaAgiLPI2R+e5hp5+hGF1TtJZOi2nxtJX63+XA3iz9g==",
       "dev": true,
       "requires": {
-        "node-fetch": "^2.6.0",
         "promise-limit": "^2.7.0",
-        "promise-retry": "^2.0.1"
+        "promise-retry": "^2.0.1",
+        "undici": "^7.2.0"
+      },
+      "dependencies": {
+        "undici": {
+          "version": "7.24.6",
+          "resolved": "https://registry.npmjs.org/undici/-/undici-7.24.6.tgz",
+          "integrity": "sha512-Xi4agocCbRzt0yYMZGMA6ApD7gvtUFaxm4ZmeacWI4cZxaF6C+8I8QfofC20NAePiB/IcvZmzkJ7XPa471AEtA==",
+          "dev": true
+        }
       }
     },
     "express": {
@@ -48092,11 +47982,21 @@
       }
     },
     "express-rate-limit": {
-      "version": "7.5.1",
-      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-7.5.1.tgz",
-      "integrity": "sha512-7iN8iPMDzOMHPUYllBEsQdWVB6fPDMPqwjBaFrgr4Jgr/+okjvzAy+UHlYYL/Vs0OsOrMkwS6PJDkFlJwoxUnw==",
+      "version": "8.2.1",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.2.1.tgz",
+      "integrity": "sha512-PCZEIEIxqwhzw4KF0n7QF4QqruVTcF73O5kFKUnGOyjbCCgizBBiFaYpd/fnBLUMPw/BWw9OsiN7GgrNYr7j6g==",
       "dev": true,
-      "requires": {}
+      "requires": {
+        "ip-address": "10.0.1"
+      },
+      "dependencies": {
+        "ip-address": {
+          "version": "10.0.1",
+          "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.0.1.tgz",
+          "integrity": "sha512-NWv9YLW4PoW2B7xtzaS3NCot75m6nK7Icdv0o3lfMceJVRfSoQwqD4wEH5rLwoKJwUiZ/rfpiVBhnaF0FK4HoA==",
+          "dev": true
+        }
+      }
     },
     "extend": {
       "version": "3.0.2",
@@ -48516,9 +48416,9 @@
       }
     },
     "firebase-admin": {
-      "version": "13.6.0",
-      "resolved": "https://registry.npmjs.org/firebase-admin/-/firebase-admin-13.6.0.tgz",
-      "integrity": "sha512-GdPA/t0+Cq8p1JnjFRBmxRxAGvF/kl2yfdhALl38PrRp325YxyQ5aNaHui0XmaKcKiGRFIJ/EgBNWFoDP0onjw==",
+      "version": "13.6.1",
+      "resolved": "https://registry.npmjs.org/firebase-admin/-/firebase-admin-13.6.1.tgz",
+      "integrity": "sha512-Zgc6yPtmPxAZo+FoK6LMG6zpSEsoSK8ifIR+IqF4oWuC3uWZU40OjxgfLTSFcsRlj/k/wD66zNv2UiTRreCNSw==",
       "dev": true,
       "requires": {
         "@fastify/busboy": "^3.0.0",
@@ -50651,12 +50551,6 @@
         "html-escaper": "^2.0.0",
         "istanbul-lib-report": "^3.0.0"
       }
-    },
-    "iterall": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/iterall/-/iterall-1.3.0.tgz",
-      "integrity": "sha512-QZ9qOMdF+QLHxy1QIpUHUU1D5pS2CG2P69LF6L6CPjPYA/XMOmKV3PZpawHoAjHNyB0swdVTRxdYT4tbBbxqwg==",
-      "dev": true
     },
     "jackspeak": {
       "version": "2.2.0",
@@ -56215,14 +56109,6 @@
         "netmask": "^2.0.2"
       }
     },
-    "package-json-from-dist": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
-      "integrity": "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==",
-      "dev": true,
-      "optional": true,
-      "peer": true
-    },
     "pako": {
       "version": "1.0.11",
       "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
@@ -56239,28 +56125,17 @@
       }
     },
     "parse": {
-      "version": "8.0.3",
-      "resolved": "https://registry.npmjs.org/parse/-/parse-8.0.3.tgz",
-      "integrity": "sha512-WQPrnfnXy6/p25OFD6qOAVK9hIhhU882Nw1AW5RjAJbO2G7YqChJxBgL94aexsaTnP9ajVzjGISSQ+mESrkMIA==",
+      "version": "8.5.0",
+      "resolved": "https://registry.npmjs.org/parse/-/parse-8.5.0.tgz",
+      "integrity": "sha512-X9gI4Yjbi9LPMPnCtKL4h0Nxe1aSCFMPWcB1zbu11qU/Be3eVSB5I5IMBunTuWlVz6Wchu3dtM5jl/1aBZ9wiQ==",
       "dev": true,
       "requires": {
         "@babel/runtime": "7.28.6",
-        "@babel/runtime-corejs3": "7.28.6",
+        "@babel/runtime-corejs3": "7.29.0",
         "crypto-js": "4.2.0",
         "idb-keyval": "6.2.2",
         "react-native-crypto-js": "1.0.0",
         "ws": "8.19.0"
-      },
-      "dependencies": {
-        "@babel/runtime-corejs3": {
-          "version": "7.28.6",
-          "resolved": "https://registry.npmjs.org/@babel/runtime-corejs3/-/runtime-corejs3-7.28.6.tgz",
-          "integrity": "sha512-kz2fAQ5UzjV7X7D3ySxmj3vRq89dTpqOZWv76Z6pNPztkwb/0Yj1Mtx1xFrYj6mbIHysxtBot8J4o0JLCblcFw==",
-          "dev": true,
-          "requires": {
-            "core-js-pure": "^3.43.0"
-          }
-        }
       }
     },
     "parse-asn1": {
@@ -56376,9 +56251,9 @@
       "dev": true
     },
     "parse-server": {
-      "version": "9.2.0",
-      "resolved": "https://registry.npmjs.org/parse-server/-/parse-server-9.2.0.tgz",
-      "integrity": "sha512-YAjVkzDqmTLlkfHdI5Tu+HegheOLSE2uzWQSaTl6KSC9Ksck3cQVCRIarQdijWZoYml5rwwqyHak3v3hgOazsg==",
+      "version": "9.6.0",
+      "resolved": "https://registry.npmjs.org/parse-server/-/parse-server-9.6.0.tgz",
+      "integrity": "sha512-SCdX+LwbSPl/kekQw37V9LvzbwgTL5WPURf5FXbcANhV0Af8prIlAGbMc3aBtwSEWa5qq/T2os88e96tMxvv0w==",
       "dev": true,
       "requires": {
         "@apollo/server": "5.4.0",
@@ -56388,13 +56263,12 @@
         "@graphql-tools/utils": "10.8.6",
         "@node-rs/bcrypt": "1.10.7",
         "@parse/fs-files-adapter": "3.0.0",
-        "@parse/push-adapter": "8.2.0",
+        "@parse/push-adapter": "8.3.1",
         "bcryptjs": "3.0.3",
-        "commander": "14.0.2",
+        "commander": "14.0.3",
         "cors": "2.8.6",
-        "deepcopy": "2.1.0",
         "express": "5.2.1",
-        "express-rate-limit": "7.5.1",
+        "express-rate-limit": "8.2.1",
         "follow-redirects": "1.15.9",
         "graphql": "16.11.0",
         "graphql-list-fields": "2.0.4",
@@ -56407,19 +56281,18 @@
         "lodash": "4.17.23",
         "lru-cache": "10.4.0",
         "mime": "4.0.7",
-        "mongodb": "7.0.0",
+        "mongodb": "7.1.0",
         "mustache": "4.2.0",
         "otpauth": "9.4.0",
-        "parse": "8.0.3",
+        "parse": "8.5.0",
         "path-to-regexp": "8.3.0",
-        "pg-monitor": "3.0.0",
+        "pg-monitor": "3.1.0",
         "pg-promise": "12.6.0",
         "pluralize": "8.0.0",
         "punycode": "2.3.1",
         "rate-limit-redis": "4.2.0",
         "redis": "5.10.0",
         "semver": "7.7.2",
-        "subscriptions-transport-ws": "0.11.0",
         "tv4": "1.3.0",
         "uuid": "11.1.0",
         "winston": "3.19.0",
@@ -56451,9 +56324,9 @@
           "dev": true
         },
         "commander": {
-          "version": "14.0.2",
-          "resolved": "https://registry.npmjs.org/commander/-/commander-14.0.2.tgz",
-          "integrity": "sha512-TywoWNNRbhoD0BXs1P3ZEScW8W5iKrnbithIl0YH+uCmBd0QpPOA8yc82DS3BIE5Ma6FnBVUsJ7wVUDz4dvOWQ==",
+          "version": "14.0.3",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-14.0.3.tgz",
+          "integrity": "sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw==",
           "dev": true
         },
         "data-uri-to-buffer": {
@@ -56465,17 +56338,16 @@
           "peer": true
         },
         "gaxios": {
-          "version": "7.1.3",
-          "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-7.1.3.tgz",
-          "integrity": "sha512-YGGyuEdVIjqxkxVH1pUTMY/XtmmsApXrCVv5EU25iX6inEPbV+VakJfLealkBtJN69AQmh1eGOdCl9Sm1UP6XQ==",
+          "version": "7.1.4",
+          "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-7.1.4.tgz",
+          "integrity": "sha512-bTIgTsM2bWn3XklZISBTQX7ZSddGW+IO3bMdGaemHZ3tbqExMENHLx6kKZ/KlejgrMtj8q7wBItt51yegqalrA==",
           "dev": true,
           "optional": true,
           "peer": true,
           "requires": {
             "extend": "^3.0.2",
             "https-proxy-agent": "^7.0.1",
-            "node-fetch": "^3.3.2",
-            "rimraf": "^5.0.1"
+            "node-fetch": "^3.3.2"
           }
         },
         "gcp-metadata": {
@@ -56512,13 +56384,13 @@
           }
         },
         "mongodb": {
-          "version": "7.0.0",
-          "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-7.0.0.tgz",
-          "integrity": "sha512-vG/A5cQrvGGvZm2mTnCSz1LUcbOPl83hfB6bxULKQ8oFZauyox/2xbZOoGNl+64m8VBrETkdGCDBdOsCr3F3jg==",
+          "version": "7.1.0",
+          "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-7.1.0.tgz",
+          "integrity": "sha512-kMfnKunbolQYwCIyrkxNJFB4Ypy91pYqua5NargS/f8ODNSJxT03ZU3n1JqL4mCzbSih8tvmMEMLpKTT7x5gCg==",
           "dev": true,
           "requires": {
             "@mongodb-js/saslprep": "^1.3.0",
-            "bson": "^7.0.0",
+            "bson": "^7.1.1",
             "mongodb-connection-string-url": "^7.0.0"
           }
         },
@@ -56832,12 +56704,12 @@
       "dev": true
     },
     "pg-monitor": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/pg-monitor/-/pg-monitor-3.0.0.tgz",
-      "integrity": "sha512-62jezmq3lR+lKCIsi9BXVg8Fxv+JG5LtaAuUmex5EVnBPlvAU7Ad6dOiQXHtH1xNh/Oy6Hux36k8uIjZWNeWtQ==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/pg-monitor/-/pg-monitor-3.1.0.tgz",
+      "integrity": "sha512-giK0h52AOO/v8iu6hZCdZ/X9W8oAM9Dm1VReQQtki532X8g4z1LVIm4Z/3cGvDcETWW+Ty0FrtU8iTrGFYIZfA==",
       "dev": true,
       "requires": {
-        "picocolors": "^1.1.1"
+        "picocolors": "1.1.1"
       }
     },
     "pg-pool": {
@@ -58114,77 +57986,6 @@
       "resolved": "https://registry.npmjs.org/rfdc/-/rfdc-1.4.1.tgz",
       "integrity": "sha512-q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA==",
       "dev": true
-    },
-    "rimraf": {
-      "version": "5.0.10",
-      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-5.0.10.tgz",
-      "integrity": "sha512-l0OE8wL34P4nJH/H2ffoaniAokM2qSmrtXHmlpvYr5AVVX8msAyW0l8NVJFDxlSK4u3Uh/f41cQheDVdnYijwQ==",
-      "dev": true,
-      "optional": true,
-      "peer": true,
-      "requires": {
-        "glob": "^10.3.7"
-      },
-      "dependencies": {
-        "brace-expansion": {
-          "version": "2.0.2",
-          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
-          "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
-          "dev": true,
-          "optional": true,
-          "peer": true,
-          "requires": {
-            "balanced-match": "^1.0.0"
-          }
-        },
-        "glob": {
-          "version": "10.5.0",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz",
-          "integrity": "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==",
-          "dev": true,
-          "optional": true,
-          "peer": true,
-          "requires": {
-            "foreground-child": "^3.1.0",
-            "jackspeak": "^3.1.2",
-            "minimatch": "^9.0.4",
-            "minipass": "^7.1.2",
-            "package-json-from-dist": "^1.0.0",
-            "path-scurry": "^1.11.1"
-          }
-        },
-        "jackspeak": {
-          "version": "3.4.3",
-          "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-3.4.3.tgz",
-          "integrity": "sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==",
-          "dev": true,
-          "optional": true,
-          "peer": true,
-          "requires": {
-            "@isaacs/cliui": "^8.0.2",
-            "@pkgjs/parseargs": "^0.11.0"
-          }
-        },
-        "minimatch": {
-          "version": "9.0.5",
-          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
-          "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
-          "dev": true,
-          "optional": true,
-          "peer": true,
-          "requires": {
-            "brace-expansion": "^2.0.1"
-          }
-        },
-        "minipass": {
-          "version": "7.1.2",
-          "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.2.tgz",
-          "integrity": "sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==",
-          "dev": true,
-          "optional": true,
-          "peer": true
-        }
-      }
     },
     "ripemd160": {
       "version": "2.0.2",
@@ -59567,28 +59368,6 @@
         "commander": "^12.0.0"
       }
     },
-    "subscriptions-transport-ws": {
-      "version": "0.11.0",
-      "resolved": "https://registry.npmjs.org/subscriptions-transport-ws/-/subscriptions-transport-ws-0.11.0.tgz",
-      "integrity": "sha512-8D4C6DIH5tGiAIpp5I0wD/xRlNiZAPGHygzCe7VzyzUoxHtawzjNAY9SUTXU05/EY2NMY9/9GF0ycizkXr1CWQ==",
-      "dev": true,
-      "requires": {
-        "backo2": "^1.0.2",
-        "eventemitter3": "^3.1.0",
-        "iterall": "^1.2.1",
-        "symbol-observable": "^1.0.4",
-        "ws": "^5.2.0 || ^6.0.0 || ^7.0.0"
-      },
-      "dependencies": {
-        "ws": {
-          "version": "7.5.9",
-          "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.9.tgz",
-          "integrity": "sha512-F+P9Jil7UiSKSkppIiD94dN07AwvFixvLIj1Og1Rl9GGMuNipJnV9JzjD6XuqmAeiswGvUmNLjr5cFuXwNS77Q==",
-          "dev": true,
-          "requires": {}
-        }
-      }
-    },
     "super-regex": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/super-regex/-/super-regex-1.0.0.tgz",
@@ -59658,12 +59437,6 @@
           "optional": true
         }
       }
-    },
-    "symbol-observable": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-1.2.0.tgz",
-      "integrity": "sha512-e900nM8RRtGhlV36KGEU9k65K3mPb1WV70OdjfxlG2EAuM1noi/E/BaW/uMhL7bPEssK8QV57vN3esixjUvcXQ==",
-      "dev": true
     },
     "symbol-tree": {
       "version": "3.2.4",

--- a/package.json
+++ b/package.json
@@ -115,7 +115,7 @@
     "madge": "8.0.0",
     "metro-react-native-babel-preset": "0.77.0",
     "mongodb-runner": "6.6.1",
-    "parse-server": "9.2.0",
+    "parse-server": "9.6.0",
     "puppeteer": "24.37.2",
     "regenerator-runtime": "0.14.1",
     "semantic-release": "25.0.3",


### PR DESCRIPTION
Closes #2951

### Changes

- **9.3.0**: Enhanced authData validation on provider unlinking
- **9.4.0**: AuthData validation fixes for unchanged providers
- **9.5.0–9.5.2**: JWT and audience validation improvements; added BaseCodeAuthAdapter requiring code field for OAuth2 auth providers (Twitter, etc.)
- **9.6.0**: Enforced string type for authData IDs; hardened login provider checks; blocked dot-notation authData updates

### Breaking Changes

- **9.5.2**: Auth adapters using code-based OAuth2 (e.g. Twitter) now require a `code` field in authData via `beforeFind` validation
- **9.6.0**: `authData.id` must be a string; numeric IDs are rejected with error code 162

### Code Changes Required

- Fixed custom auth test to use string ID (`'1234'` instead of `1234`)
- Fixed Twitter auth tests to spy on the server adapter instance (`server.config.auth.twitter.beforeFind`) instead of the module export, ensuring the mock correctly intercepts the `beforeFind` code validation

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Simplified and hardened social login/linking tests for Twitter and Facebook; adjusted auth payload handling (IDs asserted as strings) and moved to adapter-level spying while removing some per-instance validation assertions.

* **Chores**
  * Upgraded parse-server to 9.6.0 and refreshed lockfile, updating many transitive dependencies and removing an obsolete WebSocket transport package.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->