### PR TITLE
fix: Change getSessionToken return type to string | undefined

### DIFF
--- a/types/ParseUser.d.ts
+++ b/types/ParseUser.d.ts
@@ -172,7 +172,7 @@ declare class ParseUser<T extends Attributes = Attributes> extends ParseObject<T
      *
      * @returns {string} the session token, or undefined
      */
-    getSessionToken(): string | null;
+    getSessionToken(): string | undefined;
     /**
      * Checks whether this user is the current user and has been authenticated.
      *


### PR DESCRIPTION
`getSessionToken()` was incorrectly declared as returning `string | null` even though the jsdoc says it returns string or undefined. This caused issues in our parse-server implementation.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Clarified how missing session tokens are represented so absence is handled consistently.
  * Updated behavior and documentation to reduce unexpected issues when a session token is not available.
  * Improved type accuracy to increase reliability for integrations and tooling that check or consume session tokens.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->