### PR TITLE
refactor: Bump jasmine from 6.0.0 to 6.1.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -47,7 +47,7 @@
         "gulp": "5.0.1",
         "gulp-babel": "8.0.0",
         "gulp-watch": "5.0.1",
-        "jasmine": "6.0.0",
+        "jasmine": "6.1.0",
         "jasmine-reporters": "2.5.2",
         "jasmine-spec-reporter": "7.0.0",
         "jest": "29.7.0",
@@ -20390,23 +20390,23 @@
       }
     },
     "node_modules/jasmine": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/jasmine/-/jasmine-6.0.0.tgz",
-      "integrity": "sha512-eSPL6LPWT39WwvHSEEbRXuSvioXMTheNhIPaeUT1OPmSprDZwj4S29884DkTx6/tyiOWTWB1N+LdW2ZSg74aEA==",
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/jasmine/-/jasmine-6.1.0.tgz",
+      "integrity": "sha512-WPphPqEMY0uBRMjuhRHoVoxQNvJuxIMqz0yIcJ3k3oYxBedeGoH60/NXNgasxnx2FvfXrq5/r+2wssJ7WE8ABw==",
       "dev": true,
       "dependencies": {
         "@jasminejs/reporters": "^1.0.0",
         "glob": "^10.2.2 || ^11.0.3 || ^12.0.0 || ^13.0.0",
-        "jasmine-core": "~6.0.0"
+        "jasmine-core": "~6.1.0"
       },
       "bin": {
         "jasmine": "bin/jasmine.js"
       }
     },
     "node_modules/jasmine-core": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/jasmine-core/-/jasmine-core-6.0.1.tgz",
-      "integrity": "sha512-gUtzV5ASR0MLBwDNqri4kBsgKNCcRQd9qOlNw/w/deavD0cl3JmWXXfH8JhKM4LTg6LPTt2IOQ4px3YYfgh2Xg==",
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/jasmine-core/-/jasmine-core-6.1.0.tgz",
+      "integrity": "sha512-p/tjBw58O6vxKIWMlrU+yys8lqR3+l3UrqwNTT7wpj+dQ7N4etQekFM8joI+cWzPDYqZf54kN+hLC1+s5TvZvg==",
       "dev": true
     },
     "node_modules/jasmine-reporters": {
@@ -49371,14 +49371,14 @@
       }
     },
     "jasmine": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/jasmine/-/jasmine-6.0.0.tgz",
-      "integrity": "sha512-eSPL6LPWT39WwvHSEEbRXuSvioXMTheNhIPaeUT1OPmSprDZwj4S29884DkTx6/tyiOWTWB1N+LdW2ZSg74aEA==",
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/jasmine/-/jasmine-6.1.0.tgz",
+      "integrity": "sha512-WPphPqEMY0uBRMjuhRHoVoxQNvJuxIMqz0yIcJ3k3oYxBedeGoH60/NXNgasxnx2FvfXrq5/r+2wssJ7WE8ABw==",
       "dev": true,
       "requires": {
         "@jasminejs/reporters": "^1.0.0",
         "glob": "^10.2.2 || ^11.0.3 || ^12.0.0 || ^13.0.0",
-        "jasmine-core": "~6.0.0"
+        "jasmine-core": "~6.1.0"
       },
       "dependencies": {
         "brace-expansion": {
@@ -49415,9 +49415,9 @@
       }
     },
     "jasmine-core": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/jasmine-core/-/jasmine-core-6.0.1.tgz",
-      "integrity": "sha512-gUtzV5ASR0MLBwDNqri4kBsgKNCcRQd9qOlNw/w/deavD0cl3JmWXXfH8JhKM4LTg6LPTt2IOQ4px3YYfgh2Xg==",
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/jasmine-core/-/jasmine-core-6.1.0.tgz",
+      "integrity": "sha512-p/tjBw58O6vxKIWMlrU+yys8lqR3+l3UrqwNTT7wpj+dQ7N4etQekFM8joI+cWzPDYqZf54kN+hLC1+s5TvZvg==",
       "dev": true
     },
     "jasmine-reporters": {

--- a/package.json
+++ b/package.json
@@ -104,7 +104,7 @@
     "gulp": "5.0.1",
     "gulp-babel": "8.0.0",
     "gulp-watch": "5.0.1",
-    "jasmine": "6.0.0",
+    "jasmine": "6.1.0",
     "jasmine-reporters": "2.5.2",
     "jasmine-spec-reporter": "7.0.0",
     "jest": "29.7.0",


### PR DESCRIPTION
## Changes

- Bumps [jasmine](https://github.com/jasmine/jasmine-npm) from 6.0.0 to 6.1.0
- jasmine 6.1.0 updates jasmine-core to 6.1.0, which adds AggregateError reporting and fixes JsDoc for MAX_PRETTY_PRINT_CHARS
- Safari 16 and 17 are no longer supported in jasmine-core (not relevant to this SDK's Node.js testing)

## Breaking Changes

None

## Code Changes Required

None

Closes #2970

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated testing framework dependencies to latest minor versions for improved stability and performance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->