### PR TITLE
refactor: Bump parse-server from 9.6.0 to 9.7.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -58,7 +58,7 @@
         "madge": "8.0.0",
         "metro-react-native-babel-preset": "0.77.0",
         "mongodb-runner": "6.7.3",
-        "parse-server": "9.6.0",
+        "parse-server": "9.7.0",
         "puppeteer": "24.37.3",
         "regenerator-runtime": "0.14.1",
         "semantic-release": "25.0.3",
@@ -143,11 +143,10 @@
       }
     },
     "node_modules/@apollo/server": {
-      "version": "5.4.0",
-      "resolved": "https://registry.npmjs.org/@apollo/server/-/server-5.4.0.tgz",
-      "integrity": "sha512-E0/2C5Rqp7bWCjaDh4NzYuEPDZ+dltTf2c0FI6GCKJA6GBetVferX3h1//1rS4+NxD36wrJsGGJK+xyT/M3ysg==",
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/@apollo/server/-/server-5.5.0.tgz",
+      "integrity": "sha512-vWtodBOK/SZwBTJzItECOmLfL8E8pn/IdvP7pnxN5g2tny9iW4+9sxdajE798wV1H2+PYp/rRcl/soSHIBKMPw==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@apollo/cache-control-types": "^1.0.3",
         "@apollo/server-gateway-interface": "^2.0.0",
@@ -6368,68 +6367,71 @@
       }
     },
     "node_modules/@redis/bloom": {
-      "version": "5.10.0",
-      "resolved": "https://registry.npmjs.org/@redis/bloom/-/bloom-5.10.0.tgz",
-      "integrity": "sha512-doIF37ob+l47n0rkpRNgU8n4iacBlKM9xLiP1LtTZTvz8TloJB8qx/MgvhMhKdYG+CvCY2aPBnN2706izFn/4A==",
+      "version": "5.11.0",
+      "resolved": "https://registry.npmjs.org/@redis/bloom/-/bloom-5.11.0.tgz",
+      "integrity": "sha512-KYiVilAhAFN3057afUb/tfYJpsEyTkQB+tQcn5gVVA7DgcNOAj8lLxe4j8ov8BF6I9C1Fe/kwlbuAICcTMX8Lw==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">= 18"
       },
       "peerDependencies": {
-        "@redis/client": "^5.10.0"
+        "@redis/client": "^5.11.0"
       }
     },
     "node_modules/@redis/client": {
-      "version": "5.10.0",
-      "resolved": "https://registry.npmjs.org/@redis/client/-/client-5.10.0.tgz",
-      "integrity": "sha512-JXmM4XCoso6C75Mr3lhKA3eNxSzkYi3nCzxDIKY+YOszYsJjuKbFgVtguVPbLMOttN4iu2fXoc2BGhdnYhIOxA==",
+      "version": "5.11.0",
+      "resolved": "https://registry.npmjs.org/@redis/client/-/client-5.11.0.tgz",
+      "integrity": "sha512-GHoprlNQD51Xq2Ztd94HHV94MdFZQ3CVrpA04Fz8MVoHM0B7SlbmPEVIjwTbcv58z8QyjnrOuikS0rWF03k5dQ==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "cluster-key-slot": "1.1.2"
       },
       "engines": {
         "node": ">= 18"
+      },
+      "peerDependencies": {
+        "@node-rs/xxhash": "^1.1.0"
+      },
+      "peerDependenciesMeta": {
+        "@node-rs/xxhash": {
+          "optional": true
+        }
       }
     },
     "node_modules/@redis/json": {
-      "version": "5.10.0",
-      "resolved": "https://registry.npmjs.org/@redis/json/-/json-5.10.0.tgz",
-      "integrity": "sha512-B2G8XlOmTPUuZtD44EMGbtoepQG34RCDXLZbjrtON1Djet0t5Ri7/YPXvL9aomXqP8lLTreaprtyLKF4tmXEEA==",
+      "version": "5.11.0",
+      "resolved": "https://registry.npmjs.org/@redis/json/-/json-5.11.0.tgz",
+      "integrity": "sha512-1iAy9kAtcD0quB21RbPTbUqqy+T2Uu2JxucwE+B4A+VaDbIRvpZR6DMqV8Iqaws2YxJYB3GC5JVNzPYio2ErUg==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">= 18"
       },
       "peerDependencies": {
-        "@redis/client": "^5.10.0"
+        "@redis/client": "^5.11.0"
       }
     },
     "node_modules/@redis/search": {
-      "version": "5.10.0",
-      "resolved": "https://registry.npmjs.org/@redis/search/-/search-5.10.0.tgz",
-      "integrity": "sha512-3SVcPswoSfp2HnmWbAGUzlbUPn7fOohVu2weUQ0S+EMiQi8jwjL+aN2p6V3TI65eNfVsJ8vyPvqWklm6H6esmg==",
+      "version": "5.11.0",
+      "resolved": "https://registry.npmjs.org/@redis/search/-/search-5.11.0.tgz",
+      "integrity": "sha512-g1l7f3Rnyk/xI99oGHIgWHSKFl45Re5YTIcO8j/JE8olz389yUFyz2+A6nqVy/Zi031VgPDWscbbgOk8hlhZ3g==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">= 18"
       },
       "peerDependencies": {
-        "@redis/client": "^5.10.0"
+        "@redis/client": "^5.11.0"
       }
     },
     "node_modules/@redis/time-series": {
-      "version": "5.10.0",
-      "resolved": "https://registry.npmjs.org/@redis/time-series/-/time-series-5.10.0.tgz",
-      "integrity": "sha512-cPkpddXH5kc/SdRhF0YG0qtjL+noqFT0AcHbQ6axhsPsO7iqPi1cjxgdkE9TNeKiBUUdCaU1DbqkR/LzbzPBhg==",
+      "version": "5.11.0",
+      "resolved": "https://registry.npmjs.org/@redis/time-series/-/time-series-5.11.0.tgz",
+      "integrity": "sha512-TWFeOcU4xkj0DkndnOyhtxvX1KWD+78UHT3XX3x3XRBUGWeQrKo3jqzDsZwxbggUgf9yLJr/akFHXru66X5UQA==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">= 18"
       },
       "peerDependencies": {
-        "@redis/client": "^5.10.0"
+        "@redis/client": "^5.11.0"
       }
     },
     "node_modules/@rollup/plugin-inject": {
@@ -13871,7 +13873,6 @@
       "resolved": "https://registry.npmjs.org/cluster-key-slot/-/cluster-key-slot-1.1.2.tgz",
       "integrity": "sha512-RMr0FhtfXemyinomL4hrWcYJxmX6deFdCxpJzhDttxgO1+bcCnkk+9drydLVDmAMG7NE6aN/fl4F7ucU/90gAA==",
       "dev": true,
-      "license": "Apache-2.0",
       "engines": {
         "node": ">=0.10.0"
       }
@@ -16731,13 +16732,12 @@
       }
     },
     "node_modules/express-rate-limit": {
-      "version": "8.2.1",
-      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.2.1.tgz",
-      "integrity": "sha512-PCZEIEIxqwhzw4KF0n7QF4QqruVTcF73O5kFKUnGOyjbCCgizBBiFaYpd/fnBLUMPw/BWw9OsiN7GgrNYr7j6g==",
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.3.0.tgz",
+      "integrity": "sha512-KJzBawY6fB9FiZGdE/0aftepZ91YlaGIrV8vgblRM3J8X+dHx/aiowJWwkx6LIGyuqGiANsjSwwrbb8mifOJ4Q==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "ip-address": "10.0.1"
+        "ip-address": "10.1.0"
       },
       "engines": {
         "node": ">= 16"
@@ -16747,16 +16747,6 @@
       },
       "peerDependencies": {
         "express": ">= 4.11"
-      }
-    },
-    "node_modules/express-rate-limit/node_modules/ip-address": {
-      "version": "10.0.1",
-      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.0.1.tgz",
-      "integrity": "sha512-NWv9YLW4PoW2B7xtzaS3NCot75m6nK7Icdv0o3lfMceJVRfSoQwqD4wEH5rLwoKJwUiZ/rfpiVBhnaF0FK4HoA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 12"
       }
     },
     "node_modules/express/node_modules/accepts": {
@@ -17573,9 +17563,9 @@
       "dev": true
     },
     "node_modules/follow-redirects": {
-      "version": "1.15.9",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.9.tgz",
-      "integrity": "sha512-gew4GsXizNgdoRyqmyfMHyAmXsZDk6mHkSxZFCzW9gwlbtOW44CDtYavM+y+72qD/Vq2l550kMF52DT8fOLJqQ==",
+      "version": "1.15.11",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.11.tgz",
+      "integrity": "sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==",
       "dev": true,
       "funding": [
         {
@@ -18625,11 +18615,10 @@
       "dev": true
     },
     "node_modules/graphql": {
-      "version": "16.11.0",
-      "resolved": "https://registry.npmjs.org/graphql/-/graphql-16.11.0.tgz",
-      "integrity": "sha512-mS1lbMsxgQj6hge1XZ6p7GPhbrtFwUFYi3wRzXAC/FmYnyXMTvvI3td3rjmQ2u8ewXueaSvRPWaEcgVVOT9Jnw==",
+      "version": "16.13.2",
+      "resolved": "https://registry.npmjs.org/graphql/-/graphql-16.13.2.tgz",
+      "integrity": "sha512-5bJ+nf/UCpAjHM8i06fl7eLyVC9iuNAjm9qzkiu2ZGhM0VscSvS6WDPfAwkdkBuoXGM9FJSbKl6wylMwP9Ktig==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": "^12.22.0 || ^14.16.0 || ^16.0.0 || >=17.0.0"
       }
@@ -28190,14 +28179,13 @@
       }
     },
     "node_modules/parse-server": {
-      "version": "9.6.0",
-      "resolved": "https://registry.npmjs.org/parse-server/-/parse-server-9.6.0.tgz",
-      "integrity": "sha512-SCdX+LwbSPl/kekQw37V9LvzbwgTL5WPURf5FXbcANhV0Af8prIlAGbMc3aBtwSEWa5qq/T2os88e96tMxvv0w==",
+      "version": "9.7.0",
+      "resolved": "https://registry.npmjs.org/parse-server/-/parse-server-9.7.0.tgz",
+      "integrity": "sha512-QY5h5dAJvIG3tAcPfCGoDGKFDKIGhbNZ20rPzzhbRvWcX5n2rrE7KWKrL1Sk9aIuLKS2VAN4Muk7p5zTDP/dfQ==",
       "dev": true,
       "hasInstallScript": true,
-      "license": "Apache-2.0",
       "dependencies": {
-        "@apollo/server": "5.4.0",
+        "@apollo/server": "5.5.0",
         "@as-integrations/express5": "1.1.2",
         "@graphql-tools/merge": "9.0.24",
         "@graphql-tools/schema": "10.0.23",
@@ -28208,9 +28196,9 @@
         "commander": "14.0.3",
         "cors": "2.8.6",
         "express": "5.2.1",
-        "express-rate-limit": "8.2.1",
-        "follow-redirects": "1.15.9",
-        "graphql": "16.11.0",
+        "express-rate-limit": "8.3.0",
+        "follow-redirects": "1.15.11",
+        "graphql": "16.13.2",
         "graphql-list-fields": "2.0.4",
         "graphql-relay": "0.10.2",
         "graphql-upload": "15.0.2",
@@ -28219,25 +28207,25 @@
         "jwks-rsa": "3.2.0",
         "ldapjs": "3.0.7",
         "lodash": "4.17.23",
-        "lru-cache": "10.4.0",
+        "lru-cache": "11.2.7",
         "mime": "4.0.7",
         "mongodb": "7.1.0",
         "mustache": "4.2.0",
         "otpauth": "9.4.0",
         "parse": "8.5.0",
-        "path-to-regexp": "8.3.0",
+        "path-to-regexp": "8.4.0",
         "pg-monitor": "3.1.0",
         "pg-promise": "12.6.0",
         "pluralize": "8.0.0",
         "punycode": "2.3.1",
-        "rate-limit-redis": "4.2.0",
-        "redis": "5.10.0",
+        "rate-limit-redis": "4.3.1",
+        "redis": "5.11.0",
         "semver": "7.7.2",
         "tv4": "1.3.0",
         "uuid": "11.1.0",
         "winston": "3.19.0",
         "winston-daily-rotate-file": "5.0.0",
-        "ws": "8.18.2"
+        "ws": "8.20.0"
       },
       "bin": {
         "parse-server": "bin/parse-server"
@@ -28367,6 +28355,15 @@
       },
       "engines": {
         "node": ">= 14"
+      }
+    },
+    "node_modules/parse-server/node_modules/lru-cache": {
+      "version": "11.2.7",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.7.tgz",
+      "integrity": "sha512-aY/R+aEsRelme17KGQa/1ZSIpLpNYYrhcrepKTZgE+W3WM16YMCaPwOHLHsmopZHELU0Ojin1lPVxKR0MihncA==",
+      "dev": true,
+      "engines": {
+        "node": "20 || >=22"
       }
     },
     "node_modules/parse-server/node_modules/mongodb": {
@@ -28499,9 +28496,9 @@
       }
     },
     "node_modules/parse-server/node_modules/ws": {
-      "version": "8.18.2",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.2.tgz",
-      "integrity": "sha512-DMricUmwGZUVr++AEAe2uiVM7UoO9MAVZMDu05UQOaUII0lp+zOzLLU4Xqh/JvTqklB1T4uELaaPBKyjE1r4fQ==",
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.0.tgz",
+      "integrity": "sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==",
       "dev": true,
       "engines": {
         "node": ">=10.0.0"
@@ -28698,11 +28695,10 @@
       }
     },
     "node_modules/path-to-regexp": {
-      "version": "8.3.0",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.3.0.tgz",
-      "integrity": "sha512-7jdwVIRtsP8MYpdXSwOS0YdD0Du+qOoF/AEPIt88PcCFrZCzx41oxku1jD88hZBwbNUIEfpqvuhjFaMAqMTWnA==",
+      "version": "8.4.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.4.0.tgz",
+      "integrity": "sha512-PuseHIvAnz3bjrM2rGJtSgo1zjgxapTLZ7x2pjhzWwlp4SJQgK3f3iZIQwkpEnBaKz6seKBADpM4B4ySkuYypg==",
       "dev": true,
-      "license": "MIT",
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/express"
@@ -29814,9 +29810,9 @@
       }
     },
     "node_modules/rate-limit-redis": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/rate-limit-redis/-/rate-limit-redis-4.2.0.tgz",
-      "integrity": "sha512-wV450NQyKC24NmPosJb2131RoczLdfIJdKCReNwtVpm5998U8SgKrAZrIHaN/NfQgqOHaan8Uq++B4sa5REwjA==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/rate-limit-redis/-/rate-limit-redis-4.3.1.tgz",
+      "integrity": "sha512-+a1zU8+D7L8siDK9jb14refQXz60vq427VuiplgnaLk9B2LnvGe/APLTfhwb4uNIL7eWVknh8GnRp/unCj+lMA==",
       "dev": true,
       "engines": {
         "node": ">= 16"
@@ -30169,17 +30165,16 @@
       }
     },
     "node_modules/redis": {
-      "version": "5.10.0",
-      "resolved": "https://registry.npmjs.org/redis/-/redis-5.10.0.tgz",
-      "integrity": "sha512-0/Y+7IEiTgVGPrLFKy8oAEArSyEJkU0zvgV5xyi9NzNQ+SLZmyFbUsWIbgPcd4UdUh00opXGKlXJwMmsis5Byw==",
+      "version": "5.11.0",
+      "resolved": "https://registry.npmjs.org/redis/-/redis-5.11.0.tgz",
+      "integrity": "sha512-YwXjATVDT+AuxcyfOwZn046aml9jMlQPvU1VXIlLDVAExe0u93aTfPYSeRgG4p9Q/Jlkj+LXJ1XEoFV+j2JKcQ==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "@redis/bloom": "5.10.0",
-        "@redis/client": "5.10.0",
-        "@redis/json": "5.10.0",
-        "@redis/search": "5.10.0",
-        "@redis/time-series": "5.10.0"
+        "@redis/bloom": "5.11.0",
+        "@redis/client": "5.11.0",
+        "@redis/json": "5.11.0",
+        "@redis/search": "5.11.0",
+        "@redis/time-series": "5.11.0"
       },
       "engines": {
         "node": ">= 18"
@@ -35017,9 +35012,9 @@
       }
     },
     "@apollo/server": {
-      "version": "5.4.0",
-      "resolved": "https://registry.npmjs.org/@apollo/server/-/server-5.4.0.tgz",
-      "integrity": "sha512-E0/2C5Rqp7bWCjaDh4NzYuEPDZ+dltTf2c0FI6GCKJA6GBetVferX3h1//1rS4+NxD36wrJsGGJK+xyT/M3ysg==",
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/@apollo/server/-/server-5.5.0.tgz",
+      "integrity": "sha512-vWtodBOK/SZwBTJzItECOmLfL8E8pn/IdvP7pnxN5g2tny9iW4+9sxdajE798wV1H2+PYp/rRcl/soSHIBKMPw==",
       "dev": true,
       "requires": {
         "@apollo/cache-control-types": "^1.0.3",
@@ -39354,39 +39349,39 @@
       }
     },
     "@redis/bloom": {
-      "version": "5.10.0",
-      "resolved": "https://registry.npmjs.org/@redis/bloom/-/bloom-5.10.0.tgz",
-      "integrity": "sha512-doIF37ob+l47n0rkpRNgU8n4iacBlKM9xLiP1LtTZTvz8TloJB8qx/MgvhMhKdYG+CvCY2aPBnN2706izFn/4A==",
+      "version": "5.11.0",
+      "resolved": "https://registry.npmjs.org/@redis/bloom/-/bloom-5.11.0.tgz",
+      "integrity": "sha512-KYiVilAhAFN3057afUb/tfYJpsEyTkQB+tQcn5gVVA7DgcNOAj8lLxe4j8ov8BF6I9C1Fe/kwlbuAICcTMX8Lw==",
       "dev": true,
       "requires": {}
     },
     "@redis/client": {
-      "version": "5.10.0",
-      "resolved": "https://registry.npmjs.org/@redis/client/-/client-5.10.0.tgz",
-      "integrity": "sha512-JXmM4XCoso6C75Mr3lhKA3eNxSzkYi3nCzxDIKY+YOszYsJjuKbFgVtguVPbLMOttN4iu2fXoc2BGhdnYhIOxA==",
+      "version": "5.11.0",
+      "resolved": "https://registry.npmjs.org/@redis/client/-/client-5.11.0.tgz",
+      "integrity": "sha512-GHoprlNQD51Xq2Ztd94HHV94MdFZQ3CVrpA04Fz8MVoHM0B7SlbmPEVIjwTbcv58z8QyjnrOuikS0rWF03k5dQ==",
       "dev": true,
       "requires": {
         "cluster-key-slot": "1.1.2"
       }
     },
     "@redis/json": {
-      "version": "5.10.0",
-      "resolved": "https://registry.npmjs.org/@redis/json/-/json-5.10.0.tgz",
-      "integrity": "sha512-B2G8XlOmTPUuZtD44EMGbtoepQG34RCDXLZbjrtON1Djet0t5Ri7/YPXvL9aomXqP8lLTreaprtyLKF4tmXEEA==",
+      "version": "5.11.0",
+      "resolved": "https://registry.npmjs.org/@redis/json/-/json-5.11.0.tgz",
+      "integrity": "sha512-1iAy9kAtcD0quB21RbPTbUqqy+T2Uu2JxucwE+B4A+VaDbIRvpZR6DMqV8Iqaws2YxJYB3GC5JVNzPYio2ErUg==",
       "dev": true,
       "requires": {}
     },
     "@redis/search": {
-      "version": "5.10.0",
-      "resolved": "https://registry.npmjs.org/@redis/search/-/search-5.10.0.tgz",
-      "integrity": "sha512-3SVcPswoSfp2HnmWbAGUzlbUPn7fOohVu2weUQ0S+EMiQi8jwjL+aN2p6V3TI65eNfVsJ8vyPvqWklm6H6esmg==",
+      "version": "5.11.0",
+      "resolved": "https://registry.npmjs.org/@redis/search/-/search-5.11.0.tgz",
+      "integrity": "sha512-g1l7f3Rnyk/xI99oGHIgWHSKFl45Re5YTIcO8j/JE8olz389yUFyz2+A6nqVy/Zi031VgPDWscbbgOk8hlhZ3g==",
       "dev": true,
       "requires": {}
     },
     "@redis/time-series": {
-      "version": "5.10.0",
-      "resolved": "https://registry.npmjs.org/@redis/time-series/-/time-series-5.10.0.tgz",
-      "integrity": "sha512-cPkpddXH5kc/SdRhF0YG0qtjL+noqFT0AcHbQ6axhsPsO7iqPi1cjxgdkE9TNeKiBUUdCaU1DbqkR/LzbzPBhg==",
+      "version": "5.11.0",
+      "resolved": "https://registry.npmjs.org/@redis/time-series/-/time-series-5.11.0.tgz",
+      "integrity": "sha512-TWFeOcU4xkj0DkndnOyhtxvX1KWD+78UHT3XX3x3XRBUGWeQrKo3jqzDsZwxbggUgf9yLJr/akFHXru66X5UQA==",
       "dev": true,
       "requires": {}
     },
@@ -46810,20 +46805,12 @@
       }
     },
     "express-rate-limit": {
-      "version": "8.2.1",
-      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.2.1.tgz",
-      "integrity": "sha512-PCZEIEIxqwhzw4KF0n7QF4QqruVTcF73O5kFKUnGOyjbCCgizBBiFaYpd/fnBLUMPw/BWw9OsiN7GgrNYr7j6g==",
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.3.0.tgz",
+      "integrity": "sha512-KJzBawY6fB9FiZGdE/0aftepZ91YlaGIrV8vgblRM3J8X+dHx/aiowJWwkx6LIGyuqGiANsjSwwrbb8mifOJ4Q==",
       "dev": true,
       "requires": {
-        "ip-address": "10.0.1"
-      },
-      "dependencies": {
-        "ip-address": {
-          "version": "10.0.1",
-          "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.0.1.tgz",
-          "integrity": "sha512-NWv9YLW4PoW2B7xtzaS3NCot75m6nK7Icdv0o3lfMceJVRfSoQwqD4wEH5rLwoKJwUiZ/rfpiVBhnaF0FK4HoA==",
-          "dev": true
-        }
+        "ip-address": "10.1.0"
       }
     },
     "extend": {
@@ -47328,9 +47315,9 @@
       "dev": true
     },
     "follow-redirects": {
-      "version": "1.15.9",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.9.tgz",
-      "integrity": "sha512-gew4GsXizNgdoRyqmyfMHyAmXsZDk6mHkSxZFCzW9gwlbtOW44CDtYavM+y+72qD/Vq2l550kMF52DT8fOLJqQ==",
+      "version": "1.15.11",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.11.tgz",
+      "integrity": "sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==",
       "dev": true
     },
     "for-each": {
@@ -48098,9 +48085,9 @@
       "dev": true
     },
     "graphql": {
-      "version": "16.11.0",
-      "resolved": "https://registry.npmjs.org/graphql/-/graphql-16.11.0.tgz",
-      "integrity": "sha512-mS1lbMsxgQj6hge1XZ6p7GPhbrtFwUFYi3wRzXAC/FmYnyXMTvvI3td3rjmQ2u8ewXueaSvRPWaEcgVVOT9Jnw==",
+      "version": "16.13.2",
+      "resolved": "https://registry.npmjs.org/graphql/-/graphql-16.13.2.tgz",
+      "integrity": "sha512-5bJ+nf/UCpAjHM8i06fl7eLyVC9iuNAjm9qzkiu2ZGhM0VscSvS6WDPfAwkdkBuoXGM9FJSbKl6wylMwP9Ktig==",
       "dev": true
     },
     "graphql-list-fields": {
@@ -54941,12 +54928,12 @@
       "dev": true
     },
     "parse-server": {
-      "version": "9.6.0",
-      "resolved": "https://registry.npmjs.org/parse-server/-/parse-server-9.6.0.tgz",
-      "integrity": "sha512-SCdX+LwbSPl/kekQw37V9LvzbwgTL5WPURf5FXbcANhV0Af8prIlAGbMc3aBtwSEWa5qq/T2os88e96tMxvv0w==",
+      "version": "9.7.0",
+      "resolved": "https://registry.npmjs.org/parse-server/-/parse-server-9.7.0.tgz",
+      "integrity": "sha512-QY5h5dAJvIG3tAcPfCGoDGKFDKIGhbNZ20rPzzhbRvWcX5n2rrE7KWKrL1Sk9aIuLKS2VAN4Muk7p5zTDP/dfQ==",
       "dev": true,
       "requires": {
-        "@apollo/server": "5.4.0",
+        "@apollo/server": "5.5.0",
         "@as-integrations/express5": "1.1.2",
         "@graphql-tools/merge": "9.0.24",
         "@graphql-tools/schema": "10.0.23",
@@ -54958,9 +54945,9 @@
         "commander": "14.0.3",
         "cors": "2.8.6",
         "express": "5.2.1",
-        "express-rate-limit": "8.2.1",
-        "follow-redirects": "1.15.9",
-        "graphql": "16.11.0",
+        "express-rate-limit": "8.3.0",
+        "follow-redirects": "1.15.11",
+        "graphql": "16.13.2",
         "graphql-list-fields": "2.0.4",
         "graphql-relay": "0.10.2",
         "graphql-upload": "15.0.2",
@@ -54969,25 +54956,25 @@
         "jwks-rsa": "3.2.0",
         "ldapjs": "3.0.7",
         "lodash": "4.17.23",
-        "lru-cache": "10.4.0",
+        "lru-cache": "11.2.7",
         "mime": "4.0.7",
         "mongodb": "7.1.0",
         "mustache": "4.2.0",
         "otpauth": "9.4.0",
         "parse": "8.5.0",
-        "path-to-regexp": "8.3.0",
+        "path-to-regexp": "8.4.0",
         "pg-monitor": "3.1.0",
         "pg-promise": "12.6.0",
         "pluralize": "8.0.0",
         "punycode": "2.3.1",
-        "rate-limit-redis": "4.2.0",
-        "redis": "5.10.0",
+        "rate-limit-redis": "4.3.1",
+        "redis": "5.11.0",
         "semver": "7.7.2",
         "tv4": "1.3.0",
         "uuid": "11.1.0",
         "winston": "3.19.0",
         "winston-daily-rotate-file": "5.0.0",
-        "ws": "8.18.2"
+        "ws": "8.20.0"
       },
       "dependencies": {
         "@types/whatwg-url": {
@@ -55073,6 +55060,12 @@
             "debug": "4"
           }
         },
+        "lru-cache": {
+          "version": "11.2.7",
+          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.7.tgz",
+          "integrity": "sha512-aY/R+aEsRelme17KGQa/1ZSIpLpNYYrhcrepKTZgE+W3WM16YMCaPwOHLHsmopZHELU0Ojin1lPVxKR0MihncA==",
+          "dev": true
+        },
         "mongodb": {
           "version": "7.1.0",
           "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-7.1.0.tgz",
@@ -55139,9 +55132,9 @@
           }
         },
         "ws": {
-          "version": "8.18.2",
-          "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.2.tgz",
-          "integrity": "sha512-DMricUmwGZUVr++AEAe2uiVM7UoO9MAVZMDu05UQOaUII0lp+zOzLLU4Xqh/JvTqklB1T4uELaaPBKyjE1r4fQ==",
+          "version": "8.20.0",
+          "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.0.tgz",
+          "integrity": "sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==",
           "dev": true,
           "requires": {}
         }
@@ -55276,9 +55269,9 @@
       }
     },
     "path-to-regexp": {
-      "version": "8.3.0",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.3.0.tgz",
-      "integrity": "sha512-7jdwVIRtsP8MYpdXSwOS0YdD0Du+qOoF/AEPIt88PcCFrZCzx41oxku1jD88hZBwbNUIEfpqvuhjFaMAqMTWnA==",
+      "version": "8.4.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.4.0.tgz",
+      "integrity": "sha512-PuseHIvAnz3bjrM2rGJtSgo1zjgxapTLZ7x2pjhzWwlp4SJQgK3f3iZIQwkpEnBaKz6seKBADpM4B4ySkuYypg==",
       "dev": true
     },
     "path-type": {
@@ -56085,9 +56078,9 @@
       "dev": true
     },
     "rate-limit-redis": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/rate-limit-redis/-/rate-limit-redis-4.2.0.tgz",
-      "integrity": "sha512-wV450NQyKC24NmPosJb2131RoczLdfIJdKCReNwtVpm5998U8SgKrAZrIHaN/NfQgqOHaan8Uq++B4sa5REwjA==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/rate-limit-redis/-/rate-limit-redis-4.3.1.tgz",
+      "integrity": "sha512-+a1zU8+D7L8siDK9jb14refQXz60vq427VuiplgnaLk9B2LnvGe/APLTfhwb4uNIL7eWVknh8GnRp/unCj+lMA==",
       "dev": true,
       "requires": {}
     },
@@ -56370,16 +56363,16 @@
       }
     },
     "redis": {
-      "version": "5.10.0",
-      "resolved": "https://registry.npmjs.org/redis/-/redis-5.10.0.tgz",
-      "integrity": "sha512-0/Y+7IEiTgVGPrLFKy8oAEArSyEJkU0zvgV5xyi9NzNQ+SLZmyFbUsWIbgPcd4UdUh00opXGKlXJwMmsis5Byw==",
+      "version": "5.11.0",
+      "resolved": "https://registry.npmjs.org/redis/-/redis-5.11.0.tgz",
+      "integrity": "sha512-YwXjATVDT+AuxcyfOwZn046aml9jMlQPvU1VXIlLDVAExe0u93aTfPYSeRgG4p9Q/Jlkj+LXJ1XEoFV+j2JKcQ==",
       "dev": true,
       "requires": {
-        "@redis/bloom": "5.10.0",
-        "@redis/client": "5.10.0",
-        "@redis/json": "5.10.0",
-        "@redis/search": "5.10.0",
-        "@redis/time-series": "5.10.0"
+        "@redis/bloom": "5.11.0",
+        "@redis/client": "5.11.0",
+        "@redis/json": "5.11.0",
+        "@redis/search": "5.11.0",
+        "@redis/time-series": "5.11.0"
       }
     },
     "reflect-metadata": {

--- a/package.json
+++ b/package.json
@@ -115,7 +115,7 @@
     "madge": "8.0.0",
     "metro-react-native-babel-preset": "0.77.0",
     "mongodb-runner": "6.7.3",
-    "parse-server": "9.6.0",
+    "parse-server": "9.7.0",
     "puppeteer": "24.37.3",
     "regenerator-runtime": "0.14.1",
     "semantic-release": "25.0.3",


### PR DESCRIPTION
Bump `parse-server` from 9.6.0 to 9.7.0.

This is a devDependency used for integration testing. The 9.7.0 release includes 14 bug fixes (8 security advisories) and 4 features, all backward-compatible.

Closes #2968

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated parse-server to 9.7.0 and advanced multiple transitive dependencies including Apollo Server, Redis modules, express-rate-limit, graphql, follow-redirects, websocket support, and related packages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->