### PR TITLE
refactor: Bump eslint-plugin-jsdoc from 62.5.4 to 62.5.5

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -42,7 +42,7 @@
         "cross-env": "10.1.0",
         "eslint": "9.39.2",
         "eslint-plugin-expect-type": "0.6.2",
-        "eslint-plugin-jsdoc": "62.5.4",
+        "eslint-plugin-jsdoc": "62.5.5",
         "express": "5.2.1",
         "gulp": "5.0.1",
         "gulp-babel": "8.0.0",
@@ -15971,10 +15971,11 @@
       }
     },
     "node_modules/eslint-plugin-jsdoc": {
-      "version": "62.5.4",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-jsdoc/-/eslint-plugin-jsdoc-62.5.4.tgz",
-      "integrity": "sha512-U+Q5ppErmC17VFQl542eBIaXcuq975BzoIHBXyx7UQx/i4gyHXxPiBkonkuxWyFA98hGLALLUuD+NJcXqSGKxg==",
+      "version": "62.5.5",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-jsdoc/-/eslint-plugin-jsdoc-62.5.5.tgz",
+      "integrity": "sha512-aRp0KVW26imgPqn17oSDnJdA3tlu+6D/xI/pqWzK5qDPQbldQ1Hsg84dYAsFyvGJhI+u/sGvzgGjMjlKQtUG/Q==",
       "dev": true,
+      "license": "BSD-3-Clause",
       "dependencies": {
         "@es-joy/jsdoccomment": "~0.84.0",
         "@es-joy/resolve.exports": "1.2.0",
@@ -46268,9 +46269,9 @@
       }
     },
     "eslint-plugin-jsdoc": {
-      "version": "62.5.4",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-jsdoc/-/eslint-plugin-jsdoc-62.5.4.tgz",
-      "integrity": "sha512-U+Q5ppErmC17VFQl542eBIaXcuq975BzoIHBXyx7UQx/i4gyHXxPiBkonkuxWyFA98hGLALLUuD+NJcXqSGKxg==",
+      "version": "62.5.5",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-jsdoc/-/eslint-plugin-jsdoc-62.5.5.tgz",
+      "integrity": "sha512-aRp0KVW26imgPqn17oSDnJdA3tlu+6D/xI/pqWzK5qDPQbldQ1Hsg84dYAsFyvGJhI+u/sGvzgGjMjlKQtUG/Q==",
       "dev": true,
       "requires": {
         "@es-joy/jsdoccomment": "~0.84.0",

--- a/package.json
+++ b/package.json
@@ -99,7 +99,7 @@
     "cross-env": "10.1.0",
     "eslint": "9.39.2",
     "eslint-plugin-expect-type": "0.6.2",
-    "eslint-plugin-jsdoc": "62.5.4",
+    "eslint-plugin-jsdoc": "62.5.5",
     "express": "5.2.1",
     "gulp": "5.0.1",
     "gulp-babel": "8.0.0",


### PR DESCRIPTION
Closes #2923

### Changes

- **62.5.5**: Patch release of eslint-plugin-jsdoc

### Breaking Changes

None

### Code Changes Required

None — the upgrade is a drop-in replacement.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated linting tool dependency to the latest patch version for improved code quality tooling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->