### PR TITLE
refactor: Bump parse-server from 9.8.0 to 9.9.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -58,7 +58,7 @@
         "madge": "8.0.0",
         "metro-react-native-babel-preset": "0.77.0",
         "mongodb-runner": "6.7.3",
-        "parse-server": "9.8.0",
+        "parse-server": "9.9.0",
         "puppeteer": "24.40.0",
         "regenerator-runtime": "0.14.1",
         "semantic-release": "25.0.3",
@@ -6028,29 +6028,6 @@
       "integrity": "sha512-3lqz5YjWTYnW6dlDa5TLaTCcShfar1e40rmcJVwCBJC6mWlFuj0eCHIElmG1g5kyuJ/GD+8Wn4FFCcz4gJPfaQ==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/@parse/node-apn/node_modules/jsonwebtoken": {
-      "version": "9.0.3",
-      "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-9.0.3.tgz",
-      "integrity": "sha512-MT/xP0CrubFRNLNKvxJ2BYfy53Zkm++5bX9dtuPbqAeQpTVe0MQTFhao8+Cp//EmJp244xt6Drw/GVEGCUj40g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "jws": "^4.0.1",
-        "lodash.includes": "^4.3.0",
-        "lodash.isboolean": "^3.0.3",
-        "lodash.isinteger": "^4.0.4",
-        "lodash.isnumber": "^3.0.3",
-        "lodash.isplainobject": "^4.0.6",
-        "lodash.isstring": "^4.0.1",
-        "lodash.once": "^4.0.0",
-        "ms": "^2.1.1",
-        "semver": "^7.5.4"
-      },
-      "engines": {
-        "node": ">=12",
-        "npm": ">=6"
-      }
     },
     "node_modules/@parse/node-apn/node_modules/verror": {
       "version": "1.10.1",
@@ -23253,13 +23230,13 @@
       }
     },
     "node_modules/jsonwebtoken": {
-      "version": "9.0.2",
-      "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-9.0.2.tgz",
-      "integrity": "sha512-PRp66vJ865SSqOlgqS8hujT5U4AOgMfhrwYIuIhfKaoSCZcirrmASQr8CX7cUg+RMih+hgznrjp99o+W4pJLHQ==",
+      "version": "9.0.3",
+      "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-9.0.3.tgz",
+      "integrity": "sha512-MT/xP0CrubFRNLNKvxJ2BYfy53Zkm++5bX9dtuPbqAeQpTVe0MQTFhao8+Cp//EmJp244xt6Drw/GVEGCUj40g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "jws": "^3.2.2",
+        "jws": "^4.0.1",
         "lodash.includes": "^4.3.0",
         "lodash.isboolean": "^3.0.3",
         "lodash.isinteger": "^4.0.4",
@@ -23273,29 +23250,6 @@
       "engines": {
         "node": ">=12",
         "npm": ">=6"
-      }
-    },
-    "node_modules/jsonwebtoken/node_modules/jwa": {
-      "version": "1.4.2",
-      "resolved": "https://registry.npmjs.org/jwa/-/jwa-1.4.2.tgz",
-      "integrity": "sha512-eeH5JO+21J78qMvTIDdBXidBd6nG2kZjg5Ohz/1fpa28Z4CcsWUzJ1ZZyFq/3z3N17aZy+ZuBoHljASbL1WfOw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "buffer-equal-constant-time": "^1.0.1",
-        "ecdsa-sig-formatter": "1.0.11",
-        "safe-buffer": "^5.0.1"
-      }
-    },
-    "node_modules/jsonwebtoken/node_modules/jws": {
-      "version": "3.2.3",
-      "resolved": "https://registry.npmjs.org/jws/-/jws-3.2.3.tgz",
-      "integrity": "sha512-byiJ0FLRdLdSVSReO/U4E7RoEyOCKnEnEPMjq3HxWtvzLsV08/i5RQKsFVNkCldrCaPr2vDNAOMsfs8T/Hze7g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "jwa": "^1.4.2",
-        "safe-buffer": "^5.0.1"
       }
     },
     "node_modules/jwa": {
@@ -28870,9 +28824,9 @@
       }
     },
     "node_modules/parse-server": {
-      "version": "9.8.0",
-      "resolved": "https://registry.npmjs.org/parse-server/-/parse-server-9.8.0.tgz",
-      "integrity": "sha512-osUyuA2yqE5gBnmzcCvR3r9cEtZFNVglFufQsRG5pJaOJzb/+x1T5sbhdDvgE8C55hkhAKzLL2xFYPf1NPONWA==",
+      "version": "9.9.0",
+      "resolved": "https://registry.npmjs.org/parse-server/-/parse-server-9.9.0.tgz",
+      "integrity": "sha512-r3MpxphR40G7Jgpb4H40ElXj4bEoC/5WNV3hqE13+XZG7ZLl6pATEzF6GjQwvM2421m2MHsvqGl34BxsVtURqg==",
       "dev": true,
       "hasInstallScript": true,
       "license": "Apache-2.0",
@@ -28896,7 +28850,7 @@
         "graphql-relay": "0.10.2",
         "graphql-upload": "15.0.2",
         "intersect": "1.0.1",
-        "jsonwebtoken": "9.0.2",
+        "jsonwebtoken": "9.0.3",
         "jwks-rsa": "3.2.0",
         "ldapjs": "3.0.7",
         "lodash": "4.18.1",
@@ -28905,8 +28859,8 @@
         "mongodb": "7.1.0",
         "mustache": "4.2.0",
         "otpauth": "9.5.0",
-        "parse": "8.5.0",
-        "path-to-regexp": "8.4.0",
+        "parse": "8.6.0",
+        "path-to-regexp": "8.4.2",
         "pg-monitor": "3.1.0",
         "pg-promise": "12.6.0",
         "pluralize": "8.0.0",
@@ -28923,7 +28877,7 @@
         "parse-server": "bin/parse-server"
       },
       "engines": {
-        "node": ">=20.19.0 <21.0.0 || >=22.12.0 <23.0.0 || >=24.11.0 <25.0.0"
+        "node": ">=20.19.0 <21.0.0 || >=22.13.0 <23.0.0 || >=24.11.0 <25.0.0"
       },
       "funding": {
         "type": "opencollective",
@@ -29127,6 +29081,24 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/node-fetch"
+      }
+    },
+    "node_modules/parse-server/node_modules/parse": {
+      "version": "8.6.0",
+      "resolved": "https://registry.npmjs.org/parse/-/parse-8.6.0.tgz",
+      "integrity": "sha512-AZjc8yGo8/iTZFpCXWw/r1qNusiUGWtq9i92/u0jNd+Iupg3EJUSV/OOyTrCeav8NDyo92wVS5O3iKAYPlhlsA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@babel/runtime": "7.29.2",
+        "@babel/runtime-corejs3": "7.29.2",
+        "crypto-js": "4.2.0",
+        "idb-keyval": "6.2.2",
+        "react-native-crypto-js": "1.0.0",
+        "ws": "8.20.0"
+      },
+      "engines": {
+        "node": ">=20.19.0 <21 || >=22.13.0 <23 || >=24.1.0 <25"
       }
     },
     "node_modules/parse-server/node_modules/punycode": {
@@ -29402,9 +29374,9 @@
       }
     },
     "node_modules/path-to-regexp": {
-      "version": "8.4.0",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.4.0.tgz",
-      "integrity": "sha512-PuseHIvAnz3bjrM2rGJtSgo1zjgxapTLZ7x2pjhzWwlp4SJQgK3f3iZIQwkpEnBaKz6seKBADpM4B4ySkuYypg==",
+      "version": "8.4.2",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.4.2.tgz",
+      "integrity": "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==",
       "dev": true,
       "license": "MIT",
       "funding": {
@@ -39782,24 +39754,6 @@
           "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
           "integrity": "sha512-3lqz5YjWTYnW6dlDa5TLaTCcShfar1e40rmcJVwCBJC6mWlFuj0eCHIElmG1g5kyuJ/GD+8Wn4FFCcz4gJPfaQ==",
           "dev": true
-        },
-        "jsonwebtoken": {
-          "version": "9.0.3",
-          "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-9.0.3.tgz",
-          "integrity": "sha512-MT/xP0CrubFRNLNKvxJ2BYfy53Zkm++5bX9dtuPbqAeQpTVe0MQTFhao8+Cp//EmJp244xt6Drw/GVEGCUj40g==",
-          "dev": true,
-          "requires": {
-            "jws": "^4.0.1",
-            "lodash.includes": "^4.3.0",
-            "lodash.isboolean": "^3.0.3",
-            "lodash.isinteger": "^4.0.4",
-            "lodash.isnumber": "^3.0.3",
-            "lodash.isplainobject": "^4.0.6",
-            "lodash.isstring": "^4.0.1",
-            "lodash.once": "^4.0.0",
-            "ms": "^2.1.1",
-            "semver": "^7.5.4"
-          }
         },
         "verror": {
           "version": "1.10.1",
@@ -51901,12 +51855,12 @@
       }
     },
     "jsonwebtoken": {
-      "version": "9.0.2",
-      "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-9.0.2.tgz",
-      "integrity": "sha512-PRp66vJ865SSqOlgqS8hujT5U4AOgMfhrwYIuIhfKaoSCZcirrmASQr8CX7cUg+RMih+hgznrjp99o+W4pJLHQ==",
+      "version": "9.0.3",
+      "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-9.0.3.tgz",
+      "integrity": "sha512-MT/xP0CrubFRNLNKvxJ2BYfy53Zkm++5bX9dtuPbqAeQpTVe0MQTFhao8+Cp//EmJp244xt6Drw/GVEGCUj40g==",
       "dev": true,
       "requires": {
-        "jws": "^3.2.2",
+        "jws": "^4.0.1",
         "lodash.includes": "^4.3.0",
         "lodash.isboolean": "^3.0.3",
         "lodash.isinteger": "^4.0.4",
@@ -51916,29 +51870,6 @@
         "lodash.once": "^4.0.0",
         "ms": "^2.1.1",
         "semver": "^7.5.4"
-      },
-      "dependencies": {
-        "jwa": {
-          "version": "1.4.2",
-          "resolved": "https://registry.npmjs.org/jwa/-/jwa-1.4.2.tgz",
-          "integrity": "sha512-eeH5JO+21J78qMvTIDdBXidBd6nG2kZjg5Ohz/1fpa28Z4CcsWUzJ1ZZyFq/3z3N17aZy+ZuBoHljASbL1WfOw==",
-          "dev": true,
-          "requires": {
-            "buffer-equal-constant-time": "^1.0.1",
-            "ecdsa-sig-formatter": "1.0.11",
-            "safe-buffer": "^5.0.1"
-          }
-        },
-        "jws": {
-          "version": "3.2.3",
-          "resolved": "https://registry.npmjs.org/jws/-/jws-3.2.3.tgz",
-          "integrity": "sha512-byiJ0FLRdLdSVSReO/U4E7RoEyOCKnEnEPMjq3HxWtvzLsV08/i5RQKsFVNkCldrCaPr2vDNAOMsfs8T/Hze7g==",
-          "dev": true,
-          "requires": {
-            "jwa": "^1.4.2",
-            "safe-buffer": "^5.0.1"
-          }
-        }
       }
     },
     "jwa": {
@@ -55756,9 +55687,9 @@
       "dev": true
     },
     "parse-server": {
-      "version": "9.8.0",
-      "resolved": "https://registry.npmjs.org/parse-server/-/parse-server-9.8.0.tgz",
-      "integrity": "sha512-osUyuA2yqE5gBnmzcCvR3r9cEtZFNVglFufQsRG5pJaOJzb/+x1T5sbhdDvgE8C55hkhAKzLL2xFYPf1NPONWA==",
+      "version": "9.9.0",
+      "resolved": "https://registry.npmjs.org/parse-server/-/parse-server-9.9.0.tgz",
+      "integrity": "sha512-r3MpxphR40G7Jgpb4H40ElXj4bEoC/5WNV3hqE13+XZG7ZLl6pATEzF6GjQwvM2421m2MHsvqGl34BxsVtURqg==",
       "dev": true,
       "requires": {
         "@apollo/server": "5.5.0",
@@ -55781,7 +55712,7 @@
         "graphql-relay": "0.10.2",
         "graphql-upload": "15.0.2",
         "intersect": "1.0.1",
-        "jsonwebtoken": "9.0.2",
+        "jsonwebtoken": "9.0.3",
         "jwks-rsa": "3.2.0",
         "ldapjs": "3.0.7",
         "lodash": "4.18.1",
@@ -55790,8 +55721,8 @@
         "mongodb": "7.1.0",
         "mustache": "4.2.0",
         "otpauth": "9.5.0",
-        "parse": "8.5.0",
-        "path-to-regexp": "8.4.0",
+        "parse": "8.6.0",
+        "path-to-regexp": "8.4.2",
         "pg-monitor": "3.1.0",
         "pg-promise": "12.6.0",
         "pluralize": "8.0.0",
@@ -55918,6 +55849,20 @@
             "data-uri-to-buffer": "^4.0.0",
             "fetch-blob": "^3.1.4",
             "formdata-polyfill": "^4.0.10"
+          }
+        },
+        "parse": {
+          "version": "8.6.0",
+          "resolved": "https://registry.npmjs.org/parse/-/parse-8.6.0.tgz",
+          "integrity": "sha512-AZjc8yGo8/iTZFpCXWw/r1qNusiUGWtq9i92/u0jNd+Iupg3EJUSV/OOyTrCeav8NDyo92wVS5O3iKAYPlhlsA==",
+          "dev": true,
+          "requires": {
+            "@babel/runtime": "7.29.2",
+            "@babel/runtime-corejs3": "7.29.2",
+            "crypto-js": "4.2.0",
+            "idb-keyval": "6.2.2",
+            "react-native-crypto-js": "1.0.0",
+            "ws": "8.20.0"
           }
         },
         "punycode": {
@@ -56082,9 +56027,9 @@
       }
     },
     "path-to-regexp": {
-      "version": "8.4.0",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.4.0.tgz",
-      "integrity": "sha512-PuseHIvAnz3bjrM2rGJtSgo1zjgxapTLZ7x2pjhzWwlp4SJQgK3f3iZIQwkpEnBaKz6seKBADpM4B4ySkuYypg==",
+      "version": "8.4.2",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.4.2.tgz",
+      "integrity": "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==",
       "dev": true
     },
     "path-type": {

--- a/package.json
+++ b/package.json
@@ -115,7 +115,7 @@
     "madge": "8.0.0",
     "metro-react-native-babel-preset": "0.77.0",
     "mongodb-runner": "6.7.3",
-    "parse-server": "9.8.0",
+    "parse-server": "9.9.0",
     "puppeteer": "24.40.0",
     "regenerator-runtime": "0.14.1",
     "semantic-release": "25.0.3",


### PR DESCRIPTION
Bumps the dev dependency [parse-server](https://github.com/parse-community/parse-server) from 9.8.0 to 9.9.0.

Replacement PR for #3035 (pins the exact version and updates the lock file from the fork so CI secrets are available).

### Changes
- Bumps `parse-server` (devDependency) from `9.8.0` to `9.9.0`.
- parse-community/parse-server 9.9.0 is a minor release: two bug fixes (request-context leak in `ParseServerRESTController`, MFA SMS OTP double-accept `GHSA-jpq4-7fmq-q5fj`) and two additive features (`rawValues`/`rawFieldNames` aggregation options, installation `deviceToken` dedup options).

### Breaking Changes
None.

### Code Changes Required
None. Manifest + lock file only.

Closes #3035