### PR TITLE
refactor: Bump vite from 7.3.1 to 7.3.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -63,7 +63,7 @@
         "regenerator-runtime": "0.14.1",
         "semantic-release": "25.0.3",
         "typescript-eslint": "8.58.0",
-        "vite": "7.3.1",
+        "vite": "7.3.2",
         "vite-plugin-commonjs": "0.10.4",
         "vite-plugin-node-polyfills": "0.26.0"
       },
@@ -34245,10 +34245,11 @@
       }
     },
     "node_modules/vite": {
-      "version": "7.3.1",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.1.tgz",
-      "integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
+      "version": "7.3.2",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.2.tgz",
+      "integrity": "sha512-Bby3NOsna2jsjfLVOHKes8sGwgl4TT0E6vvpYgnAYDIF/tie7MRaFthmKuHx1NSXjiTueXH3do80FMQgvEktRg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "esbuild": "^0.27.0",
         "fdir": "^6.5.0",
@@ -59058,9 +59059,9 @@
       }
     },
     "vite": {
-      "version": "7.3.1",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.1.tgz",
-      "integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
+      "version": "7.3.2",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.2.tgz",
+      "integrity": "sha512-Bby3NOsna2jsjfLVOHKes8sGwgl4TT0E6vvpYgnAYDIF/tie7MRaFthmKuHx1NSXjiTueXH3do80FMQgvEktRg==",
       "dev": true,
       "requires": {
         "esbuild": "^0.27.0",

--- a/package.json
+++ b/package.json
@@ -120,7 +120,7 @@
     "regenerator-runtime": "0.14.1",
     "semantic-release": "25.0.3",
     "typescript-eslint": "8.58.0",
-    "vite": "7.3.1",
+    "vite": "7.3.2",
     "vite-plugin-commonjs": "0.10.4",
     "vite-plugin-node-polyfills": "0.26.0"
   },


### PR DESCRIPTION
## Changes

Bumps [vite](https://github.com/vitejs/vite) from 7.3.1 to 7.3.2 (patch).

This security patch resolves 3 CVEs affecting vite >= 7.0.0, <= 7.3.1:
- Path traversal vulnerability
- Arbitrary file read vulnerability
- `server.fs.deny` bypass vulnerability

## Breaking Changes

None. This is a patch release with security fixes only.

## Code Changes Required

None.

Closes #3007

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build tool dependencies to the latest patch version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->