### PR TITLE
refactor: Bump idb-keyval from 6.2.2 to 6.3.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@babel/runtime": "7.29.2",
         "@babel/runtime-corejs3": "7.29.2",
         "crypto-js": "4.2.0",
-        "idb-keyval": "6.2.2",
+        "idb-keyval": "6.3.0",
         "react-native-crypto-js": "1.0.0",
         "ws": "8.21.0"
       },
@@ -20163,9 +20163,9 @@
       }
     },
     "node_modules/idb-keyval": {
-      "version": "6.2.2",
-      "resolved": "https://registry.npmjs.org/idb-keyval/-/idb-keyval-6.2.2.tgz",
-      "integrity": "sha512-yjD9nARJ/jb1g+CvD0tlhUHOrJ9Sy0P8T9MF3YaLlHnSRpwPfpTX0XIvpmw3gAJUmEu3FiICLBDPXVwyEvrleg==",
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/idb-keyval/-/idb-keyval-6.3.0.tgz",
+      "integrity": "sha512-um+2dgAWmYsu615EXpWVwSmapJhON0G43t3Ka/EVaohzPQXSMqKEqeDK/oIW3Ow+BXaF2PvSc+oBTFp793A5Ow==",
       "license": "Apache-2.0"
     },
     "node_modules/ieee754": {
@@ -29510,6 +29510,13 @@
         "node": ">= 14"
       }
     },
+    "node_modules/parse-server/node_modules/idb-keyval": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/idb-keyval/-/idb-keyval-6.2.2.tgz",
+      "integrity": "sha512-yjD9nARJ/jb1g+CvD0tlhUHOrJ9Sy0P8T9MF3YaLlHnSRpwPfpTX0XIvpmw3gAJUmEu3FiICLBDPXVwyEvrleg==",
+      "dev": true,
+      "license": "Apache-2.0"
+    },
     "node_modules/parse-server/node_modules/lru-cache": {
       "version": "11.2.7",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.7.tgz",
@@ -29718,6 +29725,13 @@
       "engines": {
         "node": ">=6.9.0"
       }
+    },
+    "node_modules/parse/node_modules/idb-keyval": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/idb-keyval/-/idb-keyval-6.2.2.tgz",
+      "integrity": "sha512-yjD9nARJ/jb1g+CvD0tlhUHOrJ9Sy0P8T9MF3YaLlHnSRpwPfpTX0XIvpmw3gAJUmEu3FiICLBDPXVwyEvrleg==",
+      "dev": true,
+      "license": "Apache-2.0"
     },
     "node_modules/parse/node_modules/ws": {
       "version": "8.19.0",
@@ -50270,9 +50284,9 @@
       }
     },
     "idb-keyval": {
-      "version": "6.2.2",
-      "resolved": "https://registry.npmjs.org/idb-keyval/-/idb-keyval-6.2.2.tgz",
-      "integrity": "sha512-yjD9nARJ/jb1g+CvD0tlhUHOrJ9Sy0P8T9MF3YaLlHnSRpwPfpTX0XIvpmw3gAJUmEu3FiICLBDPXVwyEvrleg=="
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/idb-keyval/-/idb-keyval-6.3.0.tgz",
+      "integrity": "sha512-um+2dgAWmYsu615EXpWVwSmapJhON0G43t3Ka/EVaohzPQXSMqKEqeDK/oIW3Ow+BXaF2PvSc+oBTFp793A5Ow=="
     },
     "ieee754": {
       "version": "1.2.1",
@@ -56441,6 +56455,12 @@
             "core-js-pure": "^3.48.0"
           }
         },
+        "idb-keyval": {
+          "version": "6.2.2",
+          "resolved": "https://registry.npmjs.org/idb-keyval/-/idb-keyval-6.2.2.tgz",
+          "integrity": "sha512-yjD9nARJ/jb1g+CvD0tlhUHOrJ9Sy0P8T9MF3YaLlHnSRpwPfpTX0XIvpmw3gAJUmEu3FiICLBDPXVwyEvrleg==",
+          "dev": true
+        },
         "ws": {
           "version": "8.19.0",
           "resolved": "https://registry.npmjs.org/ws/-/ws-8.19.0.tgz",
@@ -56686,6 +56706,12 @@
             "agent-base": "^7.1.2",
             "debug": "4"
           }
+        },
+        "idb-keyval": {
+          "version": "6.2.2",
+          "resolved": "https://registry.npmjs.org/idb-keyval/-/idb-keyval-6.2.2.tgz",
+          "integrity": "sha512-yjD9nARJ/jb1g+CvD0tlhUHOrJ9Sy0P8T9MF3YaLlHnSRpwPfpTX0XIvpmw3gAJUmEu3FiICLBDPXVwyEvrleg==",
+          "dev": true
         },
         "lru-cache": {
           "version": "11.2.7",

--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
     "@babel/runtime": "7.29.2",
     "@babel/runtime-corejs3": "7.29.2",
     "crypto-js": "4.2.0",
-    "idb-keyval": "6.2.2",
+    "idb-keyval": "6.3.0",
     "react-native-crypto-js": "1.0.0",
     "ws": "8.21.0"
   },


### PR DESCRIPTION
Closes #3077

## Summary

Bumps [idb-keyval](https://github.com/jakearchibald/idb-keyval) from `6.2.2` to `6.3.0`.

This is a **production dependency** (used for the IndexedDB-backed storage controller at runtime), pinned exactly.

## Changelog

This is a routine minor bump. Changes between `6.2.2` and `6.3.0` are non-breaking:

- Fix nested transaction inefficiency in `entries()`
- Fix `update()` to reject the promise on invalid keys (previously could hang)
- Correct `getMany()` return type to `Promise<(T | undefined)[]>`
- Internal build/tooling and database caching improvements

No public API breaking changes.

## Notes

This replaces the original Dependabot PR #3077.
