### PR TITLE
refactor: Bump @semantic-release/github from 12.0.5 to 12.0.6

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -30,7 +30,7 @@
         "@semantic-release/changelog": "6.0.3",
         "@semantic-release/commit-analyzer": "13.0.1",
         "@semantic-release/git": "10.0.1",
-        "@semantic-release/github": "12.0.5",
+        "@semantic-release/github": "12.0.6",
         "@semantic-release/npm": "13.1.4",
         "@semantic-release/release-notes-generator": "14.1.0",
         "@types/facebook-js-sdk": "3.3.11",
@@ -7949,10 +7949,11 @@
       }
     },
     "node_modules/@semantic-release/github": {
-      "version": "12.0.5",
-      "resolved": "https://registry.npmjs.org/@semantic-release/github/-/github-12.0.5.tgz",
-      "integrity": "sha512-QEf76UJGbNdq58EWQHBO56YWVQbPDuFOSITkfaI6Q4acpThWqL/jpbrDTilcqo3plRE3NnJko97XLmpCEp4WGw==",
+      "version": "12.0.6",
+      "resolved": "https://registry.npmjs.org/@semantic-release/github/-/github-12.0.6.tgz",
+      "integrity": "sha512-aYYFkwHW3c6YtHwQF0t0+lAjlU+87NFOZuH2CvWFD0Ylivc7MwhZMiHOJ0FMpIgPpCVib/VUAcOwvrW0KnxQtA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@octokit/core": "^7.0.0",
         "@octokit/plugin-paginate-rest": "^14.0.0",
@@ -40328,9 +40329,9 @@
       }
     },
     "@semantic-release/github": {
-      "version": "12.0.5",
-      "resolved": "https://registry.npmjs.org/@semantic-release/github/-/github-12.0.5.tgz",
-      "integrity": "sha512-QEf76UJGbNdq58EWQHBO56YWVQbPDuFOSITkfaI6Q4acpThWqL/jpbrDTilcqo3plRE3NnJko97XLmpCEp4WGw==",
+      "version": "12.0.6",
+      "resolved": "https://registry.npmjs.org/@semantic-release/github/-/github-12.0.6.tgz",
+      "integrity": "sha512-aYYFkwHW3c6YtHwQF0t0+lAjlU+87NFOZuH2CvWFD0Ylivc7MwhZMiHOJ0FMpIgPpCVib/VUAcOwvrW0KnxQtA==",
       "dev": true,
       "requires": {
         "@octokit/core": "^7.0.0",

--- a/package.json
+++ b/package.json
@@ -87,7 +87,7 @@
     "@semantic-release/changelog": "6.0.3",
     "@semantic-release/commit-analyzer": "13.0.1",
     "@semantic-release/git": "10.0.1",
-    "@semantic-release/github": "12.0.5",
+    "@semantic-release/github": "12.0.6",
     "@semantic-release/npm": "13.1.4",
     "@semantic-release/release-notes-generator": "14.1.0",
     "@types/facebook-js-sdk": "3.3.11",


### PR DESCRIPTION
Closes #2920

### Changes

- **12.0.6**: Patch release of @semantic-release/github

### Breaking Changes

None

### Code Changes Required

None — the upgrade is a drop-in replacement.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated @semantic-release/github dependency to version 12.0.6

<!-- end of auto-generated comment: release notes by coderabbit.ai -->