### PR TITLE
refactor: Bump mongodb-runner from 6.6.1 to 6.7.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -57,7 +57,7 @@
         "lint-staged": "16.2.7",
         "madge": "8.0.0",
         "metro-react-native-babel-preset": "0.77.0",
-        "mongodb-runner": "6.6.1",
+        "mongodb-runner": "6.7.3",
         "parse-server": "9.6.0",
         "puppeteer": "24.37.3",
         "regenerator-runtime": "0.14.1",
@@ -5236,9 +5236,9 @@
       }
     },
     "node_modules/@mongodb-js/oidc-mock-provider": {
-      "version": "0.13.6",
-      "resolved": "https://registry.npmjs.org/@mongodb-js/oidc-mock-provider/-/oidc-mock-provider-0.13.6.tgz",
-      "integrity": "sha512-2K7KfCwWquonVKvi/MEPWG+Q8vnTGLMcm1I5En0zf9Jqk6CFuoEnojVK7IJtVHdXYp9oR6fnNCMzir5xs965mQ==",
+      "version": "0.13.7",
+      "resolved": "https://registry.npmjs.org/@mongodb-js/oidc-mock-provider/-/oidc-mock-provider-0.13.7.tgz",
+      "integrity": "sha512-OARcW2flFuMtA0TxHsE5oItrpr06w/w0Ihi1Rnqbakyc7/y/yARemBCP4iJX1qLKPLJYwGlEmWrAA4ocs5wrKg==",
       "dev": true,
       "dependencies": {
         "yargs": "^17.7.2"
@@ -24489,13 +24489,13 @@
       }
     },
     "node_modules/mongodb-runner": {
-      "version": "6.6.1",
-      "resolved": "https://registry.npmjs.org/mongodb-runner/-/mongodb-runner-6.6.1.tgz",
-      "integrity": "sha512-drm5qGWERJEgX6sh+F3h9TcNw8VLCzMx8JjxyD8NaL8Chsy0DWOfUekqe3s/fqgImZ0kX2CC2p+9T0uqAhHBow==",
+      "version": "6.7.3",
+      "resolved": "https://registry.npmjs.org/mongodb-runner/-/mongodb-runner-6.7.3.tgz",
+      "integrity": "sha512-wNGwVAuMh9+LF3ajfGTiGL2YV/dssrlf5eUuDuTwNC0xL/gSAZGYUJRGVeOQYy4ISMd8G+xTSPltwcoxy+F0UQ==",
       "dev": true,
       "dependencies": {
-        "@mongodb-js/mongodb-downloader": "^1.1.7",
-        "@mongodb-js/oidc-mock-provider": "^0.13.6",
+        "@mongodb-js/mongodb-downloader": "^1.1.9",
+        "@mongodb-js/oidc-mock-provider": "^0.13.7",
         "@mongodb-js/saslprep": "^1.4.6",
         "@peculiar/x509": "^1.14.2",
         "debug": "^4.4.0",
@@ -38492,9 +38492,9 @@
       }
     },
     "@mongodb-js/oidc-mock-provider": {
-      "version": "0.13.6",
-      "resolved": "https://registry.npmjs.org/@mongodb-js/oidc-mock-provider/-/oidc-mock-provider-0.13.6.tgz",
-      "integrity": "sha512-2K7KfCwWquonVKvi/MEPWG+Q8vnTGLMcm1I5En0zf9Jqk6CFuoEnojVK7IJtVHdXYp9oR6fnNCMzir5xs965mQ==",
+      "version": "0.13.7",
+      "resolved": "https://registry.npmjs.org/@mongodb-js/oidc-mock-provider/-/oidc-mock-provider-0.13.7.tgz",
+      "integrity": "sha512-OARcW2flFuMtA0TxHsE5oItrpr06w/w0Ihi1Rnqbakyc7/y/yARemBCP4iJX1qLKPLJYwGlEmWrAA4ocs5wrKg==",
       "dev": true,
       "requires": {
         "yargs": "^17.7.2"
@@ -52409,13 +52409,13 @@
       }
     },
     "mongodb-runner": {
-      "version": "6.6.1",
-      "resolved": "https://registry.npmjs.org/mongodb-runner/-/mongodb-runner-6.6.1.tgz",
-      "integrity": "sha512-drm5qGWERJEgX6sh+F3h9TcNw8VLCzMx8JjxyD8NaL8Chsy0DWOfUekqe3s/fqgImZ0kX2CC2p+9T0uqAhHBow==",
+      "version": "6.7.3",
+      "resolved": "https://registry.npmjs.org/mongodb-runner/-/mongodb-runner-6.7.3.tgz",
+      "integrity": "sha512-wNGwVAuMh9+LF3ajfGTiGL2YV/dssrlf5eUuDuTwNC0xL/gSAZGYUJRGVeOQYy4ISMd8G+xTSPltwcoxy+F0UQ==",
       "dev": true,
       "requires": {
-        "@mongodb-js/mongodb-downloader": "^1.1.7",
-        "@mongodb-js/oidc-mock-provider": "^0.13.6",
+        "@mongodb-js/mongodb-downloader": "^1.1.9",
+        "@mongodb-js/oidc-mock-provider": "^0.13.7",
         "@mongodb-js/saslprep": "^1.4.6",
         "@peculiar/x509": "^1.14.2",
         "debug": "^4.4.0",

--- a/package.json
+++ b/package.json
@@ -114,7 +114,7 @@
     "lint-staged": "16.2.7",
     "madge": "8.0.0",
     "metro-react-native-babel-preset": "0.77.0",
-    "mongodb-runner": "6.6.1",
+    "mongodb-runner": "6.7.3",
     "parse-server": "9.6.0",
     "puppeteer": "24.37.3",
     "regenerator-runtime": "0.14.1",


### PR DESCRIPTION
Bumps mongodb-runner from 6.6.1 to 6.7.3.

Closes #2969

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated MongoDB-related development and testing dependencies to the latest versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->