### PR TITLE
refactor: Bump @babel/runtime-corejs3 from 7.29.0 to 7.29.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@babel/runtime": "7.29.2",
-        "@babel/runtime-corejs3": "7.29.0",
+        "@babel/runtime-corejs3": "7.29.2",
         "crypto-js": "4.2.0",
         "idb-keyval": "6.2.2",
         "react-native-crypto-js": "1.0.0",
@@ -2478,9 +2478,10 @@
       }
     },
     "node_modules/@babel/runtime-corejs3": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@babel/runtime-corejs3/-/runtime-corejs3-7.29.0.tgz",
-      "integrity": "sha512-TgUkdp71C9pIbBcHudc+gXZnihEDOjUAmXO1VO4HHGES7QLZcShR0stfKIxLSNIYx2fqhmJChOjm/wkF8wv4gA==",
+      "version": "7.29.2",
+      "resolved": "https://registry.npmjs.org/@babel/runtime-corejs3/-/runtime-corejs3-7.29.2.tgz",
+      "integrity": "sha512-Lc94FOD5+0aXhdb0Tdg3RUtqT6yWbI/BbFWvlaSJ3gAb9Ks+99nHRDKADVqC37er4eCB0fHyWT+y+K3QOvJKbw==",
+      "license": "MIT",
       "dependencies": {
         "core-js-pure": "^3.48.0"
       },
@@ -5980,6 +5981,19 @@
       "integrity": "sha512-05WQkdpL9COIMz4LjTxGpPNCdlpyimKppYNoJ5Di5EUObifl8t4tuLuUBBZEpoLYOmfvIWrsp9fCl0HoPRVTdA==",
       "dev": true,
       "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@parse/push-adapter/node_modules/@babel/runtime-corejs3": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/runtime-corejs3/-/runtime-corejs3-7.29.0.tgz",
+      "integrity": "sha512-TgUkdp71C9pIbBcHudc+gXZnihEDOjUAmXO1VO4HHGES7QLZcShR0stfKIxLSNIYx2fqhmJChOjm/wkF8wv4gA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "core-js-pure": "^3.48.0"
+      },
       "engines": {
         "node": ">=6.9.0"
       }
@@ -28474,6 +28488,19 @@
         "node": ">=6.9.0"
       }
     },
+    "node_modules/parse/node_modules/@babel/runtime-corejs3": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/runtime-corejs3/-/runtime-corejs3-7.29.0.tgz",
+      "integrity": "sha512-TgUkdp71C9pIbBcHudc+gXZnihEDOjUAmXO1VO4HHGES7QLZcShR0stfKIxLSNIYx2fqhmJChOjm/wkF8wv4gA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "core-js-pure": "^3.48.0"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
     "node_modules/parse/node_modules/ws": {
       "version": "8.19.0",
       "resolved": "https://registry.npmjs.org/ws/-/ws-8.19.0.tgz",
@@ -36631,9 +36658,9 @@
       "integrity": "sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g=="
     },
     "@babel/runtime-corejs3": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@babel/runtime-corejs3/-/runtime-corejs3-7.29.0.tgz",
-      "integrity": "sha512-TgUkdp71C9pIbBcHudc+gXZnihEDOjUAmXO1VO4HHGES7QLZcShR0stfKIxLSNIYx2fqhmJChOjm/wkF8wv4gA==",
+      "version": "7.29.2",
+      "resolved": "https://registry.npmjs.org/@babel/runtime-corejs3/-/runtime-corejs3-7.29.2.tgz",
+      "integrity": "sha512-Lc94FOD5+0aXhdb0Tdg3RUtqT6yWbI/BbFWvlaSJ3gAb9Ks+99nHRDKADVqC37er4eCB0fHyWT+y+K3QOvJKbw==",
       "requires": {
         "core-js-pure": "^3.48.0"
       }
@@ -39002,6 +39029,15 @@
           "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.28.6.tgz",
           "integrity": "sha512-05WQkdpL9COIMz4LjTxGpPNCdlpyimKppYNoJ5Di5EUObifl8t4tuLuUBBZEpoLYOmfvIWrsp9fCl0HoPRVTdA==",
           "dev": true
+        },
+        "@babel/runtime-corejs3": {
+          "version": "7.29.0",
+          "resolved": "https://registry.npmjs.org/@babel/runtime-corejs3/-/runtime-corejs3-7.29.0.tgz",
+          "integrity": "sha512-TgUkdp71C9pIbBcHudc+gXZnihEDOjUAmXO1VO4HHGES7QLZcShR0stfKIxLSNIYx2fqhmJChOjm/wkF8wv4gA==",
+          "dev": true,
+          "requires": {
+            "core-js-pure": "^3.48.0"
+          }
         },
         "parse": {
           "version": "8.2.0",
@@ -54512,6 +54548,15 @@
           "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.28.6.tgz",
           "integrity": "sha512-05WQkdpL9COIMz4LjTxGpPNCdlpyimKppYNoJ5Di5EUObifl8t4tuLuUBBZEpoLYOmfvIWrsp9fCl0HoPRVTdA==",
           "dev": true
+        },
+        "@babel/runtime-corejs3": {
+          "version": "7.29.0",
+          "resolved": "https://registry.npmjs.org/@babel/runtime-corejs3/-/runtime-corejs3-7.29.0.tgz",
+          "integrity": "sha512-TgUkdp71C9pIbBcHudc+gXZnihEDOjUAmXO1VO4HHGES7QLZcShR0stfKIxLSNIYx2fqhmJChOjm/wkF8wv4gA==",
+          "dev": true,
+          "requires": {
+            "core-js-pure": "^3.48.0"
+          }
         },
         "ws": {
           "version": "8.19.0",

--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
   },
   "dependencies": {
     "@babel/runtime": "7.29.2",
-    "@babel/runtime-corejs3": "7.29.0",
+    "@babel/runtime-corejs3": "7.29.2",
     "crypto-js": "4.2.0",
     "idb-keyval": "6.2.2",
     "react-native-crypto-js": "1.0.0",


### PR DESCRIPTION
Closes #3005

## Changes

- Upgrades `@babel/runtime-corejs3` from `7.29.0` to `7.29.2`
- Patch release with bug fixes (properly handle await in finally) and spec compliance improvements; see babel/babel releases [v7.29.1](https://github.com/babel/babel/releases/tag/v7.29.1) and [v7.29.2](https://github.com/babel/babel/releases/tag/v7.29.2)

## Breaking Changes

None.

## Code Changes Required

None.