### PR TITLE
refactor: Bump parse-server from 9.9.0 to 9.10.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -58,7 +58,7 @@
         "madge": "8.0.0",
         "metro-react-native-babel-preset": "0.77.0",
         "mongodb-runner": "6.7.7",
-        "parse-server": "9.9.0",
+        "parse-server": "9.10.0",
         "puppeteer": "24.42.0",
         "regenerator-runtime": "0.14.1",
         "semantic-release": "25.0.3",
@@ -29356,9 +29356,9 @@
       }
     },
     "node_modules/parse-server": {
-      "version": "9.9.0",
-      "resolved": "https://registry.npmjs.org/parse-server/-/parse-server-9.9.0.tgz",
-      "integrity": "sha512-r3MpxphR40G7Jgpb4H40ElXj4bEoC/5WNV3hqE13+XZG7ZLl6pATEzF6GjQwvM2421m2MHsvqGl34BxsVtURqg==",
+      "version": "9.10.0",
+      "resolved": "https://registry.npmjs.org/parse-server/-/parse-server-9.10.0.tgz",
+      "integrity": "sha512-f4IIsWLsh30mOJl6u6SB3GBrj7Zj4f69dKkI0PPZxNeVttlKFBEg/VHc2AQrWKWRvnIlWy22o2UdX4ECPDPCIw==",
       "dev": true,
       "hasInstallScript": true,
       "license": "Apache-2.0",
@@ -56584,9 +56584,9 @@
       "dev": true
     },
     "parse-server": {
-      "version": "9.9.0",
-      "resolved": "https://registry.npmjs.org/parse-server/-/parse-server-9.9.0.tgz",
-      "integrity": "sha512-r3MpxphR40G7Jgpb4H40ElXj4bEoC/5WNV3hqE13+XZG7ZLl6pATEzF6GjQwvM2421m2MHsvqGl34BxsVtURqg==",
+      "version": "9.10.0",
+      "resolved": "https://registry.npmjs.org/parse-server/-/parse-server-9.10.0.tgz",
+      "integrity": "sha512-f4IIsWLsh30mOJl6u6SB3GBrj7Zj4f69dKkI0PPZxNeVttlKFBEg/VHc2AQrWKWRvnIlWy22o2UdX4ECPDPCIw==",
       "dev": true,
       "requires": {
         "@apollo/server": "5.5.0",

--- a/package.json
+++ b/package.json
@@ -115,7 +115,7 @@
     "madge": "8.0.0",
     "metro-react-native-babel-preset": "0.77.0",
     "mongodb-runner": "6.7.7",
-    "parse-server": "9.9.0",
+    "parse-server": "9.10.0",
     "puppeteer": "24.42.0",
     "regenerator-runtime": "0.14.1",
     "semantic-release": "25.0.3",


### PR DESCRIPTION
Closes #3064

Bumps the `parse-server` dev dependency (used for the integration test suite) from `9.9.0` to `9.10.0`.

## Changes

`9.10.0` is a routine minor release consisting of security-focused bug fixes plus one new feature ([full release notes](https://github.com/parse-community/parse-server/releases/tag/9.10.0)):

- Multiple security hardening fixes (query-operator DoS, MFA/protected-field disclosure, GraphQL schema disclosure, LiveQuery ACL leakage, file-upload XSS bypasses, rate-limit and route-allowlist bypasses).
- Fixes for GeoPoint distance queries on MongoDB 8.3+, Cloud Function `maxUploadSize` enforcement, and `beforeFind` context prototype-pollution isolation.
- New feature: option to disallow aggregation pipelines for the read-only master key.

## Breaking Changes

None. This is a minor version bump with no breaking changes for consumers of the SDK.

## Code Changes Required

None. `parse-server` is a dev/test-only dependency; no SDK source changes are required.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the Parse Server dependency to version 9.10.0.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->