### PR TITLE
refactor: Bump @babel/runtime from 7.28.6 to 7.29.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "8.5.1-alpha.1",
       "license": "Apache-2.0",
       "dependencies": {
-        "@babel/runtime": "7.28.6",
+        "@babel/runtime": "7.29.2",
         "@babel/runtime-corejs3": "7.29.0",
         "crypto-js": "4.2.0",
         "idb-keyval": "6.2.2",
@@ -2469,9 +2469,9 @@
       }
     },
     "node_modules/@babel/runtime": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.28.6.tgz",
-      "integrity": "sha512-05WQkdpL9COIMz4LjTxGpPNCdlpyimKppYNoJ5Di5EUObifl8t4tuLuUBBZEpoLYOmfvIWrsp9fCl0HoPRVTdA==",
+      "version": "7.29.2",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.2.tgz",
+      "integrity": "sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==",
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -5972,6 +5972,16 @@
       },
       "engines": {
         "node": "20 || 22 || 24"
+      }
+    },
+    "node_modules/@parse/push-adapter/node_modules/@babel/runtime": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.28.6.tgz",
+      "integrity": "sha512-05WQkdpL9COIMz4LjTxGpPNCdlpyimKppYNoJ5Di5EUObifl8t4tuLuUBBZEpoLYOmfvIWrsp9fCl0HoPRVTdA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
       }
     },
     "node_modules/@parse/push-adapter/node_modules/parse": {
@@ -28454,6 +28464,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/parse/node_modules/@babel/runtime": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.28.6.tgz",
+      "integrity": "sha512-05WQkdpL9COIMz4LjTxGpPNCdlpyimKppYNoJ5Di5EUObifl8t4tuLuUBBZEpoLYOmfvIWrsp9fCl0HoPRVTdA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
     "node_modules/parse/node_modules/ws": {
       "version": "8.19.0",
       "resolved": "https://registry.npmjs.org/ws/-/ws-8.19.0.tgz",
@@ -36605,9 +36625,9 @@
       }
     },
     "@babel/runtime": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.28.6.tgz",
-      "integrity": "sha512-05WQkdpL9COIMz4LjTxGpPNCdlpyimKppYNoJ5Di5EUObifl8t4tuLuUBBZEpoLYOmfvIWrsp9fCl0HoPRVTdA=="
+      "version": "7.29.2",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.2.tgz",
+      "integrity": "sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g=="
     },
     "@babel/runtime-corejs3": {
       "version": "7.29.0",
@@ -38976,6 +38996,12 @@
         "web-push": "3.6.7"
       },
       "dependencies": {
+        "@babel/runtime": {
+          "version": "7.28.6",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.28.6.tgz",
+          "integrity": "sha512-05WQkdpL9COIMz4LjTxGpPNCdlpyimKppYNoJ5Di5EUObifl8t4tuLuUBBZEpoLYOmfvIWrsp9fCl0HoPRVTdA==",
+          "dev": true
+        },
         "parse": {
           "version": "8.2.0",
           "resolved": "https://registry.npmjs.org/parse/-/parse-8.2.0.tgz",
@@ -54480,6 +54506,12 @@
         "ws": "8.19.0"
       },
       "dependencies": {
+        "@babel/runtime": {
+          "version": "7.28.6",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.28.6.tgz",
+          "integrity": "sha512-05WQkdpL9COIMz4LjTxGpPNCdlpyimKppYNoJ5Di5EUObifl8t4tuLuUBBZEpoLYOmfvIWrsp9fCl0HoPRVTdA==",
+          "dev": true
+        },
         "ws": {
           "version": "8.19.0",
           "resolved": "https://registry.npmjs.org/ws/-/ws-8.19.0.tgz",

--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
     "react-native": false
   },
   "dependencies": {
-    "@babel/runtime": "7.28.6",
+    "@babel/runtime": "7.29.2",
     "@babel/runtime-corejs3": "7.29.0",
     "crypto-js": "4.2.0",
     "idb-keyval": "6.2.2",


### PR DESCRIPTION
Bumps @babel/runtime from 7.28.6 to 7.29.2.

Closes #2989

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated @babel/runtime dependency to version 7.29.2, including corresponding lock file updates to ensure consistent package management across all environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->