### PR TITLE
refactor: Bump @babel/preset-env from 7.29.0 to 7.29.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,7 @@
         "@babel/core": "7.29.0",
         "@babel/plugin-proposal-class-properties": "7.18.6",
         "@babel/plugin-transform-runtime": "7.29.0",
-        "@babel/preset-env": "7.29.0",
+        "@babel/preset-env": "7.29.2",
         "@babel/preset-react": "7.28.5",
         "@babel/preset-typescript": "7.27.1",
         "@eslint/js": "9.39.2",
@@ -2313,10 +2313,11 @@
       }
     },
     "node_modules/@babel/preset-env": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.29.0.tgz",
-      "integrity": "sha512-fNEdfc0yi16lt6IZo2Qxk3knHVdfMYX33czNb4v8yWhemoBhibCpQK/uYHtSKIiO+p/zd3+8fYVXhQdOVV608w==",
+      "version": "7.29.2",
+      "resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.29.2.tgz",
+      "integrity": "sha512-DYD23veRYGvBFhcTY1iUvJnDNpuqNd/BzBwCvzOTKUnJjKg5kpUBh3/u9585Agdkgj+QuygG7jLfOPWMa2KVNw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@babel/compat-data": "^7.29.0",
         "@babel/helper-compilation-targets": "^7.28.6",
@@ -37168,9 +37169,9 @@
       }
     },
     "@babel/preset-env": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.29.0.tgz",
-      "integrity": "sha512-fNEdfc0yi16lt6IZo2Qxk3knHVdfMYX33czNb4v8yWhemoBhibCpQK/uYHtSKIiO+p/zd3+8fYVXhQdOVV608w==",
+      "version": "7.29.2",
+      "resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.29.2.tgz",
+      "integrity": "sha512-DYD23veRYGvBFhcTY1iUvJnDNpuqNd/BzBwCvzOTKUnJjKg5kpUBh3/u9585Agdkgj+QuygG7jLfOPWMa2KVNw==",
       "dev": true,
       "requires": {
         "@babel/compat-data": "^7.29.0",

--- a/package.json
+++ b/package.json
@@ -77,7 +77,7 @@
     "@babel/core": "7.29.0",
     "@babel/plugin-proposal-class-properties": "7.18.6",
     "@babel/plugin-transform-runtime": "7.29.0",
-    "@babel/preset-env": "7.29.0",
+    "@babel/preset-env": "7.29.2",
     "@babel/preset-react": "7.28.5",
     "@babel/preset-typescript": "7.27.1",
     "@eslint/js": "9.39.2",


### PR DESCRIPTION
Closes #2978

### Changes

- **7.29.2**: Spec compliance fix for async arrow functions; bug fix for properly handling await in finally

### Breaking Changes

None

### Code Changes Required

None — the upgrade is a drop-in replacement.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated development dependency `@babel/preset-env` to the latest patch version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->