### PR TITLE
ci: Add `skipLibCheck` to fix type check CI failure

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,7 +7,8 @@
     "emitDeclarationOnly": true,
     "outDir": "types",
     "noImplicitAny": false,
-    "allowJs": false
+    "allowJs": false,
+    "skipLibCheck": true
   },
   "include": [
     "src/*.ts"


### PR DESCRIPTION
## Summary
- The `jest-environment-jsdom` bump to 30.3.0 pulled in `tough-cookie` 5.1.2, which changed its exports and causes a type conflict with `@types/request` (transitive dep from `parse-server`) that references `tough-cookie.CookieJar`
- Adding `skipLibCheck: true` is the standard fix for transitive dependency type conflicts in `node_modules` and doesn't reduce type safety of the project's own code since `tsc` is only used for declaration emission

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized TypeScript compilation configuration to improve build performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->