### PR TITLE
refactor: Bump @semantic-release/release-notes-generator from 14.1.0 to 14.1.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -32,7 +32,7 @@
         "@semantic-release/git": "10.0.1",
         "@semantic-release/github": "12.0.6",
         "@semantic-release/npm": "13.1.5",
-        "@semantic-release/release-notes-generator": "14.1.0",
+        "@semantic-release/release-notes-generator": "14.1.1",
         "@types/facebook-js-sdk": "3.3.11",
         "babel-jest": "30.4.1",
         "babel-plugin-minify-dead-code-elimination": "0.5.2",
@@ -10819,19 +10819,18 @@
       }
     },
     "node_modules/@semantic-release/release-notes-generator": {
-      "version": "14.1.0",
-      "resolved": "https://registry.npmjs.org/@semantic-release/release-notes-generator/-/release-notes-generator-14.1.0.tgz",
-      "integrity": "sha512-CcyDRk7xq+ON/20YNR+1I/jP7BYKICr1uKd1HHpROSnnTdGqOTburi4jcRiTYz0cpfhxSloQO3cGhnoot7IEkA==",
+      "version": "14.1.1",
+      "resolved": "https://registry.npmjs.org/@semantic-release/release-notes-generator/-/release-notes-generator-14.1.1.tgz",
+      "integrity": "sha512-Pbd2e2XRMUD0OxehHpgd5/YghsE76cddkRHSoDvKLK+OCy4Ewxn49rWR631MEUU01lgwF/uyVXvbnVuu6+Z6VA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "conventional-changelog-angular": "^8.0.0",
         "conventional-changelog-writer": "^8.0.0",
         "conventional-commits-filter": "^5.0.0",
         "conventional-commits-parser": "^6.0.0",
         "debug": "^4.0.0",
-        "get-stream": "^7.0.0",
         "import-from-esm": "^2.0.0",
-        "into-stream": "^7.0.0",
         "lodash-es": "^4.17.21",
         "read-package-up": "^11.0.0"
       },
@@ -10840,18 +10839,6 @@
       },
       "peerDependencies": {
         "semantic-release": ">=20.1.0"
-      }
-    },
-    "node_modules/@semantic-release/release-notes-generator/node_modules/get-stream": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-7.0.1.tgz",
-      "integrity": "sha512-3M8C1EOFN6r8AMUhwUAACIoXZJEOufDU5+0gFFN5uNs6XYOralD2Pqkl7m046va6x77FwposWXbAhPPIOus7mQ==",
-      "dev": true,
-      "engines": {
-        "node": ">=16"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/@semantic-release/release-notes-generator/node_modules/import-from-esm": {
@@ -43478,9 +43465,9 @@
       }
     },
     "@semantic-release/release-notes-generator": {
-      "version": "14.1.0",
-      "resolved": "https://registry.npmjs.org/@semantic-release/release-notes-generator/-/release-notes-generator-14.1.0.tgz",
-      "integrity": "sha512-CcyDRk7xq+ON/20YNR+1I/jP7BYKICr1uKd1HHpROSnnTdGqOTburi4jcRiTYz0cpfhxSloQO3cGhnoot7IEkA==",
+      "version": "14.1.1",
+      "resolved": "https://registry.npmjs.org/@semantic-release/release-notes-generator/-/release-notes-generator-14.1.1.tgz",
+      "integrity": "sha512-Pbd2e2XRMUD0OxehHpgd5/YghsE76cddkRHSoDvKLK+OCy4Ewxn49rWR631MEUU01lgwF/uyVXvbnVuu6+Z6VA==",
       "dev": true,
       "requires": {
         "conventional-changelog-angular": "^8.0.0",
@@ -43488,19 +43475,11 @@
         "conventional-commits-filter": "^5.0.0",
         "conventional-commits-parser": "^6.0.0",
         "debug": "^4.0.0",
-        "get-stream": "^7.0.0",
         "import-from-esm": "^2.0.0",
-        "into-stream": "^7.0.0",
         "lodash-es": "^4.17.21",
         "read-package-up": "^11.0.0"
       },
       "dependencies": {
-        "get-stream": {
-          "version": "7.0.1",
-          "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-7.0.1.tgz",
-          "integrity": "sha512-3M8C1EOFN6r8AMUhwUAACIoXZJEOufDU5+0gFFN5uNs6XYOralD2Pqkl7m046va6x77FwposWXbAhPPIOus7mQ==",
-          "dev": true
-        },
         "import-from-esm": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/import-from-esm/-/import-from-esm-2.0.0.tgz",

--- a/package.json
+++ b/package.json
@@ -89,7 +89,7 @@
     "@semantic-release/git": "10.0.1",
     "@semantic-release/github": "12.0.6",
     "@semantic-release/npm": "13.1.5",
-    "@semantic-release/release-notes-generator": "14.1.0",
+    "@semantic-release/release-notes-generator": "14.1.1",
     "@types/facebook-js-sdk": "3.3.11",
     "babel-jest": "30.4.1",
     "babel-plugin-minify-dead-code-elimination": "0.5.2",


### PR DESCRIPTION
Closes #3078

## Summary

Bumps the direct devDependency `@semantic-release/release-notes-generator` from `14.1.0` to `14.1.1`. This is a routine patch release; the upstream `14.1.1` no longer requires the `get-stream`/`into-stream` transitive dependencies, which are removed from the lockfile subtree accordingly.

## Changes

- `package.json`: `@semantic-release/release-notes-generator` `14.1.0` -> `14.1.1`
- `package-lock.json`: regenerated for the same subtree only

## Notes

Replacement for the Dependabot PR #3078, rebased onto `alpha`. Dev-only tooling change with no runtime impact on the published SDK.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the release notes generation tooling to version 14.1.1.
  * Refreshed the associated dependency lock information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->