### PR TITLE
refactor: Bump @rollup/plugin-terser from 0.4.4 to 1.0.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -25,7 +25,7 @@
         "@babel/preset-typescript": "7.27.1",
         "@eslint/js": "9.39.2",
         "@parse/minami": "git+https://github.com/parse-community/minami#main",
-        "@rollup/plugin-terser": "0.4.4",
+        "@rollup/plugin-terser": "1.0.0",
         "@saithodev/semantic-release-backmerge": "4.0.1",
         "@semantic-release/changelog": "6.0.3",
         "@semantic-release/commit-analyzer": "13.0.1",
@@ -6450,17 +6450,18 @@
       }
     },
     "node_modules/@rollup/plugin-terser": {
-      "version": "0.4.4",
-      "resolved": "https://registry.npmjs.org/@rollup/plugin-terser/-/plugin-terser-0.4.4.tgz",
-      "integrity": "sha512-XHeJC5Bgvs8LfukDwWZp7yeqin6ns8RTl2B9avbejt6tZqsqvVoWI7ZTQrcNsfKEDWBTnTxM8nMDkO2IFFbd0A==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@rollup/plugin-terser/-/plugin-terser-1.0.0.tgz",
+      "integrity": "sha512-FnCxhTBx6bMOYQrar6C8h3scPt8/JwIzw3+AJ2K++6guogH5fYaIFia+zZuhqv0eo1RN7W1Pz630SyvLbDjhtQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "serialize-javascript": "^6.0.1",
+        "serialize-javascript": "^7.0.3",
         "smob": "^1.0.0",
         "terser": "^5.17.4"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">=20.0.0"
       },
       "peerDependencies": {
         "rollup": "^2.0.0||^3.0.0||^4.0.0"
@@ -31275,12 +31276,13 @@
       }
     },
     "node_modules/serialize-javascript": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-6.0.2.tgz",
-      "integrity": "sha512-Saa1xPByTTq2gdeFZYLLo+RFE35NHZkAbqZeWNd3BpzppeVisAqpDjcp8dyf6uIvEqJRd46jemmyA4iFIeVk8g==",
+      "version": "7.0.5",
+      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-7.0.5.tgz",
+      "integrity": "sha512-F4LcB0UqUl1zErq+1nYEEzSHJnIwb3AF2XWB94b+afhrekOUijwooAYqFyRbjYkm2PAKBabx6oYv/xDxNi8IBw==",
       "dev": true,
-      "dependencies": {
-        "randombytes": "^2.1.0"
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=20.0.0"
       }
     },
     "node_modules/set-blocking": {
@@ -39283,12 +39285,12 @@
       }
     },
     "@rollup/plugin-terser": {
-      "version": "0.4.4",
-      "resolved": "https://registry.npmjs.org/@rollup/plugin-terser/-/plugin-terser-0.4.4.tgz",
-      "integrity": "sha512-XHeJC5Bgvs8LfukDwWZp7yeqin6ns8RTl2B9avbejt6tZqsqvVoWI7ZTQrcNsfKEDWBTnTxM8nMDkO2IFFbd0A==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@rollup/plugin-terser/-/plugin-terser-1.0.0.tgz",
+      "integrity": "sha512-FnCxhTBx6bMOYQrar6C8h3scPt8/JwIzw3+AJ2K++6guogH5fYaIFia+zZuhqv0eo1RN7W1Pz630SyvLbDjhtQ==",
       "dev": true,
       "requires": {
-        "serialize-javascript": "^6.0.1",
+        "serialize-javascript": "^7.0.3",
         "smob": "^1.0.0",
         "terser": "^5.17.4"
       }
@@ -57063,13 +57065,10 @@
       "dev": true
     },
     "serialize-javascript": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-6.0.2.tgz",
-      "integrity": "sha512-Saa1xPByTTq2gdeFZYLLo+RFE35NHZkAbqZeWNd3BpzppeVisAqpDjcp8dyf6uIvEqJRd46jemmyA4iFIeVk8g==",
-      "dev": true,
-      "requires": {
-        "randombytes": "^2.1.0"
-      }
+      "version": "7.0.5",
+      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-7.0.5.tgz",
+      "integrity": "sha512-F4LcB0UqUl1zErq+1nYEEzSHJnIwb3AF2XWB94b+afhrekOUijwooAYqFyRbjYkm2PAKBabx6oYv/xDxNi8IBw==",
+      "dev": true
     },
     "set-blocking": {
       "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -82,7 +82,7 @@
     "@babel/preset-typescript": "7.27.1",
     "@eslint/js": "9.39.2",
     "@parse/minami": "git+https://github.com/parse-community/minami#main",
-    "@rollup/plugin-terser": "0.4.4",
+    "@rollup/plugin-terser": "1.0.0",
     "@saithodev/semantic-release-backmerge": "4.0.1",
     "@semantic-release/changelog": "6.0.3",
     "@semantic-release/commit-analyzer": "13.0.1",


### PR DESCRIPTION
Closes #2956

### Changes

- **@rollup/plugin-terser 1.0.0**: Upgraded serialize-javascript to v7 and Node.js requirement to v20+
- **serialize-javascript 7.0.0**: Requires Node.js v20+
- **serialize-javascript 7.0.1**: Security fix — sanitize function bodies
- **serialize-javascript 7.0.2**: CI changes only
- **serialize-javascript 7.0.3**: Fix CVE-2020-7660 — RegExp.flags and Date.prototype.toISOString
- **serialize-javascript 7.0.4**: Release maintenance
- **serialize-javascript 7.0.5**: Security fix — array-like object serialization robustness, excessive CPU usage (GHSA-qj8w-gfj5-8c6v)

### Breaking Changes

- **serialize-javascript 7.0.0**: Requires Node.js v20+ (already satisfied by this project's CI matrix: Node 20, 22, 24)
- **@rollup/plugin-terser 1.0.0**: Requires Node.js v20+ (same as above)

### Code Changes Required

None — the upgrade is a drop-in replacement given the project's Node.js v20+ support.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated development dependencies, including build optimization tooling
  * Refreshed Node.js version requirements

<!-- end of auto-generated comment: release notes by coderabbit.ai -->