### PR TITLE
refactor: Bump babel-jest from 30.2.0 to 30.3.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -34,7 +34,7 @@
         "@semantic-release/npm": "13.1.4",
         "@semantic-release/release-notes-generator": "14.1.0",
         "@types/facebook-js-sdk": "3.3.11",
-        "babel-jest": "30.2.0",
+        "babel-jest": "30.3.0",
         "babel-plugin-minify-dead-code-elimination": "0.5.2",
         "babel-plugin-transform-inline-environment-variables": "0.4.4",
         "codecov": "3.8.3",
@@ -68,7 +68,7 @@
         "vite-plugin-node-polyfills": "0.26.0"
       },
       "engines": {
-        "node": ">=20.19.0 <21 || >=22.12.0 <23 || >=24.1.0 <25"
+        "node": ">=20.19.0 <21 || >=22.13.0 <23 || >=24.1.0 <25"
       }
     },
     "node_modules/@actions/core": {
@@ -12471,15 +12471,15 @@
       "dev": true
     },
     "node_modules/babel-jest": {
-      "version": "30.2.0",
-      "resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-30.2.0.tgz",
-      "integrity": "sha512-0YiBEOxWqKkSQWL9nNGGEgndoeL0ZpWrbLMNL5u/Kaxrli3Eaxlt3ZtIDktEvXt4L/R9r3ODr2zKwGM/2BjxVw==",
+      "version": "30.3.0",
+      "resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-30.3.0.tgz",
+      "integrity": "sha512-gRpauEU2KRrCox5Z296aeVHR4jQ98BCnu0IO332D/xpHNOsIH/bgSRk9k6GbKIbBw8vFeN6ctuu6tV8WOyVfYQ==",
       "dev": true,
       "dependencies": {
-        "@jest/transform": "30.2.0",
+        "@jest/transform": "30.3.0",
         "@types/babel__core": "^7.20.5",
         "babel-plugin-istanbul": "^7.0.1",
-        "babel-preset-jest": "30.2.0",
+        "babel-preset-jest": "30.3.0",
         "chalk": "^4.1.2",
         "graceful-fs": "^4.2.11",
         "slash": "^3.0.0"
@@ -12489,50 +12489,6 @@
       },
       "peerDependencies": {
         "@babel/core": "^7.11.0 || ^8.0.0-0"
-      }
-    },
-    "node_modules/babel-jest/node_modules/@jest/transform": {
-      "version": "30.2.0",
-      "resolved": "https://registry.npmjs.org/@jest/transform/-/transform-30.2.0.tgz",
-      "integrity": "sha512-XsauDV82o5qXbhalKxD7p4TZYYdwcaEXC77PPD2HixEFF+6YGppjrAAQurTl2ECWcEomHBMMNS9AH3kcCFx8jA==",
-      "dev": true,
-      "dependencies": {
-        "@babel/core": "^7.27.4",
-        "@jest/types": "30.2.0",
-        "@jridgewell/trace-mapping": "^0.3.25",
-        "babel-plugin-istanbul": "^7.0.1",
-        "chalk": "^4.1.2",
-        "convert-source-map": "^2.0.0",
-        "fast-json-stable-stringify": "^2.1.0",
-        "graceful-fs": "^4.2.11",
-        "jest-haste-map": "30.2.0",
-        "jest-regex-util": "30.0.1",
-        "jest-util": "30.2.0",
-        "micromatch": "^4.0.8",
-        "pirates": "^4.0.7",
-        "slash": "^3.0.0",
-        "write-file-atomic": "^5.0.1"
-      },
-      "engines": {
-        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-      }
-    },
-    "node_modules/babel-jest/node_modules/@jest/types": {
-      "version": "30.2.0",
-      "resolved": "https://registry.npmjs.org/@jest/types/-/types-30.2.0.tgz",
-      "integrity": "sha512-H9xg1/sfVvyfU7o3zMfBEjQ1gcsdeTMgqHoYdN79tuLqfTtuu7WckRA1R5whDwOzxaZAeMKTYWqP+WCAi0CHsg==",
-      "dev": true,
-      "dependencies": {
-        "@jest/pattern": "30.0.1",
-        "@jest/schemas": "30.0.5",
-        "@types/istanbul-lib-coverage": "^2.0.6",
-        "@types/istanbul-reports": "^3.0.4",
-        "@types/node": "*",
-        "@types/yargs": "^17.0.33",
-        "chalk": "^4.1.2"
-      },
-      "engines": {
-        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
       }
     },
     "node_modules/babel-jest/node_modules/ansi-styles": {
@@ -12548,47 +12504,6 @@
       },
       "funding": {
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
-    "node_modules/babel-jest/node_modules/anymatch": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.3.tgz",
-      "integrity": "sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==",
-      "dev": true,
-      "dependencies": {
-        "normalize-path": "^3.0.0",
-        "picomatch": "^2.0.4"
-      },
-      "engines": {
-        "node": ">= 8"
-      }
-    },
-    "node_modules/babel-jest/node_modules/babel-plugin-jest-hoist": {
-      "version": "30.2.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-30.2.0.tgz",
-      "integrity": "sha512-ftzhzSGMUnOzcCXd6WHdBGMyuwy15Wnn0iyyWGKgBDLxf9/s5ABuraCSpBX2uG0jUg4rqJnxsLc5+oYBqoxVaA==",
-      "dev": true,
-      "dependencies": {
-        "@types/babel__core": "^7.20.5"
-      },
-      "engines": {
-        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-      }
-    },
-    "node_modules/babel-jest/node_modules/babel-preset-jest": {
-      "version": "30.2.0",
-      "resolved": "https://registry.npmjs.org/babel-preset-jest/-/babel-preset-jest-30.2.0.tgz",
-      "integrity": "sha512-US4Z3NOieAQumwFnYdUWKvUKh8+YSnS/gB3t6YBiz0bskpu7Pine8pPCheNxlPEW4wnUkma2a94YuW2q3guvCQ==",
-      "dev": true,
-      "dependencies": {
-        "babel-plugin-jest-hoist": "30.2.0",
-        "babel-preset-current-node-syntax": "^1.2.0"
-      },
-      "engines": {
-        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.11.0 || ^8.0.0-beta.1"
       }
     },
     "node_modules/babel-jest/node_modules/chalk": {
@@ -12625,20 +12540,6 @@
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "dev": true
     },
-    "node_modules/babel-jest/node_modules/fsevents": {
-      "version": "2.3.3",
-      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
-      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
-      "dev": true,
-      "hasInstallScript": true,
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
-      }
-    },
     "node_modules/babel-jest/node_modules/graceful-fs": {
       "version": "4.2.11",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
@@ -12652,99 +12553,6 @@
       "dev": true,
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/babel-jest/node_modules/jest-haste-map": {
-      "version": "30.2.0",
-      "resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-30.2.0.tgz",
-      "integrity": "sha512-sQA/jCb9kNt+neM0anSj6eZhLZUIhQgwDt7cPGjumgLM4rXsfb9kpnlacmvZz3Q5tb80nS+oG/if+NBKrHC+Xw==",
-      "dev": true,
-      "dependencies": {
-        "@jest/types": "30.2.0",
-        "@types/node": "*",
-        "anymatch": "^3.1.3",
-        "fb-watchman": "^2.0.2",
-        "graceful-fs": "^4.2.11",
-        "jest-regex-util": "30.0.1",
-        "jest-util": "30.2.0",
-        "jest-worker": "30.2.0",
-        "micromatch": "^4.0.8",
-        "walker": "^1.0.8"
-      },
-      "engines": {
-        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-      },
-      "optionalDependencies": {
-        "fsevents": "^2.3.3"
-      }
-    },
-    "node_modules/babel-jest/node_modules/jest-util": {
-      "version": "30.2.0",
-      "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-30.2.0.tgz",
-      "integrity": "sha512-QKNsM0o3Xe6ISQU869e+DhG+4CK/48aHYdJZGlFQVTjnbvgpcKyxpzk29fGiO7i/J8VENZ+d2iGnSsvmuHywlA==",
-      "dev": true,
-      "dependencies": {
-        "@jest/types": "30.2.0",
-        "@types/node": "*",
-        "chalk": "^4.1.2",
-        "ci-info": "^4.2.0",
-        "graceful-fs": "^4.2.11",
-        "picomatch": "^4.0.2"
-      },
-      "engines": {
-        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-      }
-    },
-    "node_modules/babel-jest/node_modules/jest-util/node_modules/picomatch": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
-      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
-      "dev": true,
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/jonschlinkert"
-      }
-    },
-    "node_modules/babel-jest/node_modules/jest-worker": {
-      "version": "30.2.0",
-      "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-30.2.0.tgz",
-      "integrity": "sha512-0Q4Uk8WF7BUwqXHuAjc23vmopWJw5WH7w2tqBoUOZpOjW/ZnR44GXXd1r82RvnmI2GZge3ivrYXk/BE2+VtW2g==",
-      "dev": true,
-      "dependencies": {
-        "@types/node": "*",
-        "@ungap/structured-clone": "^1.3.0",
-        "jest-util": "30.2.0",
-        "merge-stream": "^2.0.0",
-        "supports-color": "^8.1.1"
-      },
-      "engines": {
-        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-      }
-    },
-    "node_modules/babel-jest/node_modules/jest-worker/node_modules/supports-color": {
-      "version": "8.1.1",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
-      "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
-      "dev": true,
-      "dependencies": {
-        "has-flag": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/supports-color?sponsor=1"
-      }
-    },
-    "node_modules/babel-jest/node_modules/normalize-path": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
-      "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
-      "dev": true,
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
     "node_modules/babel-jest/node_modules/supports-color": {
@@ -21095,28 +20903,6 @@
       },
       "funding": {
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
-    "node_modules/jest-config/node_modules/babel-jest": {
-      "version": "30.3.0",
-      "resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-30.3.0.tgz",
-      "integrity": "sha512-gRpauEU2KRrCox5Z296aeVHR4jQ98BCnu0IO332D/xpHNOsIH/bgSRk9k6GbKIbBw8vFeN6ctuu6tV8WOyVfYQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@jest/transform": "30.3.0",
-        "@types/babel__core": "^7.20.5",
-        "babel-plugin-istanbul": "^7.0.1",
-        "babel-preset-jest": "30.3.0",
-        "chalk": "^4.1.2",
-        "graceful-fs": "^4.2.11",
-        "slash": "^3.0.0"
-      },
-      "engines": {
-        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.11.0 || ^8.0.0-0"
       }
     },
     "node_modules/jest-config/node_modules/brace-expansion": {
@@ -44056,58 +43842,20 @@
       "dev": true
     },
     "babel-jest": {
-      "version": "30.2.0",
-      "resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-30.2.0.tgz",
-      "integrity": "sha512-0YiBEOxWqKkSQWL9nNGGEgndoeL0ZpWrbLMNL5u/Kaxrli3Eaxlt3ZtIDktEvXt4L/R9r3ODr2zKwGM/2BjxVw==",
+      "version": "30.3.0",
+      "resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-30.3.0.tgz",
+      "integrity": "sha512-gRpauEU2KRrCox5Z296aeVHR4jQ98BCnu0IO332D/xpHNOsIH/bgSRk9k6GbKIbBw8vFeN6ctuu6tV8WOyVfYQ==",
       "dev": true,
       "requires": {
-        "@jest/transform": "30.2.0",
+        "@jest/transform": "30.3.0",
         "@types/babel__core": "^7.20.5",
         "babel-plugin-istanbul": "^7.0.1",
-        "babel-preset-jest": "30.2.0",
+        "babel-preset-jest": "30.3.0",
         "chalk": "^4.1.2",
         "graceful-fs": "^4.2.11",
         "slash": "^3.0.0"
       },
       "dependencies": {
-        "@jest/transform": {
-          "version": "30.2.0",
-          "resolved": "https://registry.npmjs.org/@jest/transform/-/transform-30.2.0.tgz",
-          "integrity": "sha512-XsauDV82o5qXbhalKxD7p4TZYYdwcaEXC77PPD2HixEFF+6YGppjrAAQurTl2ECWcEomHBMMNS9AH3kcCFx8jA==",
-          "dev": true,
-          "requires": {
-            "@babel/core": "^7.27.4",
-            "@jest/types": "30.2.0",
-            "@jridgewell/trace-mapping": "^0.3.25",
-            "babel-plugin-istanbul": "^7.0.1",
-            "chalk": "^4.1.2",
-            "convert-source-map": "^2.0.0",
-            "fast-json-stable-stringify": "^2.1.0",
-            "graceful-fs": "^4.2.11",
-            "jest-haste-map": "30.2.0",
-            "jest-regex-util": "30.0.1",
-            "jest-util": "30.2.0",
-            "micromatch": "^4.0.8",
-            "pirates": "^4.0.7",
-            "slash": "^3.0.0",
-            "write-file-atomic": "^5.0.1"
-          }
-        },
-        "@jest/types": {
-          "version": "30.2.0",
-          "resolved": "https://registry.npmjs.org/@jest/types/-/types-30.2.0.tgz",
-          "integrity": "sha512-H9xg1/sfVvyfU7o3zMfBEjQ1gcsdeTMgqHoYdN79tuLqfTtuu7WckRA1R5whDwOzxaZAeMKTYWqP+WCAi0CHsg==",
-          "dev": true,
-          "requires": {
-            "@jest/pattern": "30.0.1",
-            "@jest/schemas": "30.0.5",
-            "@types/istanbul-lib-coverage": "^2.0.6",
-            "@types/istanbul-reports": "^3.0.4",
-            "@types/node": "*",
-            "@types/yargs": "^17.0.33",
-            "chalk": "^4.1.2"
-          }
-        },
         "ansi-styles": {
           "version": "4.3.0",
           "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
@@ -44115,35 +43863,6 @@
           "dev": true,
           "requires": {
             "color-convert": "^2.0.1"
-          }
-        },
-        "anymatch": {
-          "version": "3.1.3",
-          "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.3.tgz",
-          "integrity": "sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==",
-          "dev": true,
-          "requires": {
-            "normalize-path": "^3.0.0",
-            "picomatch": "^2.0.4"
-          }
-        },
-        "babel-plugin-jest-hoist": {
-          "version": "30.2.0",
-          "resolved": "https://registry.npmjs.org/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-30.2.0.tgz",
-          "integrity": "sha512-ftzhzSGMUnOzcCXd6WHdBGMyuwy15Wnn0iyyWGKgBDLxf9/s5ABuraCSpBX2uG0jUg4rqJnxsLc5+oYBqoxVaA==",
-          "dev": true,
-          "requires": {
-            "@types/babel__core": "^7.20.5"
-          }
-        },
-        "babel-preset-jest": {
-          "version": "30.2.0",
-          "resolved": "https://registry.npmjs.org/babel-preset-jest/-/babel-preset-jest-30.2.0.tgz",
-          "integrity": "sha512-US4Z3NOieAQumwFnYdUWKvUKh8+YSnS/gB3t6YBiz0bskpu7Pine8pPCheNxlPEW4wnUkma2a94YuW2q3guvCQ==",
-          "dev": true,
-          "requires": {
-            "babel-plugin-jest-hoist": "30.2.0",
-            "babel-preset-current-node-syntax": "^1.2.0"
           }
         },
         "chalk": {
@@ -44171,13 +43890,6 @@
           "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
           "dev": true
         },
-        "fsevents": {
-          "version": "2.3.3",
-          "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
-          "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
-          "dev": true,
-          "optional": true
-        },
         "graceful-fs": {
           "version": "4.2.11",
           "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
@@ -44188,77 +43900,6 @@
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
           "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-          "dev": true
-        },
-        "jest-haste-map": {
-          "version": "30.2.0",
-          "resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-30.2.0.tgz",
-          "integrity": "sha512-sQA/jCb9kNt+neM0anSj6eZhLZUIhQgwDt7cPGjumgLM4rXsfb9kpnlacmvZz3Q5tb80nS+oG/if+NBKrHC+Xw==",
-          "dev": true,
-          "requires": {
-            "@jest/types": "30.2.0",
-            "@types/node": "*",
-            "anymatch": "^3.1.3",
-            "fb-watchman": "^2.0.2",
-            "fsevents": "^2.3.3",
-            "graceful-fs": "^4.2.11",
-            "jest-regex-util": "30.0.1",
-            "jest-util": "30.2.0",
-            "jest-worker": "30.2.0",
-            "micromatch": "^4.0.8",
-            "walker": "^1.0.8"
-          }
-        },
-        "jest-util": {
-          "version": "30.2.0",
-          "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-30.2.0.tgz",
-          "integrity": "sha512-QKNsM0o3Xe6ISQU869e+DhG+4CK/48aHYdJZGlFQVTjnbvgpcKyxpzk29fGiO7i/J8VENZ+d2iGnSsvmuHywlA==",
-          "dev": true,
-          "requires": {
-            "@jest/types": "30.2.0",
-            "@types/node": "*",
-            "chalk": "^4.1.2",
-            "ci-info": "^4.2.0",
-            "graceful-fs": "^4.2.11",
-            "picomatch": "^4.0.2"
-          },
-          "dependencies": {
-            "picomatch": {
-              "version": "4.0.4",
-              "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
-              "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
-              "dev": true
-            }
-          }
-        },
-        "jest-worker": {
-          "version": "30.2.0",
-          "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-30.2.0.tgz",
-          "integrity": "sha512-0Q4Uk8WF7BUwqXHuAjc23vmopWJw5WH7w2tqBoUOZpOjW/ZnR44GXXd1r82RvnmI2GZge3ivrYXk/BE2+VtW2g==",
-          "dev": true,
-          "requires": {
-            "@types/node": "*",
-            "@ungap/structured-clone": "^1.3.0",
-            "jest-util": "30.2.0",
-            "merge-stream": "^2.0.0",
-            "supports-color": "^8.1.1"
-          },
-          "dependencies": {
-            "supports-color": {
-              "version": "8.1.1",
-              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
-              "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
-              "dev": true,
-              "requires": {
-                "has-flag": "^4.0.0"
-              }
-            }
-          }
-        },
-        "normalize-path": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
-          "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
           "dev": true
         },
         "supports-color": {
@@ -50330,21 +49971,6 @@
           "dev": true,
           "requires": {
             "color-convert": "^2.0.1"
-          }
-        },
-        "babel-jest": {
-          "version": "30.3.0",
-          "resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-30.3.0.tgz",
-          "integrity": "sha512-gRpauEU2KRrCox5Z296aeVHR4jQ98BCnu0IO332D/xpHNOsIH/bgSRk9k6GbKIbBw8vFeN6ctuu6tV8WOyVfYQ==",
-          "dev": true,
-          "requires": {
-            "@jest/transform": "30.3.0",
-            "@types/babel__core": "^7.20.5",
-            "babel-plugin-istanbul": "^7.0.1",
-            "babel-preset-jest": "30.3.0",
-            "chalk": "^4.1.2",
-            "graceful-fs": "^4.2.11",
-            "slash": "^3.0.0"
           }
         },
         "brace-expansion": {

--- a/package.json
+++ b/package.json
@@ -91,7 +91,7 @@
     "@semantic-release/npm": "13.1.4",
     "@semantic-release/release-notes-generator": "14.1.0",
     "@types/facebook-js-sdk": "3.3.11",
-    "babel-jest": "30.2.0",
+    "babel-jest": "30.3.0",
     "babel-plugin-minify-dead-code-elimination": "0.5.2",
     "babel-plugin-transform-inline-environment-variables": "0.4.4",
     "codecov": "3.8.3",


### PR DESCRIPTION
Bumps babel-jest from 30.2.0 to 30.3.0 and aligns jest-environment-jsdom to 30.3.0 to match the jest 30.3.0 version already on alpha.

Closes #2977

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated Jest-related dev dependency to 30.3.0.
  * Raised minimum Node.js requirement to 22.13.0.
  * Refreshed lockfile: minor package updates, deduplicated nested entries, and updated integrity/resolution metadata.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->