### PR TITLE
ci: Pin MongoDB to 8.0.x for integration tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -133,7 +133,7 @@
     "release": "node build_releases.js && npm publish",
     "test": "cross-env PARSE_BUILD=node jest",
     "test:mongodb": "npm run test:mongodb:runnerstart && npm run integration",
-    "test:mongodb:runnerstart": "mongodb-runner start -- --port 27017",
+    "test:mongodb:runnerstart": "mongodb-runner start --version=8.0.x -- --port 27017",
     "posttest:mongodb": "mongodb-runner stop --all",
     "lint": "eslint --cache src/ integration/",
     "lint:fix": "eslint --fix --cache src/ integration/",


### PR DESCRIPTION
## Issue

The integration test CI (`build` jobs on Node 20/22/24) fails on **all** PRs targeting `alpha`. All ~13 failing specs are **Geo Point** integration tests, each failing with:

```
Unhandled promise rejection: ParseError: 1 An internal server error occurred
Error: Timeout - Async function did not complete within 20000ms
```

**Root cause (environmental, not SDK code):** the integration tests run Parse Server against a live MongoDB started by `mongodb-runner` with **no pinned version**, so it downloads the latest MongoDB at runtime — currently **8.3.4**. MongoDB 8.3 shortened its "no geospatial index" error message and removed the `field=<name>` token that Parse Server's on-demand `2d`-index creation scrapes out of the message text (`MongoCollection.js`, regex `/field=([A-Za-z_0-9]+) /`). The match returns `null`, `null[1]` throws a `TypeError`, the geo index is never created, and every `$nearSphere` distance query (`withinMiles` / `withinKilometers` / sorted `near`) fails with a generic internal error.

This is an upstream Parse Server bug (fix in progress separately). Verified by reproduction: the geo query passes on MongoDB **8.0.x** and fails on **8.3.x** with identical SDK code. The last green `alpha` run predates 8.3 being published; nothing in this repo changed.

## Approach

Pin the integration-test MongoDB to the latest **8.0.x** (currently resolves to 8.0.26) via `mongodb-runner --version=8.0.x`, so CI stops pulling 8.3.x. The `8.0.x` range floats forward with future 8.0 patches but never jumps to 8.1+.

```diff
- "test:mongodb:runnerstart": "mongodb-runner start -- --port 27017",
+ "test:mongodb:runnerstart": "mongodb-runner start --version=8.0.x -- --port 27017",
```

Verified locally: downloaded 8.0.26 through this exact specifier and confirmed the previously-failing `withinMiles` geo query returns results (`QUERY OK`).

> ⚠️ **Temporary workaround.** This pin should be removed (or bumped) once the upstream Parse Server fix ships and is picked up here, so CI resumes testing against current MongoDB.

## Tasks

- [x] Reproduce and root-cause the failure
- [x] Verify geo queries pass on the pinned 8.0.x version
- [ ] Follow-up: remove pin after the Parse Server fix lands

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the MongoDB test runner command to use MongoDB version 8.0.x.
  * Corrected command-line argument formatting for more reliable test setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->